### PR TITLE
Feat/rwa yield analysis #74

### DIFF
--- a/src/app/analysis/page.tsx
+++ b/src/app/analysis/page.tsx
@@ -1,0 +1,39 @@
+import { AnalysisFooter } from "@/components/analysis/stats/AnalysisFooter";
+import { AnalysisHeader } from "@/components/analysis/stats/AnalysisHeader";
+import { StatsGrid } from "@/components/analysis/stats/StatsGrid";
+
+export default function AnalysisPage() {
+  return (
+    <div className="min-h-screen bg-[#071122] px-4 py-8 md:px-8">
+      <section className="mx-auto w-full max-w-6xl border-[3px] border-black bg-white shadow-[8px_8px_0_#000]">
+        <AnalysisHeader />
+        <StatsGrid />
+
+        <div className="grid grid-cols-1 gap-3 px-4 pb-4 md:grid-cols-2 md:px-6 md:pb-6">
+          <button
+            type="button"
+            className="inline-flex h-14 items-center justify-center gap-2 border-[3px] border-black bg-[#37FF1C] px-5 font-display text-sm font-bold uppercase tracking-[0.08em] text-black transition-colors hover:bg-[#2fe015] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black"
+          >
+            <span aria-hidden className="font-mono text-base">
+              v
+            </span>
+            WITHDRAW YIELD
+          </button>
+
+          <button
+            type="button"
+            className="inline-flex h-14 items-center justify-center gap-2 border-[3px] border-black bg-white px-5 font-display text-sm font-bold uppercase tracking-[0.08em] text-black transition-colors hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black"
+          >
+            <span aria-hidden className="font-mono text-base">
+              {"<"}
+            </span>
+            BACK TO PROFILE
+          </button>
+        </div>
+
+        <AnalysisFooter />
+      </section>
+    </div>
+  );
+}
+

--- a/src/components/analysis/stats/AnalysisFooter.tsx
+++ b/src/components/analysis/stats/AnalysisFooter.tsx
@@ -1,0 +1,12 @@
+export function AnalysisFooter() {
+  return (
+    <footer className="border-t-[3px] border-black px-4 py-3 md:px-6">
+      <div className="grid grid-cols-1 gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[#323843] md:grid-cols-3">
+        <p>NETWORK: STELLAR MAINNET</p>
+        <p className="md:text-center">CONTRACT ID: 0x_SOROB...</p>
+        <p className="md:text-right">NODE HEALTH: 100%</p>
+      </div>
+    </footer>
+  );
+}
+

--- a/src/components/analysis/stats/AnalysisHeader.tsx
+++ b/src/components/analysis/stats/AnalysisHeader.tsx
@@ -1,0 +1,39 @@
+export function AnalysisHeader() {
+  return (
+    <header className="border-b-[3px] border-black px-4 py-3 md:px-6">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <span
+            aria-hidden
+            className="flex size-5 items-center justify-center border-2 border-black bg-[#37FF1C]"
+          >
+            <span className="size-1.5 rounded-full border border-black bg-[#0A0A0A]" />
+          </span>
+
+          <h1 className="font-display text-lg font-bold uppercase tracking-tight text-[#1A1F2B] md:text-2xl">
+            RWA YIELD PROTOCOL ANALYSIS
+          </h1>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span className="hidden border-2 border-black bg-black px-3 py-1 font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-[#37FF1C] sm:inline-flex">
+            LIVE: STELLAR SOROBAN
+          </span>
+
+          <button
+            type="button"
+            aria-label="Close analysis"
+            className="inline-flex size-7 items-center justify-center border-2 border-black bg-white font-bold text-black transition-colors hover:bg-zinc-100"
+          >
+            X
+          </button>
+        </div>
+      </div>
+
+      <span className="mt-2 inline-flex border-2 border-black bg-black px-3 py-1 font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-[#37FF1C] sm:hidden">
+        LIVE: STELLAR SOROBAN
+      </span>
+    </header>
+  );
+}
+

--- a/src/components/analysis/stats/StatsGrid.tsx
+++ b/src/components/analysis/stats/StatsGrid.tsx
@@ -1,0 +1,89 @@
+type StatCard = {
+  id: string;
+  title: string;
+  value: string;
+  subtitle?: string;
+  dark?: boolean;
+  badge?: string;
+};
+
+const stats: StatCard[] = [
+  {
+    id: "principal",
+    title: "PRINCIPAL STAKED",
+    value: "45,000 XLM",
+    subtitle: "1,200 USDC",
+  },
+  {
+    id: "yield",
+    title: "NET YIELD GENERATED",
+    value: "0.842931 XLM",
+    subtitle: "+0.542% (24H)",
+    dark: true,
+  },
+  {
+    id: "apy",
+    title: "CURRENT APY",
+    value: "12.5%",
+    badge: "FIXED MULTIPLIER X1.2",
+  },
+];
+
+export function StatsGrid() {
+  return (
+    <section className="grid grid-cols-1 gap-3 p-4 md:grid-cols-3 md:p-6">
+      {stats.map((stat) => (
+        <article
+          key={stat.id}
+          className={
+            stat.dark
+              ? "border-[3px] border-black bg-black p-4"
+              : "border-[3px] border-black bg-[#F5F5F5] p-4"
+          }
+        >
+          <p
+            className={
+              stat.dark
+                ? "font-mono text-[9px] font-bold uppercase tracking-[0.16em] text-[#37FF1C]"
+                : "font-mono text-[9px] font-bold uppercase tracking-[0.16em] text-[#7A808A]"
+            }
+          >
+            {stat.title}
+          </p>
+
+          <p
+            className={
+              stat.dark
+                ? "mt-3 text-4xl font-black uppercase leading-none tracking-tight text-[#37FF1C]"
+                : "mt-3 text-5xl font-bold italic leading-none tracking-tight text-[#1E2430]"
+            }
+          >
+            {stat.value}
+          </p>
+
+          <div className="mt-3 flex items-end justify-between gap-3">
+            {stat.subtitle ? (
+              <p
+                className={
+                  stat.dark
+                    ? "font-mono text-[11px] font-bold uppercase text-[#37FF1C]"
+                    : "font-display text-2xl font-semibold text-[#1E2430]"
+                }
+              >
+                {stat.subtitle}
+              </p>
+            ) : (
+              <span />
+            )}
+
+            {stat.badge ? (
+              <span className="border-2 border-black bg-white px-2 py-0.5 font-mono text-[8px] font-bold uppercase tracking-[0.1em] text-black">
+                {stat.badge}
+              </span>
+            ) : null}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #74

Implemented `/analysis` core UI with:
- header (title, protocol icon, live status badge, close button)
- top stats cards (Principal Staked, Net Yield Generated, Current APY + fixed multiplier badge)
- action buttons (Withdraw Yield, Back to Profile)
- footer network/contract/node health row

Files:
- `src/app/analysis/page.tsx`
- `src/components/analysis/stats/AnalysisHeader.tsx`
- `src/components/analysis/stats/StatsGrid.tsx`
- `src/components/analysis/stats/AnalysisFooter.tsx`