### PR TITLE
 Implement the arena v2 waiting page, introducing EntryStatsCards, Li…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -544,21 +544,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@creit-tech/stellar-wallets-kit/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@creit.tech/xbull-wallet-connect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.4.0.tgz",
@@ -6452,6 +6437,20 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "license": "MIT"
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -13031,6 +13030,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/src/app/arena-v2/waiting/page.tsx
+++ b/frontend/src/app/arena-v2/waiting/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { QuorumProgress } from "@/components/arena-v2/waiting/QuorumProgress";
+import { LiveManifest } from "@/components/arena-v2/waiting/LiveManifest";
+import { PreGameIntel } from "@/components/arena-v2/waiting/PreGameIntel";
+import { EntryStatsCards } from "@/components/arena-v2/waiting/EntryStatsCards";
+
+export default function WaitingPage() {
+    return (
+        <div className="min-h-screen bg-background-dark text-white font-display pb-16">
+            <main className="max-w-[1400px] mx-auto p-6 space-y-6">
+                {/* ── Quorum header + progress bar ── */}
+                <QuorumProgress />
+
+                {/* ── Bento grid: Manifest | Stats + Intel ── */}
+                <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 h-auto lg:h-[600px]">
+                    {/* Left column — participant manifest */}
+                    <div className="lg:col-span-5 flex flex-col">
+                        <LiveManifest />
+                    </div>
+
+                    {/* Right column — stats cards + terminal */}
+                    <div className="lg:col-span-7 flex flex-col gap-6">
+                        <EntryStatsCards />
+                        <PreGameIntel />
+                    </div>
+                </div>
+
+                {/* ── View All Participants button ── */}
+                <div className="flex flex-col items-center gap-4 py-8">
+                    <button className="w-full h-24 bg-white text-black text-2xl sm:text-3xl lg:text-4xl font-black neubrutalist-border hover:bg-primary transition-colors uppercase tracking-tight flex items-center justify-center gap-4 group neubrutalist-button font-display">
+                        VIEW ALL PARTICIPANTS
+                        <span className="material-symbols-outlined text-4xl lg:text-5xl transition-transform group-hover:translate-x-2">
+                            arrow_forward
+                        </span>
+                    </button>
+                    <div className="flex items-center gap-4">
+                        <span className="text-white/50 font-bold uppercase tracking-[0.3em] text-sm italic font-display">
+                            SYSTEM STATUS:
+                        </span>
+                        <span className="text-primary font-black uppercase tracking-widest text-sm bg-black px-2 py-1 neubrutalist-border font-display">
+                            WAITING FOR MINIMUM QUORUM
+                        </span>
+                    </div>
+                </div>
+            </main>
+
+            {/* ── Sticky footer ── */}
+            <footer className="fixed bottom-0 w-full neubrutalist-border border-x-0 border-b-0 bg-black py-2 px-6 flex justify-between items-center z-50">
+                <div className="flex gap-4 sm:gap-8 flex-wrap">
+                    <div className="flex items-center gap-2">
+                        <span className="text-[10px] font-black text-white/50 uppercase font-display">
+                            PLAYERS
+                        </span>
+                        <span className="text-sm font-black text-primary tabular-nums font-display">
+                            72/100
+                        </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="text-[10px] font-black text-white/50 uppercase font-display">
+                            TOTAL_STAKED
+                        </span>
+                        <span className="text-sm font-black text-white font-display">
+                            36,000 XLM
+                        </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="text-[10px] font-black text-white/50 uppercase font-display">
+                            LATENCY
+                        </span>
+                        <span className="text-sm font-black text-primary tabular-nums font-display">
+                            12ms
+                        </span>
+                    </div>
+                </div>
+                <div className="text-[10px] font-black text-white/30 uppercase tracking-widest font-display hidden sm:block">
+                    ENCRYPTED_CONNECTION: AES-256-GCM
+                </div>
+            </footer>
+        </div>
+    );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -69,3 +69,37 @@ body {
 .font-pixel {
   font-family: var(--font-pixel), monospace;
 }
+
+/* ── Neubrutalist utilities (Waiting Room) ── */
+.neubrutalist-border {
+  border: 3px solid #000000;
+}
+
+.neubrutalist-button {
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+.neubrutalist-button:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 4px 4px 0px #000000;
+}
+.neubrutalist-button:active {
+  transform: translate(0px, 0px);
+  box-shadow: 0px 0px 0px #000000;
+}
+
+.joining-flash {
+  background-color: #39FF14;
+  color: #000000;
+}
+
+/* Waiting room scrollbar */
+.waiting-scrollbar::-webkit-scrollbar {
+  width: 12px;
+}
+.waiting-scrollbar::-webkit-scrollbar-track {
+  background: #000000;
+}
+.waiting-scrollbar::-webkit-scrollbar-thumb {
+  background: #39FF14;
+  border: 2px solid #000000;
+}

--- a/frontend/src/components/arena-v2/waiting/EntryStatsCards.tsx
+++ b/frontend/src/components/arena-v2/waiting/EntryStatsCards.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface EntryStatsCardsProps {
+    entryStake?: string;
+    prizePool?: string;
+    rwaLiveYield?: string;
+}
+
+export function EntryStatsCards({
+    entryStake = "500 XLM",
+    prizePool = "50,000 XLM",
+    rwaLiveYield = "+2.453 XLM",
+}: EntryStatsCardsProps) {
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, delay: 0.3 }}
+            className="neubrutalist-border bg-primary p-6 text-black grid grid-cols-1 md:grid-cols-3 gap-6"
+        >
+            {/* Entry Stake */}
+            <div className="space-y-1">
+                <p className="text-[10px] font-black uppercase tracking-widest leading-none font-display">
+                    ENTRY STAKE
+                </p>
+                <p className="text-2xl lg:text-3xl font-black italic uppercase font-display">
+                    {entryStake}
+                </p>
+            </div>
+
+            {/* Prize Pool */}
+            <div className="space-y-1">
+                <p className="text-[10px] font-black uppercase tracking-widest leading-none font-display">
+                    PRIZE POOL
+                </p>
+                <p className="text-2xl lg:text-3xl font-black italic uppercase font-display">
+                    {prizePool}
+                </p>
+            </div>
+
+            {/* RWA Live Yield */}
+            <div className="space-y-1 flex flex-col items-start md:items-end">
+                <p className="text-[10px] font-black uppercase tracking-widest leading-none font-display md:text-right">
+                    RWA LIVE YIELD
+                </p>
+                <p className="text-2xl lg:text-3xl font-black italic uppercase tabular-nums font-display">
+                    {rwaLiveYield}
+                </p>
+                <span className="text-[10px] font-bold bg-black text-primary px-1 animate-pulse">
+                    STAKING ACTIVE
+                </span>
+            </div>
+        </motion.div>
+    );
+}

