### PR TITLE
Feat/arena archives header

### DIFF
--- a/src/app/archives/page.tsx
+++ b/src/app/archives/page.tsx
@@ -1,0 +1,18 @@
+import { ArchivesFilterBar } from "@/components/archives/global/ArchivesFilterBar";
+import { ArchivesHeader } from "@/components/archives/global/ArchivesHeader";
+import { GlobalPerformanceStats } from "@/components/archives/global/GlobalPerformanceStats";
+
+export default function ArchivesPage() {
+  return (
+    <div className="min-h-screen bg-[#050B15] px-4 py-6 md:px-8 md:py-8">
+      <section className="mx-auto w-full max-w-6xl overflow-hidden border-[3px] border-[#0E1A2D] bg-[#0A1324]">
+        <ArchivesHeader />
+
+        <div className="px-4 py-5 md:px-8 md:py-6">
+          <GlobalPerformanceStats />
+          <ArchivesFilterBar />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/archives/global/ArchivesFilterBar.tsx
+++ b/src/components/archives/global/ArchivesFilterBar.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+const filters = [
+  { id: "all-games", label: "ALL GAMES" },
+  { id: "victories", label: "VICTORIES" },
+  { id: "eliminations", label: "ELIMINATIONS" },
+  { id: "hosted", label: "HOSTED" },
+] as const;
+
+export function ArchivesFilterBar() {
+  const [activeFilter, setActiveFilter] = useState<(typeof filters)[number]["id"]>("all-games");
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2 md:gap-3">
+      {filters.map((filter) => (
+        <button
+          key={filter.id}
+          type="button"
+          onClick={() => setActiveFilter(filter.id)}
+          className={
+            activeFilter === filter.id
+              ? "border border-[#37FF1C] bg-[#37FF1C] px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-black transition-colors"
+              : "border border-[#2B3A52] bg-[#121C2C] px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-[#9CA7BB] transition-colors hover:border-[#4B5B76]"
+          }
+        >
+          {filter.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/archives/global/ArchivesHeader.tsx
+++ b/src/components/archives/global/ArchivesHeader.tsx
@@ -1,0 +1,18 @@
+export function ArchivesHeader() {
+  return (
+    <header className="border-b border-[#152339] px-4 py-6 md:px-8 md:py-8">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-[#687285]">
+        SYSTEM / LOGS / <span className="text-[#37FF1C]">MATCH_HISTORY</span>
+      </p>
+
+      <h1 className="mt-4 font-display text-4xl font-bold uppercase italic leading-[0.88] tracking-tight text-white md:text-6xl">
+        ARENA_ARCHIVES:
+        <span className="block text-[#37FF1C]">PERFORMANCE_LOGS</span>
+      </h1>
+
+      <p className="mt-4 max-w-4xl font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[#687285] md:text-[11px]">
+        NEUBRUTALIST_HISTORY_DECRYPTED: ACCESSING STELLAR SOROBAN LEDGER DATA FOR ELIMINATION PROTOCOLS.
+      </p>
+    </header>
+  );
+}

--- a/src/components/archives/global/GlobalPerformanceStats.tsx
+++ b/src/components/archives/global/GlobalPerformanceStats.tsx
@@ -1,0 +1,77 @@
+type PerformanceStat = {
+  label: string;
+  value: string;
+  trend?: string;
+  highlight?: boolean;
+  badge?: string;
+};
+
+const performanceStats: PerformanceStat[] = [
+  {
+    label: "TOTAL GAMES PLAYED",
+    value: "124",
+    trend: "+12%",
+  },
+  {
+    label: "HIGHEST ROUND REACHED",
+    value: "R24",
+    trend: "+2%",
+  },
+  {
+    label: "ACCUMULATED RWA YIELD",
+    value: "42.50 XLM",
+    badge: "STABLE",
+    highlight: true,
+  },
+];
+
+export function GlobalPerformanceStats() {
+  return (
+    <section className="grid grid-cols-1 gap-3 md:grid-cols-3">
+      {performanceStats.map((stat) => (
+        <article
+          key={stat.label}
+          className={
+            stat.highlight
+              ? "border-[3px] border-[#37FF1C] bg-[#37FF1C] p-4"
+              : "border-[3px] border-[#0F1B2D] bg-[#131D2E] p-4"
+          }
+        >
+          <p
+            className={
+              stat.highlight
+                ? "font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-black/70"
+                : "font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-[#6B7487]"
+            }
+          >
+            {stat.label}
+          </p>
+
+          <div className="mt-3 flex items-end justify-between gap-3">
+            <p
+              className={
+                stat.highlight
+                  ? "text-3xl font-bold uppercase tracking-tight text-black"
+                  : "text-3xl font-semibold uppercase tracking-tight text-white"
+              }
+            >
+              {stat.value}
+            </p>
+
+            {stat.trend ? (
+              <span className="mb-1 font-mono text-[11px] font-bold uppercase text-[#37FF1C]">
+                {stat.trend}
+              </span>
+            ) : null}
+
+            {stat.badge ? (
+              <span className="mb-1 border border-black/30 bg-black/10 px-2 py-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-black">
+                {stat.badge}
+              </span>
+            ) : null}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #78

Implemented the `/archives` header section with:
- breadcrumb, title, and subtitle
- 3 global stats cards (including highlighted RWA yield card)
- interactive category filter bar (`ALL GAMES`, `VICTORIES`, `ELIMINATIONS`, `HOSTED`)

Files added:
- `src/app/archives/page.tsx`
- `src/components/archives/global/ArchivesHeader.tsx`
- `src/components/archives/global/GlobalPerformanceStats.tsx`
- `src/components/archives/global/ArchivesFilterBar.tsx`