### PR TITLE
feat: implement global settings configuration page

### DIFF
--- a/frontend/src/app/arena-v2/settings/page.tsx
+++ b/frontend/src/app/arena-v2/settings/page.tsx
@@ -23,19 +23,19 @@ export default function ArenaV2SettingsPage() {
   };
 
   return (
-    <main className="min-h-screen bg-[#060d1f] px-4 py-6 text-white sm:px-8 lg:px-10">
-      <div className="mx-auto w-full max-w-[1160px] rounded-md border-2 border-[#20345f] bg-[#0a1430] p-4 shadow-[0_0_0_2px_#08132a] sm:p-6">
-        <header className="mb-6 flex flex-col gap-4 border-b border-[#1d2c52] pb-4 sm:flex-row sm:items-start sm:justify-between">
+    <main className="min-h-screen bg-[#060d1f] px-4 py-6 text-[#d8e4ff] sm:px-8 lg:px-10">
+      <div className="mx-auto w-full max-w-290 rounded-md border-2 border-[#273a63] bg-[#0b1836] p-4 shadow-[0_0_0_2px_#08132a] sm:p-6">
+        <header className="mb-6 flex flex-col gap-4 border-b border-[#22345b] pb-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h1 className="font-pixel text-4xl uppercase tracking-[0.12em] text-white sm:text-5xl">GLOBAL_SETTINGS</h1>
-            <p className="mt-2 font-pixel text-[10px] uppercase tracking-[0.16em] text-white/45">
+            <h1 className="font-pixel text-4xl uppercase tracking-[0.12em] text-[#eef4ff] sm:text-5xl">GLOBAL_SETTINGS</h1>
+            <p className="mt-2 font-pixel text-[10px] uppercase tracking-[0.16em] text-[#8b9bc0]">
               CONFIGURE_TERMINAL_INTERFACE_AND_AUDIO_ARRAYS
             </p>
           </div>
 
-          <div className="inline-flex items-center gap-2 self-start border border-[#1f7f33] bg-[#0a2015] px-3 py-1">
-            <span className="h-2.5 w-2.5 rounded-full bg-[#31ff34] shadow-[0_0_10px_rgba(49,255,52,0.9)] animate-pulse" />
-            <span className="font-pixel text-[9px] uppercase tracking-[0.14em] text-[#48ff54]">LIVE_CONNECTION_STABLE</span>
+          <div className="inline-flex items-center gap-2 self-start border border-[#20612a] bg-[#092212] px-3 py-1">
+            <span className="h-2.5 w-2.5 rounded-full bg-[#39ff14] shadow-[0_0_10px_rgba(57,255,20,0.9)] animate-pulse" />
+            <span className="font-pixel text-[9px] uppercase tracking-[0.14em] text-[#5eff52]">LIVE_CONNECTION_STABLE</span>
           </div>
         </header>
 
@@ -54,7 +54,7 @@ export default function ArenaV2SettingsPage() {
 
           <div className="space-y-4">
             <SettingsCard title="ENERGY_PULSE">
-              <p className="mb-4 font-pixel text-[9px] uppercase tracking-[0.13em] text-white/45">
+              <p className="mb-4 font-pixel text-[9px] uppercase tracking-[0.13em] text-[#8b9bc0]">
                 ENABLE_VISUAL_RWA_UI_PULSES_FOR_LIVE_YIELD
               </p>
               <button
@@ -62,8 +62,8 @@ export default function ArenaV2SettingsPage() {
                 onClick={() => setEnergyPulseEnabled((prev) => !prev)}
                 className={`flex h-12 w-full items-center justify-between border-2 border-black px-3 font-pixel text-[11px] uppercase tracking-[0.14em] transition ${
                   energyPulseEnabled
-                    ? "bg-[#30ff33] text-black hover:brightness-95"
-                    : "bg-[#0f1220] text-white hover:border-[#30ff33]"
+                    ? "bg-[#39ff14] text-black hover:brightness-95"
+                    : "bg-[#0e1528] text-[#d8e4ff] hover:border-[#39ff14]"
                 }`}
               >
                 <span>{energyPulseEnabled ? "ENABLED" : "DISABLED"}</span>
@@ -78,8 +78,8 @@ export default function ArenaV2SettingsPage() {
                   onClick={() => setColorMode("dark")}
                   className={`h-11 w-full border-2 border-black font-pixel text-[10px] uppercase tracking-[0.14em] transition ${
                     colorMode === "dark"
-                      ? "bg-[#30ff33] text-black"
-                      : "bg-[#0f1220] text-white hover:border-[#30ff33]"
+                      ? "bg-[#39ff14] text-black"
+                      : "bg-[#0e1528] text-[#d8e4ff] hover:border-[#39ff14]"
                   }`}
                 >
                   DARK_MODE
@@ -89,8 +89,8 @@ export default function ArenaV2SettingsPage() {
                   onClick={() => setColorMode("high-contrast")}
                   className={`h-11 w-full border-2 font-pixel text-[10px] uppercase tracking-[0.14em] transition ${
                     colorMode === "high-contrast"
-                      ? "border-[#30ff33] bg-[#30ff33] text-black"
-                      : "border-[#203157] bg-transparent text-white/85 hover:border-[#30ff33]"
+                      ? "border-[#39ff14] bg-[#39ff14] text-black"
+                      : "border-[#25365d] bg-transparent text-[#d8e4ff] hover:border-[#39ff14]"
                   }`}
                 >
                   HIGH_CONTRAST_TERMINAL
@@ -115,11 +115,11 @@ export default function ArenaV2SettingsPage() {
           <button
             type="button"
             onClick={handleSave}
-            className="h-14 w-full border-2 border-[#0f3f0c] bg-[#30ff33] font-pixel text-2xl uppercase tracking-[0.2em] text-black transition hover:brightness-95"
+            className="h-14 w-full border-2 border-[#236f2d] bg-[#39ff14] font-pixel text-2xl uppercase tracking-[0.2em] text-black transition hover:brightness-95"
           >
             SAVE_CONFIGURATION_SEQUENCE
           </button>
-          <p className="h-5 text-center font-pixel text-[10px] uppercase tracking-[0.18em] text-[#55ff5e]">
+          <p className="h-5 text-center font-pixel text-[10px] uppercase tracking-[0.18em] text-[#62ff5f]">
             {saveState === "saved" ? "CONFIGURATION_SEQUENCE_SAVED" : ""}
           </p>
         </footer>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -98,6 +98,8 @@ body {
 .pool-success-modal-scrollbar::-webkit-scrollbar-thumb:hover {
   background-color: #00DD00;
   /* Slightly lighter on hover */
+}
+
 /* ── Neubrutalist utilities (Waiting Room) ── */
 .neubrutalist-border {
   border: 3px solid #000000;
@@ -137,10 +139,6 @@ body {
 }
 
 /* ── Arena V2 ── */
-@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
-
-@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
-@import "tailwindcss";
 
 :root {
   --arena-green: #00ff41;

--- a/frontend/src/components/arena-v2/settings/SettingsCard.tsx
+++ b/frontend/src/components/arena-v2/settings/SettingsCard.tsx
@@ -8,10 +8,10 @@ interface SettingsCardProps {
 
 export function SettingsCard({ title, children, className = "" }: SettingsCardProps) {
   return (
-    <section className={`border-2 border-[#0b1734] bg-[#131f3b] p-5 shadow-[0_0_0_1px_rgba(28,255,92,0.05)] ${className}`}>
+    <section className={`border-2 border-[#04112d] bg-[#142443] p-5 shadow-[0_0_0_1px_rgba(5,12,30,0.8)] ${className}`}>
       <header className="mb-5 flex items-center gap-2">
-        <span className="h-2.5 w-2.5 rounded-full bg-[#33ff2f] shadow-[0_0_12px_rgba(51,255,47,0.8)]" />
-        <h2 className="font-pixel text-sm uppercase tracking-[0.14em] text-white/80">{title}</h2>
+        <span className="h-2.5 w-2.5 rounded-full bg-[#39ff14] shadow-[0_0_10px_rgba(57,255,20,0.8)]" />
+        <h2 className="font-pixel text-sm uppercase tracking-[0.14em] text-[#c7d3ec]">{title}</h2>
       </header>
       {children}
     </section>

--- a/frontend/src/components/arena-v2/settings/SettingsSlider.tsx
+++ b/frontend/src/components/arena-v2/settings/SettingsSlider.tsx
@@ -22,23 +22,23 @@ export function SettingsSlider({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <label className="font-pixel text-[10px] uppercase tracking-[0.14em] text-white/70">{label}</label>
-        <span className="font-pixel text-3xl leading-none text-[#30ff33]">{value}%</span>
+        <label className="font-pixel text-[10px] uppercase tracking-[0.14em] text-[#b6c5e2]">{label}</label>
+        <span className="font-pixel text-3xl leading-none text-[#39ff14]">{value}%</span>
       </div>
 
       {segmented ? (
-        <div className="grid grid-cols-10 gap-[2px] border-2 border-black bg-black p-1">
+        <div className="grid grid-cols-10 gap-0.5 border-2 border-black bg-[#05070d] p-1">
           {Array.from({ length: totalSegments }).map((_, index) => (
             <div
               key={`${label}-segment-${index}`}
-              className={`h-6 ${index < filledSegments ? "bg-[#30ff33]" : "bg-[#0f1220]"}`}
+              className={`h-6 ${index < filledSegments ? "bg-[#39ff14]" : "bg-[#0e1425]"}`}
             />
           ))}
         </div>
       ) : (
-        <div className="border-2 border-black bg-black p-1">
-          <div className="h-5 w-full bg-[#0f1220]">
-            <div className="h-full bg-[#30ff33]" style={{ width: `${progress}%` }} />
+        <div className="border-2 border-black bg-[#05070d] p-1">
+          <div className="h-5 w-full bg-[#0e1425]">
+            <div className="h-full bg-[#39ff14]" style={{ width: `${progress}%` }} />
           </div>
         </div>
       )}
@@ -49,7 +49,7 @@ export function SettingsSlider({
         max={max}
         value={value}
         onChange={(event) => onChange(Number(event.target.value))}
-        className="h-2 w-full cursor-pointer appearance-none bg-transparent [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:bg-[#0b1020] [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-black [&::-webkit-slider-thumb]:bg-[#30ff33]"
+        className="h-2 w-full cursor-pointer appearance-none bg-transparent [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:bg-[#0e1527] [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-black [&::-webkit-slider-thumb]:bg-[#39ff14]"
       />
     </div>
   );

--- a/frontend/src/components/arena-v2/settings/SettingsToggle.tsx
+++ b/frontend/src/components/arena-v2/settings/SettingsToggle.tsx
@@ -11,11 +11,11 @@ export function SettingsToggle({ label, enabled, onChange }: SettingsToggleProps
       role="switch"
       aria-checked={enabled}
       onClick={() => onChange(!enabled)}
-      className="flex h-12 w-full items-center justify-between border-2 border-black bg-black px-3 transition hover:border-[#30ff33]"
+      className="flex h-12 w-full items-center justify-between border-2 border-black bg-[#05070d] px-3 transition hover:border-[#39ff14]"
     >
-      <span className="font-pixel text-[10px] uppercase tracking-[0.12em] text-white/85">{label}</span>
+      <span className="font-pixel text-[10px] uppercase tracking-[0.12em] text-[#bfd0ef]">{label}</span>
       <span
-        className={`relative inline-flex h-5 w-10 items-center rounded-full border border-black transition ${enabled ? "bg-[#30ff33]" : "bg-[#1e283f]"}`}
+        className={`relative inline-flex h-5 w-10 items-center rounded-full border border-black transition ${enabled ? "bg-[#39ff14]" : "bg-[#283758]"}`}
       >
         <span
           className={`inline-block h-3.5 w-3.5 rounded-full bg-black shadow transition ${enabled ? "translate-x-5" : "translate-x-1"}`}


### PR DESCRIPTION
## Issue
Implement the Arena V2 **Global Settings** page as a centralized configuration hub for audio, HUD, and UI personalization.
<img width="1895" height="965" alt="Screenshot from 2026-02-24 02-49-21" src="https://github.com/user-attachments/assets/abe0bf32-6130-4770-87a0-7099d15749a6" />

Closes #73 

## What We Achieved
- Added a new page at `src/app/arena-v2/settings/page.tsx` with a terminal-inspired, neon-accented settings dashboard.
- Built reusable settings UI components under `src/components/arena-v2/settings/`:
  - `SettingsCard.tsx`
  - `SettingsSlider.tsx`
  - `SettingsToggle.tsx`
- Implemented the required sections and interactions:
  - **Header** with title/subtitle and `LIVE_CONNECTION_STABLE` status badge with pulsing indicator.
  - **AUDIO_CONFIGURATION** with:
    - `MASTER_VOLUME` slider + live percentage
    - `EFFECTS_VOLUME` slider + live percentage
    - `MUSIC_STREAM` and `VOICE_COMM` toggles
  - **ENERGY_PULSE** enable/disable control
  - **COLOR_MODE** selection buttons:
    - `DARK_MODE`
    - `HIGH_CONTRAST_TERMINAL`
  - **HUD_CONFIGURATION** segmented slider for `ARENA_OVERLAY_OPACITY`
  - Full-width action button: `SAVE_CONFIGURATION_SEQUENCE`
- Added save feedback state (`CONFIGURATION_SEQUENCE_SAVED`) to confirm user action.
- Performed a palette refinement pass to align with the provided screenshot (deep navy surfaces + neon green accents).
- Fixed `globals.css` parsing issues on this branch by resolving an unclosed block and removing invalid duplicate/misplaced imports.

## Verification
- Sliders update value labels and progress visuals in real-time.
- Toggle states switch with visual feedback.
- Color mode buttons correctly reflect active selection.
- Save button shows success feedback.
- Layout remains responsive across desktop/mobile.

## Screenshot
- Added section for reference screenshot from design.
- If needed, replace this placeholder with an uploaded image in GitHub UI after PR creation.

## Notes
- Untracked `frontend/pnpm-lock.yaml` intentionally excluded from this PR.
