### PR TITLE
Feat/arena timer hook

### DIFF
--- a/src/shared-d/hooks/useArenaTimer.ts
+++ b/src/shared-d/hooks/useArenaTimer.ts
@@ -176,3 +176,19 @@ export function useArenaTimer({
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [isRunning, rawSeconds, updateTimer]);
+  // Return the hook API with stable references and computed values
+  return {
+    // State values
+    rawSeconds,
+    formattedTime: formattedTime(rawSeconds),
+    progress: progress(rawSeconds),
+    isTensionMode,
+    
+    // Control methods (stable references via useCallback)
+    start,
+    pause,
+    resume,
+    reset,
+    sync,
+  };
+}


### PR DESCRIPTION
## ✨ Implement `useArenaTimer` Hook

### Overview
This PR introduces a specialized `useArenaTimer` hook to centralize and standardize all round-based countdown logic used across the Arena. Previously, timer logic was duplicated or embedded directly within components. This hook provides a clean, reusable API for subscribing to time updates, handling synchronization, and reacting to phase transitions such as **Tension Mode**.

---

### 📁 Location
- **Hook:** `src/shared-d/hooks/useArenaTimer.ts`

---

### 🎯 Core Functionality
- High-precision countdown timer using `setInterval` with proper cleanup.
- Configurable `initialSeconds`.
- `onTimeUp` callback triggered when the timer reaches zero.
- External controls to **start**, **pause**, **resume**, and **reset** the timer.
- `sync(serverSeconds)` method (initially mocked) to align client time with server state.

---

#46 