### PR TITLE
Feat: Withdrawal Success (Funds Secured) UI

### DIFF
--- a/src/app/arena-v2/withdrawal-success/page.tsx
+++ b/src/app/arena-v2/withdrawal-success/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { SuccessHeader } from "@/components/arena-v2/withdrawal/SuccessHeader";
+import { UnlockedPadlock } from "@/components/arena-v2/withdrawal/UnlockedPadlock";
+import { WithdrawalDetails } from "@/components/arena-v2/withdrawal/WithdrawalDetails";
+
+// These props would normally come from router state, context, or query params.
+// Placeholder values are used here for demonstration.
+const MOCK_DATA = {
+  totalWithdrawn: "1,240.50",
+  currency: "USDC",
+  destinationAddress: "GBRXXXXXXK4R2",
+  networkFee: "0.00001",
+  feeToken: "XLM",
+  stellarExpertUrl:
+    "https://stellar.expert/explorer/public/tx/placeholder-tx-hash",
+};
+
+export default function WithdrawalSuccessPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-4 py-12 gap-10">
+      {/* Header */}
+      <SuccessHeader />
+
+      {/* Padlock illustration */}
+      <UnlockedPadlock pulse />
+
+      {/* Transaction detail cards */}
+      <WithdrawalDetails
+        totalWithdrawn={MOCK_DATA.totalWithdrawn}
+        currency={MOCK_DATA.currency}
+        destinationAddress={MOCK_DATA.destinationAddress}
+        networkFee={MOCK_DATA.networkFee}
+        feeToken={MOCK_DATA.feeToken}
+      />
+
+      {/* CTA button */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.7 }}
+        className="flex flex-col items-center gap-4"
+      >
+        <button
+          onClick={() => (window.location.href = "/")}
+          className="bg-neon-green text-black font-black text-sm tracking-[0.2em] uppercase px-10 py-4 hover:bg-neon-green/90 transition-colors shadow-[6px_6px_0px_0px_#000]"
+        >
+          RETURN_TO_COMMAND_CENTER
+        </button>
+
+        <a
+          href={MOCK_DATA.stellarExpertUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-mono text-[10px] tracking-widest text-white/40 uppercase hover:text-white/70 transition-colors"
+        >
+          VIEW TRANSACTION ON STELLAREXPERT
+        </a>
+      </motion.div>
+    </main>
+  );
+}

--- a/src/components/arena-v2/withdrawal/SuccessHeader.tsx
+++ b/src/components/arena-v2/withdrawal/SuccessHeader.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export function SuccessHeader() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -30 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: "easeOut" }}
+      className="flex flex-col items-center gap-3 text-center"
+    >
+      <p className="font-mono text-xs tracking-[0.25em] text-neon-green uppercase">
+        // PROTOCOL_SUCCESS // TRANSACTION_COMPLETE
+      </p>
+      <h1 className="font-black text-5xl md:text-6xl lg:text-7xl text-neon-green tracking-widest uppercase">
+        FUNDS_SECURED
+      </h1>
+    </motion.div>
+  );
+}