--- a/frontend/src/components/arena-v2/waiting/LiveManifest.tsx
+++ b/frontend/src/components/arena-v2/waiting/LiveManifest.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface Participant {
+    walletId: string;
+    status: "JOINING" | "READY";
+    timestamp: string;
+}
+
+interface LiveManifestProps {
+    participants?: Participant[];
+}
+
+const DEFAULT_PARTICIPANTS: Participant[] = [
+    { walletId: "GB7W...RQT2", status: "JOINING", timestamp: "14:22:01" },
+    { walletId: "0x71...9B2A", status: "READY", timestamp: "14:21:55" },
+    { walletId: "GD3L...88K1", status: "READY", timestamp: "14:21:42" },
+    { walletId: "0x12...5C0D", status: "READY", timestamp: "14:20:10" },
+    { walletId: "GAK9...3PX9", status: "READY", timestamp: "14:19:58" },
+    { walletId: "0x88...FF21", status: "READY", timestamp: "14:18:33" },
+    { walletId: "GCCN...L00P", status: "READY", timestamp: "14:17:45" },
+];
+
+export function LiveManifest({
+    participants = DEFAULT_PARTICIPANTS,
+}: LiveManifestProps) {
+    return (
+        <motion.div
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.5, delay: 0.2 }}
+            className="flex flex-col neubrutalist-border bg-black overflow-hidden h-full"
+        >
+            {/* Header */}
+            <div className="p-4 neubrutalist-border border-x-0 border-t-0 bg-[#1e293b] flex justify-between items-center shrink-0">
+                <h3 className="font-black text-lg tracking-widest uppercase font-display text-white">
+                    MANIFEST [LIVE_FEED]
+                </h3>
+                <div className="flex items-center gap-2">
+                    <span className="size-2 bg-primary rounded-full animate-pulse" />
+                    <span className="text-xs font-bold text-primary uppercase font-display">
+                        SYNCING
+                    </span>
+                </div>
+            </div>
+
+            {/* Scrollable table */}
+            <div className="flex-1 overflow-y-auto font-mono text-sm waiting-scrollbar">
+                <table className="w-full border-collapse">
+                    <thead className="sticky top-0 bg-black z-10">
+                        <tr className="text-left border-b-2 border-[#1e293b]">
+                            <th className="p-4 text-xs font-bold text-white/40 uppercase">
+                                WALLET_ID
+                            </th>
+                            <th className="p-4 text-xs font-bold text-white/40 uppercase">
+                                STATUS
+                            </th>
+                            <th className="p-4 text-xs font-bold text-white/40 uppercase">
+                                TIMESTAMP
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {participants.map((p, i) => (
+                            <tr
+                                key={`${p.walletId}-${i}`}
+                                className={
+                                    p.status === "JOINING"
+                                        ? "joining-flash border-b border-white/10"
+                                        : "border-b border-white/10 hover:bg-white/5"
+                                }
+                            >
+                                <td className="p-4 font-bold uppercase tracking-tighter text-inherit">
+                                    {p.walletId}
+                                </td>
+                                <td className="p-4">
+                                    {p.status === "JOINING" ? (
+                                        <span className="font-black italic animate-pulse">
+                                            JOINING...
+                                        </span>
+                                    ) : (
+                                        <span className="text-primary font-bold">READY</span>
+                                    )}
+                                </td>
+                                <td
+                                    className={`p-4 text-xs ${p.status === "JOINING" ? "opacity-70" : "opacity-50"
+                                        }`}
+                                >
+                                    {p.timestamp}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </motion.div>
+    );
+}

--- a/frontend/src/components/arena-v2/waiting/PreGameIntel.tsx
+++ b/frontend/src/components/arena-v2/waiting/PreGameIntel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+
+interface LogEntry {
+    tag: "SYSTEM" | "NETWORK" | "ARENA" | "ALERT";
+    message: string;
+}
+
+interface PreGameIntelProps {
+    logs?: LogEntry[];
+}
+
+const DEFAULT_LOGS: LogEntry[] = [
+    { tag: "SYSTEM", message: "INITIALIZING HANDSHAKE WITH SOROBAN RPC..." },
+    { tag: "NETWORK", message: "CONNECTION ESTABLISHED" },
+    { tag: "ARENA", message: "USER_0x42...8k2 ENTERED THE ARENA (71/100)" },
+    { tag: "ARENA", message: "USER_GB7W...RQT2 ENTERED THE ARENA (72/100)" },
+    { tag: "ALERT", message: "RWA TREASURY YIELD UPDATED - CURRENT APY: 4.8%" },
+    { tag: "SYSTEM", message: "WAITING FOR VALIDATOR SIGNATURES..." },
+    { tag: "ARENA", message: "TOTAL STAKED VALUE: 36,000 XLM" },
+    { tag: "SYSTEM", message: "REFRESHING LIQUIDITY POOL DATA..." },
+];
+
+function tagColor(tag: LogEntry["tag"]): string {
+    switch (tag) {
+        case "NETWORK":
+        case "ALERT":
+            return "text-primary font-bold";
+        case "ARENA":
+            return "text-white";
+        case "SYSTEM":
+        default:
+            return "text-white/40";
+    }
+}
+
+export function PreGameIntel({ logs = DEFAULT_LOGS }: PreGameIntelProps) {
+    const [inputValue, setInputValue] = useState("");
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.5, delay: 0.4 }}
+            className="flex-1 neubrutalist-border bg-black flex flex-col overflow-hidden"
+        >
+            {/* Header */}
+            <div className="p-4 neubrutalist-border border-x-0 border-t-0 bg-[#1e293b] shrink-0">
+                <h3 className="font-black text-lg tracking-widest uppercase flex items-center gap-2 font-display text-white">
+                    <span className="material-symbols-outlined text-primary">
+                        terminal
+                    </span>
+                    PRE-GAME_INTEL
+                </h3>
+            </div>
+
+            {/* Log feed */}
+            <div className="flex-1 p-4 font-mono text-xs space-y-2 overflow-y-auto waiting-scrollbar">
+                {logs.map((entry, i) => (
+                    <p key={i} className={tagColor(entry.tag)}>
+                        &gt; [{entry.tag}]: {entry.message}
+                    </p>
+                ))}
+                {/* Blinking cursor */}
+                <div className="flex items-center gap-1">
+                    <span className="text-primary font-black animate-pulse">_</span>
+                </div>
+            </div>
+
+            {/* Chat input */}
+            <div className="p-3 neubrutalist-border border-x-0 border-b-0 bg-[#1e293b] flex gap-2 shrink-0">
+                <input
+                    type="text"
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                    className="flex-1 bg-black border-2 border-black focus:border-primary text-white font-mono text-xs uppercase p-2 outline-none"
+                    placeholder="BROADCAST INTEL TO LOBBY..."
+                />
+                <button className="bg-primary text-black font-black px-4 neubrutalist-border text-xs uppercase neubrutalist-button">
+                    SEND
+                </button>
+            </div>
+        </motion.div>
+    );
+}

