### PR TITLE
feat: implement Soroban contract event parser #136

### DIFF
--- a/frontend/src/components/hook-d/sorobanEventParser.test.ts
+++ b/frontend/src/components/hook-d/sorobanEventParser.test.ts
@@ -1,0 +1,71 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { nativeToScVal, xdr } from '@stellar/stellar-sdk';
+import { parseArenaEvent, RawContractEvent } from './sorobanEventParser.js';
+
+describe('SorobanEventParser', () => {
+    test('correctly parses a PlayerJoined event', () => {
+        const mockPlayer = 'GBRPNBYBD7Y4E6BOSFCHX3DJSV7N37XYTFGPCI27SRK6A4NQX7N7C4ZZ';
+        const mockContractId = 'CAV6XGB...';
+
+        // Create mock topics
+        const topics = [
+            nativeToScVal('player_joined', { type: 'symbol' }).toXDR('base64')
+        ];
+
+        // Create mock value map
+        const valueMap = {
+            player: mockPlayer,
+        };
+        const valueXdr = nativeToScVal(valueMap).toXDR('base64');
+
+        const rawEvent: RawContractEvent = {
+            type: 'contract',
+            id: 'event-id-1',
+            contractId: mockContractId,
+            topic: topics,
+            value: { xdr: valueXdr },
+            ledgerCloseAt: '2026-02-23T18:00:00Z'
+        };
+
+        const parsed = parseArenaEvent(rawEvent);
+
+        assert.notStrictEqual(parsed, null);
+        if (parsed) {
+            assert.strictEqual(parsed.type, 'PlayerJoined');
+            assert.strictEqual(parsed.arenaId, mockContractId);
+            assert.strictEqual((parsed as any).playerWallet, mockPlayer);
+            assert.strictEqual(typeof parsed.timestamp, 'number');
+        }
+    });
+
+    test('returns null for unknown events and warns', () => {
+        const topics = [
+            nativeToScVal('unknown_event', { type: 'symbol' }).toXDR('base64')
+        ];
+
+        const rawEvent: RawContractEvent = {
+            type: 'contract',
+            id: 'event-id-2',
+            contractId: 'CAV...',
+            topic: topics,
+            value: { xdr: nativeToScVal(null).toXDR('base64') }
+        };
+
+        const parsed = parseArenaEvent(rawEvent);
+        assert.strictEqual(parsed, null);
+    });
+
+    test('returns null for invalid XDR', () => {
+        const rawEvent: RawContractEvent = {
+            type: 'contract',
+            id: 'event-id-3',
+            contractId: 'CAV...',
+            topic: ['invalid-base64'],
+            value: { xdr: 'invalid-base64' }
+        };
+
+        const parsed = parseArenaEvent(rawEvent);
+        assert.strictEqual(parsed, null);
+    });
+});