--- a/src/components/arena-v2/withdrawal/UnlockedPadlock.tsx
+++ b/src/components/arena-v2/withdrawal/UnlockedPadlock.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface UnlockedPadlockProps {
+  pulse?: boolean;
+}
+
+export function UnlockedPadlock({ pulse = true }: UnlockedPadlockProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.8 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.5, delay: 0.2, ease: "easeOut" }}
+      className="flex items-center justify-center"
+    >
+      {/* Outer neon frame */}
+      <div className="relative p-3 border-2 border-neon-green/40">
+        {/* Middle neon frame */}
+        <div className="relative p-3 border-2 border-neon-green/70">
+          {/* Inner neon frame */}
+          <motion.div
+            animate={pulse ? { boxShadow: ["0 0 8px #37FF1C", "0 0 24px #37FF1C", "0 0 8px #37FF1C"] } : {}}
+            transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
+            className="border-2 border-neon-green p-6 bg-transparent"
+          >
+            {/* Padlock SVG */}
+            <svg
+              width="80"
+              height="80"
+              viewBox="0 0 80 80"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-label="Unlocked padlock"
+            >
+              {/* Shackle (open/unlocked — shifted right) */}
+              <path
+                d="M52 36V24C52 14.06 43.94 6 34 6C24.06 6 16 14.06 16 24"
+                stroke="#37FF1C"
+                strokeWidth="6"
+                strokeLinecap="round"
+              />
+              {/* Lock body */}
+              <rect
+                x="14"
+                y="36"
+                width="52"
+                height="38"
+                rx="4"
+                fill="#37FF1C"
+              />
+              {/* Keyhole circle */}
+              <circle cx="40" cy="52" r="6" fill="#09101D" />
+              {/* Keyhole stem */}
+              <rect x="37" y="54" width="6" height="8" rx="1" fill="#09101D" />
+            </svg>
+          </motion.div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/arena-v2/withdrawal/WithdrawalDetails.tsx
+++ b/src/components/arena-v2/withdrawal/WithdrawalDetails.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface WithdrawalDetailsProps {
+  totalWithdrawn: string;
+  currency?: string;
+  destinationAddress: string;
+  networkFee: string;
+  feeToken?: string;
+}
+
+export function WithdrawalDetails({
+  totalWithdrawn,
+  currency = "USDC",
+  destinationAddress,
+  networkFee,
+  feeToken = "XLM",
+}: WithdrawalDetailsProps) {
+  const truncatedAddress =
+    destinationAddress.length > 8
+      ? `${destinationAddress.slice(0, 3)}...${destinationAddress.slice(-4)}`
+      : destinationAddress;
+
+  const cards = [
+    {
+      delay: 0.4,
+      className:
+        "bg-neon-green/10 border border-neon-green/40 p-4 flex flex-col gap-1 shadow-[6px_6px_0px_0px_#000]",
+      content: (
+        <>
+          <span className="font-mono text-[9px] tracking-widest text-neon-green/60 uppercase">
+            Total Withdrawn
+          </span>
+          <span className="font-black text-xl text-neon-green tracking-wide">
+            {totalWithdrawn}{" "}
+            <span className="text-sm font-mono text-white/70">{currency}</span>
+          </span>
+        </>
+      ),
+    },
+    {
+      delay: 0.5,
+      className:
+        "bg-card-bg border border-border-gray p-4 flex flex-col gap-1 shadow-[6px_6px_0px_0px_#000]",
+      content: (
+        <>
+          <span className="font-mono text-[9px] tracking-widest text-white/40 uppercase">
+            Destination
+          </span>
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-base text-white tracking-wide">
+              {truncatedAddress}
+            </span>
+            <span className="text-neon-green text-sm">●</span>
+          </div>
+        </>
+      ),
+    },
+    {
+      delay: 0.6,
+      className:
+        "bg-card-bg border border-border-gray p-4 flex flex-col gap-1 shadow-[6px_6px_0px_0px_#000]",
+      content: (
+        <>
+          <span className="font-mono text-[9px] tracking-widest text-white/40 uppercase">
+            Network Fee
+          </span>
+          <span className="font-mono text-base text-white tracking-wide">
+            {networkFee}{" "}
+            <span className="text-xs text-white/50">{feeToken}</span>
+          </span>
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 w-full max-w-2xl">
+      {cards.map((card, i) => (
+        <motion.div
+          key={i}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: card.delay }}
+          className={card.className}
+        >
+          {card.content}
+        </motion.div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Implements the post-withdrawal success screen as described in issue #76
- Adds `SuccessHeader` component with `// PROTOCOL_SUCCESS // TRANSACTION_COMPLETE` subtitle and `FUNDS_SECURED` title, animated with framer-motion
- Adds `UnlockedPadlock` component — custom SVG padlock with nested neon green frames and optional pulse glow animation
- Adds `WithdrawalDetails` component — three summary cards (Total Withdrawn, Destination, Network Fee) using the project's `shadow-[6px_6px_0px_0px_#000]` hard shadow style
- Adds `/arena-v2/withdrawal-success` page composing all components, CTA button (`RETURN_TO_COMMAND_CENTER`), and a `VIEW TRANSACTION ON STELLAREXPERT` link

## Test plan

- [ ] Navigate to `/arena-v2/withdrawal-success` and verify the page renders correctly
- [ ] Confirm neon green grid background, header text, and `FUNDS_SECURED` title display as expected
- [ ] Verify padlock pulse animation runs on load
- [ ] Confirm all three detail cards show with bottom-right hard shadow
- [ ] Confirm `RETURN_TO_COMMAND_CENTER` button has hard shadow and navigates correctly
- [ ] Verify `VIEW TRANSACTION ON STELLAREXPERT` link opens in a new tab
- [ ] Test responsiveness on mobile viewports (cards stack to single column)
- [ ] Run `yarn build` and confirm no TypeScript or build errors

<img width="1524" height="956" alt="Captura de pantalla 2026-02-20 a la(s) 12 12 13 p  m" src="https://github.com/user-attachments/assets/b3dbcec4-9fb5-448b-b7cf-998f7c274260" />

Closes #76