--- a/frontend/src/components/arena-v2/waiting/QuorumProgress.tsx
+++ b/frontend/src/components/arena-v2/waiting/QuorumProgress.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface QuorumProgressProps {
+    arenaId?: number;
+    currentPlayers?: number;
+    requiredPlayers?: number;
+    estimatedStart?: string;
+    blockHeight?: string;
+}
+
+export function QuorumProgress({
+    arenaId = 842,
+    currentPlayers = 72,
+    requiredPlayers = 100,
+    estimatedStart = "04:12:09",
+    blockHeight = "49,210,123",
+}: QuorumProgressProps) {
+    const percentage = Math.round((currentPlayers / requiredPlayers) * 100);
+    const remaining = requiredPlayers - currentPlayers;
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="neubrutalist-border bg-[#1e293b] p-8 space-y-6"
+        >
+            {/* Title row */}
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
+                <div className="space-y-1">
+                    <h2 className="text-3xl sm:text-4xl lg:text-5xl font-black tracking-[-0.05em] uppercase font-display text-white">
+                        ARENA #{arenaId}: DEPLOYMENT PENDING
+                    </h2>
+                    <p className="text-primary text-lg lg:text-xl font-bold italic font-display">
+                        WAITING FOR MINIMUM QUORUM: {currentPlayers} / {requiredPlayers}{" "}
+                        PLAYERS READY
+                    </p>
+                </div>
+                <div className="text-right shrink-0">
+                    <span className="text-xs font-bold text-white/50 uppercase tracking-[0.2em] block">
+                        ESTIMATED START
+                    </span>
+                    <p className="text-3xl font-black tabular-nums font-display text-white">
+                        {estimatedStart}
+                    </p>
+                </div>
+            </div>
+
+            {/* Progress bar */}
+            <div className="space-y-2">
+                <div className="flex justify-between items-end">
+                    <span className="text-sm font-black uppercase tracking-widest text-white font-display">
+                        PLAYER QUORUM STATUS
+                    </span>
+                    <span className="text-4xl font-black text-primary italic tabular-nums font-display">
+                        {percentage}%
+                    </span>
+                </div>
+                <div className="w-full h-12 neubrutalist-border bg-black p-1">
+                    <motion.div
+                        className="h-full bg-primary"
+                        initial={{ width: 0 }}
+                        animate={{ width: `${percentage}%` }}
+                        transition={{ duration: 1, ease: "easeOut" }}
+                    />
+                </div>
+                <div className="flex justify-between items-start">
+                    <span className="text-sm font-bold text-primary font-display">
+                        {remaining} MORE PARTICIPANTS REQUIRED FOR TRIGGER
+                    </span>
+                    <span className="text-sm font-bold text-white/40 uppercase font-display">
+                        BLOCK_HEIGHT: {blockHeight}
+                    </span>
+                </div>
+            </div>
+        </motion.div>
+    );
+}


### PR DESCRIPTION
feat: implement neubrutalist waiting room for arena-v2

Adds the /arena-v2/waiting route — a pre-game lobby where players wait for quorum before an arena match begins.

New files

src/app/arena-v2/waiting/page.tsx
 — Page with bento grid layout, sticky footer, and "View All Participants" CTA

src/components/arena-v2/waiting/QuorumProgress.tsx
 — Arena title, countdown timer, and animated progress bar

src/components/arena-v2/waiting/LiveManifest.tsx
 — Scrollable participant table with "JOINING…" flash animation

src/components/arena-v2/waiting/PreGameIntel.tsx
 — Terminal-style system log feed with chat input

src/components/arena-v2/waiting/EntryStatsCards.tsx
 — Entry Stake / Prize Pool / RWA Live Yield stat cards
Modified files

src/app/globals.css
 — Added neubrutalist border, button hover, joining-flash, and scrollbar utilities
All components accept props with mock defaults and are ready to be wired to live data.

close #70 