### PR TITLE
test: add unit tests for auth and payment service flows

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1589,7 +1589,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/backend/tests/auth.unit.test.ts
+++ b/backend/tests/auth.unit.test.ts
@@ -1,0 +1,136 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert";
+import jwt from "jsonwebtoken";
+import { Keypair } from "@stellar/stellar-sdk";
+import { AuthService } from "../src/services/authService";
+import { NonceModel } from "../src/db/models/nonce.model";
+import { UserModel } from "../src/db/models/user.model";
+
+// Mock environment variables
+process.env.JWT_SECRET = "test-secret-at-least-32-characters-long";
+process.env.NONCE_TTL_SECONDS = "300";
+
+const authService = new AuthService();
+const VALID_ADDRESS = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+
+afterEach(() => {
+  mock.reset();
+});
+
+test("AuthService.requestNonce: successful request", async () => {
+  const walletAddress = VALID_ADDRESS;
+  
+  // Mock NonceModel.create
+  const mockCreate = mock.method(NonceModel, "create", async () => ({}));
+
+  const result = await authService.requestNonce(walletAddress);
+
+  assert.strictEqual(typeof result.nonce, "string");
+  assert.ok(result.nonce.startsWith("Sign this message to authenticate"));
+  assert.ok(result.expiresAt instanceof Date);
+  assert.strictEqual(mockCreate.mock.callCount(), 1);
+  
+  const callParams = mockCreate.mock.calls[0].arguments[0];
+  assert.strictEqual(callParams.walletAddress, walletAddress);
+});
+
+test("AuthService.verifySignatureAndLogin: successful login", async () => {
+  const walletAddress = VALID_ADDRESS;
+  const nonce = "Sign this message to authenticate with InverseArena:\nabcdef";
+  const signature = "c2lnbmF0dXJl"; // dummy base64
+  
+  // Mock NonceModel.findOne
+  mock.method(NonceModel, "findOne", () => ({
+    sort: () => ({
+      _id: "nonce-id",
+      nonce,
+      walletAddress,
+      used: false
+    })
+  }));
+
+  // Mock Keypair.verify
+  const mockVerify = mock.fn(() => true);
+  mock.method(Keypair, "fromPublicKey", () => ({
+    verify: mockVerify
+  }));
+
+  // Mock NonceModel.findByIdAndUpdate
+  mock.method(NonceModel, "findByIdAndUpdate", async () => ({}));
+
+  // Mock UserModel.findOneAndUpdate
+  mock.method(UserModel, "findOneAndUpdate", async () => ({
+    _id: "user-id",
+    walletAddress,
+    joinedAt: new Date(),
+    lastLoginAt: new Date()
+  }));
+
+  const result = await authService.verifySignatureAndLogin(walletAddress, signature);
+
+  assert.ok(result.accessToken);
+  assert.strictEqual(result.user.walletAddress, walletAddress);
+});
+
+test("AuthService.verifySignatureAndLogin: missing nonce throws 401", async () => {
+  const walletAddress = VALID_ADDRESS;
+  
+  mock.method(NonceModel, "findOne", () => ({
+    sort: () => null
+  }));
+
+  await assert.rejects(
+    () => authService.verifySignatureAndLogin(walletAddress, "sig"),
+    (err: any) => err.status === 401 && err.message.includes("No valid nonce found")
+  );
+});
+
+test("AuthService.requestNonce: invalid address throws 400", async () => {
+  await assert.rejects(
+    () => authService.requestNonce("invalid-address"),
+    (err: any) => err.status === 400 && err.message.includes("Invalid Stellar wallet address")
+  );
+});
+
+test("AuthService.refreshTokens: valid token", async () => {
+  const secret = process.env.JWT_SECRET!;
+  const payload = { sub: "user-id", wallet: VALID_ADDRESS, type: "refresh" };
+  const refreshToken = jwt.sign(payload, secret);
+
+  const result = await authService.refreshTokens(refreshToken);
+
+  assert.ok(result.accessToken);
+  assert.ok(result.refreshToken);
+  
+  const decodedAccess = jwt.verify(result.accessToken, secret) as any;
+  assert.strictEqual(decodedAccess.sub, "user-id");
+  assert.strictEqual(decodedAccess.type, "access");
+});
+
+test("AuthService.refreshTokens: invalid token types", async () => {
+  const secret = process.env.JWT_SECRET!;
+  
+  const accessPayload = { sub: "user-id", wallet: VALID_ADDRESS, type: "access" };
+  const accessToken = jwt.sign(accessPayload, secret);
+  
+  await assert.rejects(
+    () => authService.refreshTokens(accessToken),
+    (err: any) => err.status === 401 && err.message.includes("not a refresh token")
+  );
+
+  await assert.rejects(
+    () => authService.refreshTokens("not-a-token"),
+    (err: any) => err.status === 401
+  );
+});
+
+test("AuthService.verifyAccessToken: valid token", () => {
+  const secret = process.env.JWT_SECRET!;
+  const payload = { sub: "user-id", wallet: VALID_ADDRESS, type: "access" };
+  const token = jwt.sign(payload, secret);
+
+  const result = authService.verifyAccessToken(token);
+
+  assert.strictEqual(result.sub, "user-id");
+  assert.strictEqual(result.type, "access");
+});