--- a/frontend/src/components/hook-d/sorobanEventParser.ts
+++ b/frontend/src/components/hook-d/sorobanEventParser.ts
@@ -1,0 +1,160 @@
+import { scValToNative, xdr } from '@stellar/stellar-sdk';
+import {
+    ArenaDomainEvent,
+    ArenaCreatedEvent,
+    PlayerJoinedEvent,
+    RoundStartedEvent,
+    ChoiceSubmittedEvent,
+    RoundResolvedEvent,
+    WinnersDeclaredEvent
+} from '../../shared-d/types/arenaTypes';
+
+/**
+ * Minimal interface describing the shape of raw Soroban events from RPC/Horizon.
+ */
+export interface RawContractEvent {
+    type: string;
+    id: string;
+    contractId: string;
+    topic: string[]; // Array of base64 encoded ScVal XDR strings
+    value: {
+        xdr: string; // Base64 encoded ScVal XDR string
+    };
+    ledgerCloseAt?: string;
+}
+
+/**
+ * Normalizes raw Stellar/Soroban contract events into strongly-typed arena domain objects.
+ * @param raw - The raw event object from Stellar RPC or Horizon.
+ * @returns A typed ArenaDomainEvent or null if the event is unrecognized or invalid.
+ */
+export function parseArenaEvent(raw: RawContractEvent): ArenaDomainEvent | null {
+    try {
+        if (!raw.topic || raw.topic.length === 0) return null;
+
+        // The first topic is usually the event name as a symbol
+        const eventNameScVal = xdr.ScVal.fromXDR(raw.topic[0], 'base64');
+        const eventName = scValToNative(eventNameScVal);
+
+        switch (eventName) {
+            case 'arena_created':
+                return parseArenaCreatedEvent(raw);
+            case 'player_joined':
+                return parsePlayerJoinedEvent(raw);
+            case 'round_started':
+                return parseRoundStartedEvent(raw);
+            case 'choice_submitted':
+                return parseChoiceSubmittedEvent(raw);
+            case 'round_resolved':
+                return parseRoundResolvedEvent(raw);
+            case 'winners_declared':
+                return parseWinnersDeclaredEvent(raw);
+            default:
+                console.warn(`[SorobanEventParser] Unknown event type detected: ${eventName}`, raw);
+                return null;
+        }
+    } catch (error) {
+        console.error('[SorobanEventParser] Failed to parse event', error, raw);
+        return null;
+    }
+}
+
+function parseArenaCreatedEvent(raw: RawContractEvent): ArenaCreatedEvent | null {
+    const value = decodeValue(raw.value.xdr);
+    if (!value) return null;
+
+    return {
+        type: 'ArenaCreated',
+        arenaId: raw.contractId,
+        creator: value.creator,
+        maxPlayers: Number(value.max_players),
+        entryFee: value.entry_fee.toString(),
+        timestamp: getTimestamp(raw),
+    };
+}
+
+function parsePlayerJoinedEvent(raw: RawContractEvent): PlayerJoinedEvent | null {
+    const value = decodeValue(raw.value.xdr);
+    if (!value) return null;
+
+    return {
+        type: 'PlayerJoined',
+        arenaId: raw.contractId,
+        playerWallet: value.player,
+        timestamp: getTimestamp(raw),
+    };
+}
+
+function parseRoundStartedEvent(raw: RawContractEvent): RoundStartedEvent | null {
+    const value = decodeValue(raw.value.xdr);
+    if (!value) return null;
+
+    return {
+        type: 'RoundStarted',
+        arenaId: raw.contractId,
+        roundNumber: Number(value.round),
+        timestamp: getTimestamp(raw),
+    };
+}
+
+function parseChoiceSubmittedEvent(raw: RawContractEvent): ChoiceSubmittedEvent | null {
+    const value = decodeValue(raw.value.xdr);
+    if (!value) return null;
+
+    return {
+        type: 'ChoiceSubmitted',
+        arenaId: raw.contractId,
+        playerWallet: value.player,
+        choice: value.choice === 'Heads' ? 0 : 1,
+        roundNumber: Number(value.round),
+        timestamp: getTimestamp(raw),
+    };
+}
+
+function parseRoundResolvedEvent(raw: RawContractEvent): RoundResolvedEvent | null {
+    const value = decodeValue(raw.value.xdr);
+    if (!value) return null;
+
+    return {
+        type: 'RoundResolved',
+        arenaId: raw.contractId,
+        roundNumber: Number(value.round),
+        winningChoice: value.winner === 'Heads' ? 0 : 1,
+        timestamp: getTimestamp(raw),
+    };
+}
+
+function parseWinnersDeclaredEvent(raw: RawContractEvent): WinnersDeclaredEvent | null {
+    const value = decodeValue(raw.value.xdr);
+    if (!value) return null;
+
+    return {
+        type: 'WinnersDeclared',
+        arenaId: raw.contractId,
+        winners: Array.isArray(value.winners) ? value.winners : [],
+        timestamp: getTimestamp(raw),
+    };
+}
+
+/**
+ * Helper to decode ScVal XDR to a native JS object/value.
+ */
+function decodeValue(xdrString: string): any {
+    try {
+        const scval = xdr.ScVal.fromXDR(xdrString, 'base64');
+        return scValToNative(scval);
+    } catch (error) {
+        console.warn('[SorobanEventParser] Failed to decode value XDR', error);
+        return null;
+    }
+}
+
+/**
+ * Extracts timestamp from ledgerCloseAt or defaults to now.
+ */
+function getTimestamp(raw: RawContractEvent): number {
+    if (raw.ledgerCloseAt) {
+        return new Date(raw.ledgerCloseAt).getTime();
+    }
+    return Date.now();
+}

