### PR TITLE
feat: add transactions management with BullMQ integration and new API…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^5.14.0",
         "@stellar/stellar-sdk": "^13.1.0",
+        "bullmq": "^5.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -487,6 +488,84 @@
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
@@ -973,6 +1052,21 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bullmq": {
+      "version": "5.70.1",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.70.1.tgz",
+      "integrity": "sha512-HjfGHfICkAClrFL0Y07qNbWcmiOCv1l+nusupXUjrvTPuDEyPEJ23MP0lUwUs/QEy1a3pWt/P/sCsSZ1RjRK+w==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "4.9.0",
+        "ioredis": "5.9.3",
+        "msgpackr": "1.11.5",
+        "node-abort-controller": "3.1.1",
+        "semver": "7.7.4",
+        "tslib": "2.8.1",
+        "uuid": "11.1.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1103,6 +1197,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1164,6 +1270,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -1473,6 +1589,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1885,6 +2002,15 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2094,6 +2220,37 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
+      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -2101,6 +2258,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {
@@ -2738,6 +2916,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -2834,6 +3018,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@prisma/client": "^5.14.0",
     "@stellar/stellar-sdk": "^13.1.0",
+    "bullmq": "^5.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import { PayoutsController } from "./controllers/payouts.controller";
 import { WorkerController } from "./controllers/worker.controller";
 import { AdminController } from "./controllers/admin.controller";
 import { AuthController } from "./controllers/auth.controller";
+import { TransactionsController } from "./controllers/transactions.controller";
 import { RoundController } from "./controllers/round.controller";
 import { register } from "./utils/metrics";
 import type { PaymentService } from "./services/paymentService";
@@ -55,12 +56,13 @@ export function createApp(deps: AppDependencies): express.Application {
     deps.transactions
   );
   const authController = new AuthController(deps.authService);
+  const transactionsController = new TransactionsController(deps.transactions);
   const roundController = new RoundController(deps.roundService);
 
   const adminAuthMiddleware = requireAdmin(new ApiKeyAuthProvider());
   const userAuthMiddleware = requireAuth(deps.authService);
 
-  app.use("/api", createApiRouter(payoutsController, workerController, authController, userAuthMiddleware));
+  app.use("/api", createApiRouter(payoutsController, workerController, authController, transactionsController, userAuthMiddleware));
   app.use("/api/admin", createAdminRouter(adminController, roundController, adminAuthMiddleware));
 
   app.use(errorHandler);

--- a/backend/src/controllers/transactions.controller.ts
+++ b/backend/src/controllers/transactions.controller.ts
@@ -1,0 +1,15 @@
+import type { Request, Response } from "express";
+import type { TransactionRepository } from "../repositories/transactionRepository";
+
+export class TransactionsController {
+  constructor(private readonly transactions: TransactionRepository) {}
+
+  getById = async (req: Request, res: Response): Promise<void> => {
+    const tx = await this.transactions.findById(req.params.id);
+    if (!tx) {
+      res.status(404).json({ error: "Transaction not found" });
+      return;
+    }
+    res.json(tx);
+  };
+}

--- a/backend/src/queues/txQueue.ts
+++ b/backend/src/queues/txQueue.ts
@@ -1,0 +1,24 @@
+import { Queue } from "bullmq";
+
+export const TX_CONFIRM_QUEUE = "tx-confirm";
+
+export interface ConfirmJobData {
+  transactionId: string;
+}
+
+function redisConnectionOpts() {
+  const url = process.env.REDIS_URL ?? "redis://localhost:6379";
+  return { url };
+}
+
+export function createTxQueue(): Queue<ConfirmJobData> {
+  return new Queue<ConfirmJobData>(TX_CONFIRM_QUEUE, {
+    connection: redisConnectionOpts(),
+    defaultJobOptions: {
+      attempts: 10,
+      backoff: { type: "exponential", delay: 2_000 }, // 2s, 4s, 8s … ~34 min total
+      removeOnComplete: 100,
+      removeOnFail: 500,
+    },
+  });
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -2,18 +2,21 @@ import { Router } from "express";
 import { createPayoutsRouter } from "./payouts";
 import { createWorkerRouter } from "./worker";
 import { createAuthRouter } from "./auth";
+import { createTransactionsRouter } from "./transactions";
 import { createOracleRouter } from "./oracle";
 import { createArenasRouter } from "./arenas";
 import { createLeaderboardRouter } from "./leaderboard";
 import type { PayoutsController } from "../controllers/payouts.controller";
 import type { WorkerController } from "../controllers/worker.controller";
 import type { AuthController } from "../controllers/auth.controller";
+import type { TransactionsController } from "../controllers/transactions.controller";
 import type { RequestHandler } from "express";
 
 export function createApiRouter(
   payoutsController: PayoutsController,
   workerController: WorkerController,
   authController: AuthController,
+  transactionsController: TransactionsController,
   requireAuth: RequestHandler
 ): Router {
   const router = Router();
@@ -21,6 +24,7 @@ export function createApiRouter(
   router.use("/auth", createAuthRouter(authController, requireAuth));
   router.use("/payouts", createPayoutsRouter(payoutsController));
   router.use("/worker", createWorkerRouter(workerController));
+  router.use("/transactions", requireAuth, createTransactionsRouter(transactionsController));
   router.use("/oracle", createOracleRouter());
   router.use("/arenas", createArenasRouter());
   router.use("/leaderboard", createLeaderboardRouter());

--- a/backend/src/routes/transactions.ts
+++ b/backend/src/routes/transactions.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { asyncHandler } from "../middleware/validate";
+import type { TransactionsController } from "../controllers/transactions.controller";
+
+export function createTransactionsRouter(controller: TransactionsController): Router {
+  const router = Router();
+
+  router.get("/:id", asyncHandler(controller.getById));
+
+  return router;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { db } from "./db/client";
+// import { db } from "./db/client";
 import { redis } from "./cache/redisClient";
 import { prisma } from "./db/prisma";
 import { SqlTransactionRepository } from "./repositories/sqlTransactionRepository";
@@ -11,6 +11,8 @@ import { PaymentWorker } from "./workers/paymentWorker";
 import { AdminService } from "./services/adminService";
 import { AuthService } from "./services/authService";
 import { RoundService } from "./services/roundService";
+import { createTxQueue } from "./queues/txQueue";
+import { startTxReconcilerWorker } from "./workers/txReconciler";
 import { createApp } from "./app";
 
 import { initSentry } from "./utils/sentry";
@@ -20,13 +22,15 @@ const PORT = Number(process.env.PORT ?? 3001);
 async function main() {
   initSentry();
   await connectDB();
-  await redis.connect();
+   await redis.connect();
 
 
   const transactions = new MongoTransactionRepository();
 
+  const txQueue = createTxQueue();
   const paymentService = new PaymentService(transactions);
-  const paymentWorker = new PaymentWorker(transactions, paymentService);
+  const paymentWorker = new PaymentWorker(transactions, paymentService, txQueue);
+  startTxReconcilerWorker(paymentService, transactions);
   const adminService = new AdminService();
   const authService = new AuthService();
   const roundService = new RoundService(prisma);

--- a/backend/src/types/payment.ts
+++ b/backend/src/types/payment.ts
@@ -4,7 +4,8 @@ export type PaymentStatus =
   | "awaiting_signature"
   | "submitted"
   | "confirmed"
-  | "failed";
+  | "failed"
+  | "dead";
 
 export interface TransactionRecord {
   id: string;

--- a/backend/src/workers/txReconciler.ts
+++ b/backend/src/workers/txReconciler.ts
@@ -1,0 +1,42 @@
+import { Worker, type Job } from "bullmq";
+import type { PaymentService } from "../services/paymentService";
+import type { TransactionRepository } from "../repositories/transactionRepository";
+import { TX_CONFIRM_QUEUE, type ConfirmJobData } from "../queues/txQueue";
+
+export function startTxReconcilerWorker(
+  paymentService: PaymentService,
+  transactions: TransactionRepository
+): Worker<ConfirmJobData> {
+  const worker = new Worker<ConfirmJobData>(
+    TX_CONFIRM_QUEUE,
+    async (job: Job<ConfirmJobData>) => {
+      const tx = await paymentService.confirmSubmittedTransaction(job.data.transactionId);
+
+      if (tx.status === "submitted") {
+        // Still pending on-chain — throw so BullMQ retries with exponential backoff
+        throw new Error(`Transaction ${job.data.transactionId} still pending on-chain`);
+      }
+      // "confirmed" or "failed" → terminal state, job completes without retry
+    },
+    { connection: { url: process.env.REDIS_URL ?? "redis://localhost:6379" } }
+  );
+
+  // Dead-letter: fired on every failure attempt; only act when all retries are exhausted
+  worker.on("failed", async (job: Job<ConfirmJobData> | undefined, err: Error) => {
+    if (!job) return;
+    const maxAttempts = job.opts.attempts ?? 1;
+    if (job.attemptsMade >= maxAttempts) {
+      await transactions.update(job.data.transactionId, {
+        status: "dead",
+        errorMessage: `Confirmation failed after ${maxAttempts} attempts: ${err.message}`,
+        updatedAt: new Date(),
+      });
+    }
+  });
+
+  worker.on("error", (err: Error) => {
+    console.error("[TxReconciler] Worker error:", err.message);
+  });
+
+  return worker;
+}


### PR DESCRIPTION
Summary
Adds a persistent BullMQ job queue (tx-confirm) for on-chain Soroban transaction confirmation, replacing inline synchronous polling with durable background retry
PaymentWorker now enqueues a BullMQ confirmation job after each successful transaction submission; inline polling is only used as fallback when no queue is configured
txReconciler worker retries confirmation with exponential backoff (2s → ~34 min across 10 attempts); transactions exhausting all retries are automatically marked "dead" in the DB (dead-letter behaviour)
Adds GET /api/transactions/:id (auth required) so callers can poll transaction status asynchronously
Adds "dead" to PaymentStatus to represent terminal failure after retry exhaustion
Test plan
 Start server with Redis running — verify BullMQ worker connects ([TxReconciler] Worker connected in logs)
 Trigger POST /api/worker/run-batch with a queued transaction — verify it moves to submitted and a BullMQ job appears in Redis
 GET /api/transactions/:id with a valid JWT returns the transaction record
 GET /api/transactions/:id with no/invalid JWT returns 401
 Kill and restart server mid-confirmation — verify BullMQ resumes the job from Redis (persistence test)
 Simulate a never-confirming tx hash — after 10 retries, verify status: "dead" is set in MongoDB

Closes #84 

