### PR TITLE
Fix input validation for pools and payout/transaction endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
+    "test:request-validation": "tsx --test tests/request-validation.unit.test.ts",
     "typecheck": "tsc --noEmit",
     "migrate": "prisma migrate deploy",
     "migrate:dev": "prisma migrate dev"

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction, RequestHandler } from "express";
+import type { ZodType } from "zod";
 
 type AsyncHandler = (req: Request, res: Response, next: NextFunction) => Promise<void>;
 
@@ -9,5 +10,33 @@ type AsyncHandler = (req: Request, res: Response, next: NextFunction) => Promise
 export function asyncHandler(fn: AsyncHandler): RequestHandler {
   return (req, res, next) => {
     fn(req, res, next).catch(next);
+  };
+}
+
+/**
+ * Validates and normalizes req.body using a Zod schema.
+ */
+export function validateBody<T>(schema: ZodType<T>): RequestHandler {
+  return (req, _res, next) => {
+    try {
+      req.body = schema.parse(req.body) as unknown;
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+/**
+ * Validates and normalizes req.params using a Zod schema.
+ */
+export function validateParams<T>(schema: ZodType<T>): RequestHandler {
+  return (req, _res, next) => {
+    try {
+      req.params = schema.parse(req.params) as unknown as Request["params"];
+      next();
+    } catch (error) {
+      next(error);
+    }
   };
 }

--- a/backend/src/routes/payouts.ts
+++ b/backend/src/routes/payouts.ts
@@ -1,14 +1,24 @@
 import { Router } from "express";
-import { asyncHandler } from "../middleware/validate";
+import { asyncHandler, validateBody, validateParams } from "../middleware/validate";
 import type { PayoutsController } from "../controllers/payouts.controller";
+import { SignPayoutBodySchema, TransactionIdParamSchema } from "../validation/requestValidation";
 
 export function createPayoutsRouter(controller: PayoutsController): Router {
   const router = Router();
 
   router.post("/", asyncHandler(controller.createPayout));
-  router.get("/:id", asyncHandler(controller.getPayout));
-  router.post("/:id/sign", asyncHandler(controller.signPayout));
-  router.post("/:id/submit", asyncHandler(controller.submitPayout));
+  router.get("/:id", validateParams(TransactionIdParamSchema), asyncHandler(controller.getPayout));
+  router.post(
+    "/:id/sign",
+    validateParams(TransactionIdParamSchema),
+    validateBody(SignPayoutBodySchema),
+    asyncHandler(controller.signPayout)
+  );
+  router.post(
+    "/:id/submit",
+    validateParams(TransactionIdParamSchema),
+    asyncHandler(controller.submitPayout)
+  );
 
   return router;
 }

--- a/backend/src/routes/transactions.ts
+++ b/backend/src/routes/transactions.ts
@@ -1,11 +1,12 @@
 import { Router } from "express";
-import { asyncHandler } from "../middleware/validate";
+import { asyncHandler, validateParams } from "../middleware/validate";
 import type { TransactionsController } from "../controllers/transactions.controller";
+import { TransactionIdParamSchema } from "../validation/requestValidation";
 
 export function createTransactionsRouter(controller: TransactionsController): Router {
   const router = Router();
 
-  router.get("/:id", asyncHandler(controller.getById));
+  router.get("/:id", validateParams(TransactionIdParamSchema), asyncHandler(controller.getById));
 
   return router;
 }

--- a/backend/src/validation/requestValidation.ts
+++ b/backend/src/validation/requestValidation.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+const MONGO_OBJECT_ID_REGEX = /^[a-f0-9]{24}$/i;
+const LEGACY_TRANSACTION_ID_REGEX = /^tx_\d{10,}_[a-f0-9]{8}$/i;
+
+// Accept currently generated UUIDs, legacy tx IDs, and Mongo ObjectId for compatibility.
+export const TransactionIdSchema = z
+  .string()
+  .trim()
+  .min(1, "id is required")
+  .max(128, "id is too long")
+  .refine(
+    (value) =>
+      z.string().uuid().safeParse(value).success ||
+      MONGO_OBJECT_ID_REGEX.test(value) ||
+      LEGACY_TRANSACTION_ID_REGEX.test(value),
+    "id must be a UUID, Mongo ObjectId, or legacy tx id"
+  );
+
+export const TransactionIdParamSchema = z.object({
+  id: TransactionIdSchema,
+});
+
+export const SignPayoutBodySchema = z.object({
+  signedXdr: z
+    .string()
+    .trim()
+    .min(20, "signedXdr is too short")
+    .max(200_000, "signedXdr is too large"),
+});

--- a/backend/tests/request-validation.unit.test.ts
+++ b/backend/tests/request-validation.unit.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { NextFunction, Request, Response } from "express";
+import { ZodError } from "zod";
+
+import { validateBody, validateParams } from "../src/middleware/validate";
+import {
+  SignPayoutBodySchema,
+  TransactionIdParamSchema,
+} from "../src/validation/requestValidation";
+
+function runMiddleware(
+  middleware: (req: Request, res: Response, next: NextFunction) => void,
+  req: Partial<Request>
+): unknown {
+  let capturedError: unknown;
+
+  middleware(req as Request, {} as Response, (error?: unknown) => {
+    capturedError = error;
+  });
+
+  return capturedError;
+}
+
+test("validateParams(TransactionIdParamSchema) rejects invalid id", () => {
+  const middleware = validateParams(TransactionIdParamSchema);
+  const req = { params: { id: "not-a-valid-id" } };
+
+  const error = runMiddleware(middleware, req);
+
+  assert.ok(error instanceof ZodError);
+});
+
+test("validateParams(TransactionIdParamSchema) accepts UUID id", () => {
+  const middleware = validateParams(TransactionIdParamSchema);
+  const req = { params: { id: "c8ba1cac-5722-4f57-bc60-24f3b51022cd" } };
+
+  const error = runMiddleware(middleware, req);
+
+  assert.equal(error, undefined);
+  assert.equal(req.params?.id, "c8ba1cac-5722-4f57-bc60-24f3b51022cd");
+});
+
+test("validateBody(SignPayoutBodySchema) rejects missing signedXdr", () => {
+  const middleware = validateBody(SignPayoutBodySchema);
+  const req = { body: {} };
+
+  const error = runMiddleware(middleware, req);
+
+  assert.ok(error instanceof ZodError);
+});
+
+test("validateBody(SignPayoutBodySchema) rejects short signedXdr", () => {
+  const middleware = validateBody(SignPayoutBodySchema);
+  const req = { body: { signedXdr: "short" } };
+
+  const error = runMiddleware(middleware, req);
+
+  assert.ok(error instanceof ZodError);
+});
+
+test("validateBody(SignPayoutBodySchema) accepts valid signedXdr", () => {
+  const middleware = validateBody(SignPayoutBodySchema);
+  const req = { body: { signedXdr: "A".repeat(20) } };
+
+  const error = runMiddleware(middleware, req);
+
+  assert.equal(error, undefined);
+  assert.equal(req.body?.signedXdr, "A".repeat(20));
+});

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -187,6 +187,15 @@ Sensitive write endpoints are protected with a Redis-backed limiter (`rate-limit
 - `POST /auth/nonce`
 - `POST /pools`
 
+### POST /pools Validation
+
+Request body accepts optional fields:
+
+- `name`: optional string, trimmed, maximum `256` characters
+- `walletAddress`: optional Stellar public key, format `^G[A-Z2-7]{55}$`
+
+Invalid payloads return HTTP `400` with an `issues` array describing validation failures.
+
 ### On Limit Violation
 
 APIs return:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test:pagination": "node --test --test-isolation=none src/server/pagination/cursorPagination.test.ts",
-    "test:rate-limit": "node --test --test-isolation=none src/server/rate-limit/limiter.test.ts"
+    "test:pagination": "node --test src/server/pagination/cursorPagination.test.ts",
+    "test:rate-limit": "node --test src/server/rate-limit/limiter.test.ts",
+    "test:pools-route": "node --test src/app/pools/validation.test.ts"
   },
   "dependencies": {
     "@creit-tech/stellar-wallets-kit": "npm:@jsr/creit-tech__stellar-wallets-kit@^2.0.0-beta.9",

--- a/frontend/src/app/pools/route.ts
+++ b/frontend/src/app/pools/route.ts
@@ -2,22 +2,32 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { poolsRateLimitConfig } from "@/server/rate-limit/config";
 import { buildRateLimitRejection } from "@/server/rate-limit/limiter";
-
-type CreatePoolBody = {
-  name?: string;
-  walletAddress?: string;
-};
+import { CreatePoolBodySchema } from "./validation";
 
 export async function POST(request: NextRequest) {
-  let body: CreatePoolBody = {};
+  let payload: unknown = {};
 
   try {
-    body = (await request.json()) as CreatePoolBody;
+    payload = await request.json();
   } catch {
     return NextResponse.json({ error: "Request body must be JSON." }, { status: 400 });
   }
 
-  const walletAddress = body.walletAddress?.trim();
+  const parsedBody = CreatePoolBodySchema.safeParse(payload);
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      {
+        error: "Validation error",
+        issues: parsedBody.error.issues.map((issue) => ({
+          path: issue.path.join("."),
+          message: issue.message,
+        })),
+      },
+      { status: 400 }
+    );
+  }
+
+  const walletAddress = parsedBody.data.walletAddress;
   const limited = await buildRateLimitRejection({
     config: poolsRateLimitConfig,
     request,
@@ -30,7 +40,7 @@ export async function POST(request: NextRequest) {
   return NextResponse.json(
     {
       id: `pool-${crypto.randomUUID()}`,
-      name: body.name?.trim() || "Untitled Pool",
+      name: parsedBody.data.name || "Untitled Pool",
       createdAt: new Date().toISOString(),
     },
     { status: 201 }

--- a/frontend/src/app/pools/validation.test.ts
+++ b/frontend/src/app/pools/validation.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CreatePoolBodySchema } from "./validation.ts";
+
+const VALID_WALLET = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+
+test("CreatePoolBodySchema rejects invalid walletAddress", () => {
+  const parsed = CreatePoolBodySchema.safeParse({
+    name: "Valid Name",
+    walletAddress: "invalid-wallet",
+  });
+
+  assert.equal(parsed.success, false);
+  if (!parsed.success) {
+    assert.ok(parsed.error.issues.some((issue) => issue.path.join(".") === "walletAddress"));
+  }
+});
+
+test("CreatePoolBodySchema rejects overly long name", () => {
+  const parsed = CreatePoolBodySchema.safeParse({
+    name: "a".repeat(257),
+    walletAddress: VALID_WALLET,
+  });
+
+  assert.equal(parsed.success, false);
+  if (!parsed.success) {
+    assert.ok(parsed.error.issues.some((issue) => issue.path.join(".") === "name"));
+  }
+});
+
+test("CreatePoolBodySchema trims valid fields", () => {
+  const parsed = CreatePoolBodySchema.safeParse({
+    name: "  Weekly Arena  ",
+    walletAddress: `  ${VALID_WALLET}  `,
+  });
+
+  assert.equal(parsed.success, true);
+  if (parsed.success) {
+    assert.equal(parsed.data.name, "Weekly Arena");
+    assert.equal(parsed.data.walletAddress, VALID_WALLET);
+  }
+});

--- a/frontend/src/app/pools/validation.ts
+++ b/frontend/src/app/pools/validation.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+import { StellarPublicKeySchema } from "../../shared-d/utils/security-validation.ts";
+
+export const CreatePoolBodySchema = z.object({
+  name: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") return value;
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    },
+    z.string().max(256, "Pool name must be 256 characters or less").optional()
+  ),
+  walletAddress: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") return value;
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    },
+    StellarPublicKeySchema.optional()
+  ),
+});
+
+export type CreatePoolBody = z.infer<typeof CreatePoolBodySchema>;


### PR DESCRIPTION
## Summary
- add Zod validation for `POST /pools` payload (`name` max 256, optional Stellar `walletAddress`)
- add backend validation middleware for payout/transaction `:id` params
- validate `signedXdr` for `POST /payouts/:id/sign` with min/max length constraints
- add backend/frontend validation tests and update frontend docs for `/pools`

## Verification
- `backend`: `npm run test:request-validation` ✅
- `frontend`: `npm run test:pools-route` ✅
- `frontend`: `npm run test:rate-limit` ✅

## Notes
- Backend `npm run typecheck` currently reports pre-existing unrelated errors in existing files.
- Workspace still has unrelated unstaged changes in `backend/package-lock.json` and `frontend/src/app/arena-v2/settings/page.tsx`.

Closes #152
Closes #153
