### PR TITLE
feat: support configurable Stellar network in WalletProvider

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,5 @@
 # ── Stellar / Soroban ────────────────────────────────────────────────────────
+NEXT_PUBLIC_STELLAR_NETWORK=testnet          # "testnet" or "mainnet" (defaults to testnet)
 NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE=
 NEXT_PUBLIC_SOROBAN_RPC_URL=
 NEXT_PUBLIC_HORIZON_URL=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -159,6 +159,26 @@ The list APIs use cursor-based pagination with stable ordering by `createdAt DES
 
 ---
 
+## 🌐 Stellar Network Configuration
+
+The Stellar network used by the wallet provider is controlled by an environment variable so you can switch between testnet and mainnet without code changes:
+
+```bash
+# "testnet" (default) or "mainnet"
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+```
+
+| Value | Stellar Network | When to use |
+|-------|----------------|-------------|
+| `testnet` (default) | Test SDF Network | Local development, staging |
+| `mainnet` | Public Global Stellar Network | Production |
+
+If the variable is missing or empty the app defaults to **testnet**. An unrecognised value logs a console warning and also falls back to testnet.
+
+> **Note:** This is a Next.js public env var — changes require a restart of the dev server (or a new build).
+
+---
+
 ## 🔒 Security Configuration
 
 Set allowed web origins with environment variables so CORS can stay strict and configurable:

--- a/frontend/src/features/wallet/WalletProvider.tsx
+++ b/frontend/src/features/wallet/WalletProvider.tsx
@@ -6,16 +6,42 @@ import { Networks } from "@creit-tech/stellar-wallets-kit";
 import { WalletContextType } from './types';
 import { useStellarWallet } from './useStellarWallet';
 
+/**
+ * Resolve the Stellar network from the NEXT_PUBLIC_STELLAR_NETWORK env var.
+ * Accepted values: "testnet" | "mainnet" (case-insensitive).
+ * Defaults to TESTNET when the variable is missing or unrecognised.
+ */
+function getStellarNetwork(): Networks {
+  const env = process.env.NEXT_PUBLIC_STELLAR_NETWORK?.toLowerCase();
+
+  switch (env) {
+    case 'mainnet':
+      return Networks.PUBLIC;
+    case 'testnet':
+    case undefined:
+    case '':
+      return Networks.TESTNET;
+    default:
+      console.warn(
+        `[WalletProvider] Unknown NEXT_PUBLIC_STELLAR_NETWORK="${process.env.NEXT_PUBLIC_STELLAR_NETWORK}", defaulting to TESTNET.`
+      );
+      return Networks.TESTNET;
+  }
+}
+
+const resolvedNetwork = getStellarNetwork();
+
 export const WalletContext = createContext<WalletContextType | null>(null);
 
 export const WalletProvider = ({ children }: { children: ReactNode }) => {
-  const { publicKey, status, error, connectWallet, disconnectWallet } = useStellarWallet(Networks.TESTNET);
+  const { publicKey, status, error, connectWallet, disconnectWallet } = useStellarWallet(resolvedNetwork);
 
   const contextValue: WalletContextType = useMemo(
     () => ({
       status,
       publicKey: publicKey,
       error,
+      network: resolvedNetwork,
       connect: connectWallet,
       disconnect: disconnectWallet,
     }),

--- a/frontend/src/features/wallet/types.ts
+++ b/frontend/src/features/wallet/types.ts
@@ -9,4 +9,5 @@ export interface WalletState {
 export interface WalletContextType extends WalletState {
   connect: () => Promise<void>;
   disconnect: () => void;
+  network: string;
 }


### PR DESCRIPTION
## Summary

Closes #196

- Replaced the hardcoded `Networks.TESTNET` in `WalletProvider.tsx` with an env-driven `getStellarNetwork()` helper that reads `NEXT_PUBLIC_STELLAR_NETWORK` (`"testnet"` | `"mainnet"`, case-insensitive).
- Defaults to **TESTNET** when the env var is missing, empty, or unrecognised (with a console warning for invalid values).
- Exposed the resolved `network` in the wallet context for display/debugging.
- Added `network: string` to `WalletContextType` in `types.ts`.
- Documented the new env var in `.env.example` and `README.md`.

## Affected Files

| File | Change |
|------|--------|
| `frontend/src/features/wallet/WalletProvider.tsx` | Core logic — `getStellarNetwork()` resolves network from env var |
| `frontend/src/features/wallet/types.ts` | Added `network` field to `WalletContextType` |
| `frontend/.env.example` | Added `NEXT_PUBLIC_STELLAR_NETWORK=testnet` |
| `frontend/README.md` | Added Stellar Network Configuration documentation section |

## Acceptance Criteria

- [x] WalletProvider chooses network based on configuration/env rather than a hardcoded constant
- [x] It is possible to run the app against both testnet and mainnet by changing env only
- [x] Behavior is documented in README and env docs

## Test Plan

- Set `NEXT_PUBLIC_STELLAR_NETWORK=testnet` → verify wallet connects to Test SDF Network
- Set `NEXT_PUBLIC_STELLAR_NETWORK=mainnet` → verify wallet connects to Public Global Stellar Network
- Remove or leave env var empty → verify defaults to testnet
- Set an invalid value (e.g. `futurenet`) → verify console warning and testnet fallback