### PR TITLE
fix: withdrawal success page uses hardcoded mock data

### DIFF
--- a/frontend/src/app/arena-v2/withdrawal-success/page.tsx
+++ b/frontend/src/app/arena-v2/withdrawal-success/page.tsx
@@ -1,23 +1,47 @@
 "use client";
 
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense } from "react";
 import { motion } from "framer-motion";
 import { SuccessHeader } from "@/components/arena-v2/withdrawal/SuccessHeader";
 import { UnlockedPadlock } from "@/components/arena-v2/withdrawal/UnlockedPadlock";
 import { WithdrawalDetails } from "@/components/arena-v2/withdrawal/WithdrawalDetails";
 
-// These props would normally come from router state, context, or query params.
-// Placeholder values are used here for demonstration.
-const MOCK_DATA = {
-  totalWithdrawn: "1,240.50",
-  currency: "USDC",
-  destinationAddress: "GBRXXXXXXK4R2",
-  networkFee: "0.00001",
-  feeToken: "XLM",
-  stellarExpertUrl:
-    "https://stellar.expert/explorer/public/tx/placeholder-tx-hash",
-};
+const STELLAR_EXPERT_BASE = "https://stellar.expert/explorer/public/tx";
 
-export default function WithdrawalSuccessPage() {
+function WithdrawalSuccessContent() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  const totalWithdrawn = params.get("amount");
+  const currency = params.get("currency") ?? "USDC";
+  const destinationAddress = params.get("destination");
+  const networkFee = params.get("fee") ?? "0.00001";
+  const feeToken = params.get("feeToken") ?? "XLM";
+  const txHash = params.get("txHash");
+
+  const stellarExpertUrl = txHash
+    ? `${STELLAR_EXPERT_BASE}/${txHash}`
+    : null;
+
+  const isMissingData = !totalWithdrawn || !destinationAddress || !txHash;
+
+  if (isMissingData) {
+    return (
+      <main className="min-h-screen flex flex-col items-center justify-center px-4 py-12 gap-8">
+        <p className="font-mono text-white/50 text-sm tracking-widest uppercase">
+          No withdrawal data found.
+        </p>
+        <button
+          onClick={() => router.replace("/")}
+          className="bg-neon-green text-black font-black text-sm tracking-[0.2em] uppercase px-10 py-4 hover:bg-neon-green/90 transition-colors shadow-[6px_6px_0px_0px_#000]"
+        >
+          RETURN TO COMMAND CENTER
+        </button>
+      </main>
+    );
+  }
+
   return (
     <main className="min-h-screen flex flex-col items-center justify-center px-4 py-12 gap-10">
       {/* Header */}
@@ -28,11 +52,11 @@ export default function WithdrawalSuccessPage() {
 
       {/* Transaction detail cards */}
       <WithdrawalDetails
-        totalWithdrawn={MOCK_DATA.totalWithdrawn}
-        currency={MOCK_DATA.currency}
-        destinationAddress={MOCK_DATA.destinationAddress}
-        networkFee={MOCK_DATA.networkFee}
-        feeToken={MOCK_DATA.feeToken}
+        totalWithdrawn={totalWithdrawn}
+        currency={currency}
+        destinationAddress={destinationAddress}
+        networkFee={networkFee}
+        feeToken={feeToken}
       />
 
       {/* CTA button */}
@@ -49,15 +73,25 @@ export default function WithdrawalSuccessPage() {
           RETURN_TO_COMMAND_CENTER
         </button>
 
-        <a
-          href={MOCK_DATA.stellarExpertUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-mono text-[10px] tracking-widest text-white/40 uppercase hover:text-white/70 transition-colors"
-        >
-          VIEW TRANSACTION ON STELLAREXPERT
-        </a>
+        {stellarExpertUrl && (
+          <a
+            href={stellarExpertUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-[10px] tracking-widest text-white/40 uppercase hover:text-white/70 transition-colors"
+          >
+            VIEW TRANSACTION ON STELLAREXPERT
+          </a>
+        )}
       </motion.div>
     </main>
+  );
+}
+
+export default function WithdrawalSuccessPage() {
+  return (
+    <Suspense>
+      <WithdrawalSuccessContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary

Closes #181

Fixes the withdrawal success page which was displaying hardcoded placeholder data instead of real transaction details.

## Problem

`frontend/src/app/arena-v2/withdrawal-success/page.tsx` defined a `MOCK_DATA` constant with fake values for `totalWithdrawn`, `destinationAddress`, `networkFee`, and a placeholder Stellar Expert URL. Users who completed a real withdrawal were shown incorrect information.

## Changes

### `frontend/src/app/arena-v2/withdrawal-success/page.tsx`

- Removed `MOCK_DATA` constant entirely.
- Added `useSearchParams()` to read the following query parameters:
  - `amount` — withdrawn amount
  - `currency` — token currency (default: `USDC`)
  - `destination` — destination Stellar address
  - `fee` — network fee (default: `0.00001`)
  - `feeToken` — fee token (default: `XLM`)
  - `txHash` — real transaction hash used to build the Stellar Expert URL dynamically
- Added a graceful empty state when required params are missing (direct URL access), showing a redirect button instead of mock data.
- Wrapped in `<Suspense>` as required by Next.js App Router for `useSearchParams()`.

## Acceptance Criteria

- [x] Page shows actual withdrawn amount and currency.
- [x] Destination address reflects the real transaction destination.
- [x] Stellar Expert link uses the actual `txHash`.
- [x] Direct access without tx context shows an appropriate empty state — not mock data.