--- a/frontend/src/shared-d/types/arenaTypes.ts
+++ b/frontend/src/shared-d/types/arenaTypes.ts
@@ -1,0 +1,54 @@
+export interface ArenaCreatedEvent {
+    type: 'ArenaCreated';
+    arenaId: string;
+    creator: string;
+    maxPlayers: number;
+    entryFee: string;
+    timestamp: number;
+}
+
+export interface PlayerJoinedEvent {
+    type: 'PlayerJoined';
+    arenaId: string;
+    playerWallet: string;
+    timestamp: number;
+}
+
+export interface RoundStartedEvent {
+    type: 'RoundStarted';
+    arenaId: string;
+    roundNumber: number;
+    timestamp: number;
+}
+
+export interface ChoiceSubmittedEvent {
+    type: 'ChoiceSubmitted';
+    arenaId: string;
+    playerWallet: string;
+    choice: number;
+    roundNumber: number;
+    timestamp: number;
+}
+
+export interface RoundResolvedEvent {
+    type: 'RoundResolved';
+    arenaId: string;
+    roundNumber: number;
+    winningChoice: number;
+    timestamp: number;
+}
+
+export interface WinnersDeclaredEvent {
+    type: 'WinnersDeclared';
+    arenaId: string;
+    winners: string[];
+    timestamp: number;
+}
+
+export type ArenaDomainEvent =
+    | ArenaCreatedEvent
+    | PlayerJoinedEvent
+    | RoundStartedEvent
+    | ChoiceSubmittedEvent
+    | RoundResolvedEvent
+    | WinnersDeclaredEvent;


### PR DESCRIPTION
## Description
Implement Soroban contract event parser to normalize raw events into typed domain objects.

Closes #136

## Changes proposed

### What were you told to do?
I was tasked with implementing a parser module that normalizes raw Stellar/Soroban contract events into strongly-typed arena domain objects.

Requirements included:
- Detect event types (ArenaCreated, PlayerJoined, RoundStarted, ChoiceSubmitted, RoundResolved, WinnersDeclared).
- Extract and validate specific fields for each event.
- Return null and warn for unrecognized event types.
- Ensure TypeScript type safety matching arena domain types.
- Implement tests to verify parsing logic.

### What did I do?

#### Implementation of the event parser
- Created `frontend/src/shared-d/types/arenaTypes.ts` with definitions for all arena domain events.
- Created `frontend/src/components/hook-d/sorobanEventParser.ts` implementing `parseArenaEvent` and specific sub-parsers for each event type.
- Used `scValToNative` to decode Soroban XDR data structures into usable JavaScript objects.
- Implemented robust error handling for XDR decoding.

#### Verification and testing
- Created `frontend/src/components/hook-d/sorobanEventParser.test.ts` with unit tests covering:
  - Successful parsing of `PlayerJoined` event.
  - Graceful handling of unknown event types.
  - Resilience against invalid XDR inputs.
- Verified logic by running `npx tsx --test frontend/src/components/hook-d/sorobanEventParser.test.ts`.

#### Validation and results
- Tests passed successfully.
- Code follows project structure and naming conventions.

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Node test runner output showing 3 passed tests.
- Successfully parsed mock payloads to typed domain objects.