--- a/backend/tests/payment.unit.test.ts
+++ b/backend/tests/payment.unit.test.ts
@@ -1,0 +1,151 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert";
+import { Server, TransactionBuilder } from "@stellar/stellar-sdk";
+import { PaymentService } from "../src/services/paymentService";
+import { InMemoryTransactionRepository } from "../src/repositories/inMemoryTransactionRepository";
+import type { PaymentConfig } from "../src/config/paymentConfig";
+
+const VALID_ADDRESS = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+const VALID_IDEMPOTENCY = "idempotency-key-123";
+
+const mockConfig: PaymentConfig = {
+  liveExecution: true,
+  signWithHotKey: false,
+  maxGasStroops: 2000000,
+  maxAttempts: 5,
+  confirmPollMs: 100,
+  confirmMaxPolls: 3,
+  payoutMethodName: "distribute_winnings",
+  payoutContractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+  sourceAccount: VALID_ADDRESS,
+  hotSignerSecret: undefined,
+  networkPassphrase: "Test SDF Network ; September 2015",
+  sorobanRpcUrl: "https://soroban-testnet.stellar.org",
+};
+
+const transactions = new InMemoryTransactionRepository();
+
+// Mock Server
+const mockRpcServer = {
+  getAccount: mock.fn(async () => ({
+    sequenceNumber: () => "1",
+    accountId: () => mockConfig.sourceAccount,
+    incrementSequenceNumber: () => {},
+  })),
+  prepareTransaction: mock.fn(async (tx: any) => {
+    return {
+      fee: "100",
+      toXDR: () => tx.toXDR(),
+      sign: () => {},
+    };
+  }),
+  sendTransaction: mock.fn(async () => ({
+    status: "PENDING",
+    hash: "tx-hash",
+  })),
+  getTransaction: mock.fn(async () => ({
+    status: "SUCCESS",
+  })),
+} as unknown as Server;
+
+const paymentService = new PaymentService(transactions, { 
+  config: mockConfig,
+  rpcServer: mockRpcServer
+});
+
+afterEach(() => {
+  mock.reset();
+});
+
+test("PaymentService.createPayoutTransaction: successful creation", async () => {
+  const input = {
+    payoutId: "p-1",
+    destinationAccount: VALID_ADDRESS,
+    amount: "10.5",
+    asset: "XLM",
+    idempotencyKey: VALID_IDEMPOTENCY,
+  };
+
+  const result = await paymentService.createPayoutTransaction(input);
+
+  assert.strictEqual(result.transaction.status, "awaiting_signature");
+  assert.strictEqual(result.transaction.amountStroops, "105000000");
+  assert.ok(result.unsignedXdr);
+  
+  assert.strictEqual((mockRpcServer.getAccount as any).mock.callCount(), 1);
+});
+
+test("PaymentService.createPayoutTransaction: idempotency", async () => {
+  const input = {
+    payoutId: "p-2",
+    destinationAccount: VALID_ADDRESS,
+    amount: "5",
+    asset: "XLM",
+    idempotencyKey: "another-idempotency-key",
+  };
+
+  const result1 = await paymentService.createPayoutTransaction(input);
+  const result2 = await paymentService.createPayoutTransaction(input);
+
+  assert.strictEqual(result1.transaction.id, result2.transaction.id);
+});
+
+test("PaymentService.createPayoutTransaction: invalid input", async () => {
+  const input = {
+    payoutId: "p-3",
+    destinationAccount: "INVALID",
+    amount: "10",
+    asset: "XLM",
+    idempotencyKey: "idem", // Too short
+  };
+
+  await assert.rejects(
+    () => paymentService.createPayoutTransaction(input),
+    (err: any) => err.name === "ZodError"
+  );
+});
+
+test("PaymentService.submitQueuedTransaction: success", async () => {
+  const txId = "tx-123";
+  const signedXdr = "AAAA...base64...";
+  
+  mock.method(TransactionBuilder, "fromXDR", () => ({}));
+  
+  await transactions.insert({
+    id: txId,
+    status: "queued",
+    signedXdr,
+    attempts: 0,
+    idempotencyKey: "some-key-8-chars",
+  } as any);
+
+  const result = await paymentService.submitQueuedTransaction(txId);
+
+  assert.strictEqual(result.submitted, true);
+  assert.strictEqual(result.transaction.status, "submitted");
+  assert.strictEqual((mockRpcServer.sendTransaction as any).mock.callCount(), 1);
+});
+
+test("PaymentService.submitQueuedTransaction: Soroban rejection", async () => {
+  const txId = "tx-456";
+  
+  mock.method(TransactionBuilder, "fromXDR", () => ({}));
+  (mockRpcServer.sendTransaction as any).mock.mockImplementationOnce(async () => ({
+    status: "ERROR",
+    hash: "failed-hash"
+  }));
+
+  await transactions.insert({
+    id: txId,
+    status: "queued",
+    signedXdr: "sig",
+    attempts: 0,
+    idempotencyKey: "another-key-8-chars",
+  } as any);
+
+  const result = await paymentService.submitQueuedTransaction(txId);
+
+  assert.strictEqual(result.submitted, false);
+  assert.strictEqual(result.transaction.status, "failed");
+  assert.match(result.transaction.errorMessage!, /rejected/);
+});


### PR DESCRIPTION
This PR adds unit-level test coverage for the backend core services:
- **AuthService**: Added coverage for nonce generation, signature verification, and token management.
- **PaymentService**: Added coverage for payout transaction creation, idempotency, and submission flows.

Tests are implemented using the built-in `node:test` and `node:mock` frameworks.

Closes #151