### PR TITLE
refactor: standardize contract error handling across all transaction …

### DIFF
--- a/frontend/src/components/modals/StakeModal.tsx
+++ b/frontend/src/components/modals/StakeModal.tsx
@@ -6,6 +6,7 @@ import { useWallet } from "@/shared-d/hooks/useWallet";
 import {
   buildStakeProtocolTransaction,
   submitSignedTransaction,
+  parseStellarError,
 } from "@/shared-d/utils/stellar-transactions";
 
 type TransactionState = "idle" | "signing" | "submitting" | "success" | "error";
@@ -85,8 +86,7 @@ export default function StakeModal({
         onClose();
       }, 1500);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Transaction failed. Please try again.";
-      setErrorMessage(message);
+      setErrorMessage(parseStellarError(err));
       setTxState("error");
     }
   };

--- a/frontend/src/components/modals/TransactionModal.tsx
+++ b/frontend/src/components/modals/TransactionModal.tsx
@@ -57,12 +57,9 @@ export function TransactionModal({
             // However, if onConfirm involves the whole flow including submission, it might take time.
             // Let's assume onConfirm resolves when the txn is successfully submitted on-chain or at least sent.
             setState("SUCCESS");
-        } catch (err: any) {
-            console.error("Transaction failed:", err);
+        } catch (err: unknown) {
             setState("ERROR");
-            // Use parseStellarError to get a user-friendly message
-            const parsedError = parseStellarError(err);
-            setErrorMessage(parsedError);
+            setErrorMessage(parseStellarError(err));
         }
     }, [onConfirm]);
 

--- a/frontend/src/shared-d/utils/__tests__/contract-error.test.ts
+++ b/frontend/src/shared-d/utils/__tests__/contract-error.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  ContractError,
+  ContractErrorCode,
+  parseContractError,
+} from '../contract-error';
+
+// ── ContractError class ──────────────────────────────────────────────
+
+describe('ContractError', () => {
+  it('should be an instance of Error', () => {
+    const err = new ContractError({
+      code: ContractErrorCode.UNKNOWN,
+      fn: 'testFn',
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ContractError);
+  });
+
+  it('should use default message when none provided', () => {
+    const err = new ContractError({
+      code: ContractErrorCode.ACCOUNT_NOT_FOUND,
+      fn: 'getAccount',
+    });
+    expect(err.message).toBe('Account not found on network. Please fund it first.');
+    expect(err.code).toBe(ContractErrorCode.ACCOUNT_NOT_FOUND);
+    expect(err.fn).toBe('getAccount');
+  });
+
+  it('should use custom message when provided', () => {
+    const err = new ContractError({
+      code: ContractErrorCode.VALIDATION_FAILED,
+      message: 'Custom validation message',
+      fn: 'buildCreatePoolTransaction',
+    });
+    expect(err.message).toBe('Custom validation message');
+  });
+
+  it('should preserve cause', () => {
+    const original = new Error('original');
+    const err = new ContractError({
+      code: ContractErrorCode.UNKNOWN,
+      fn: 'test',
+      cause: original,
+    });
+    expect(err.cause).toBe(original);
+  });
+
+  it('should have name "ContractError"', () => {
+    const err = new ContractError({
+      code: ContractErrorCode.UNKNOWN,
+      fn: 'test',
+    });
+    expect(err.name).toBe('ContractError');
+  });
+});
+
+// ── parseContractError ───────────────────────────────────────────────
+
+describe('parseContractError', () => {
+  it('should return existing ContractError as-is', () => {
+    const original = new ContractError({
+      code: ContractErrorCode.BAD_AUTH,
+      fn: 'original',
+    });
+    const result = parseContractError(original, 'wrapper');
+    expect(result).toBe(original);
+    expect(result.fn).toBe('original');
+  });
+
+  // ── Zod errors ───────────────────────────────────────────────────
+
+  it('should map ZodError to VALIDATION_FAILED', () => {
+    const zodLike = {
+      name: 'ZodError',
+      message: 'Validation error',
+      issues: [
+        { message: 'Invalid public key' },
+        { message: 'Amount must be positive' },
+      ],
+    };
+    const result = parseContractError(zodLike, 'buildJoinArenaTransaction');
+    expect(result.code).toBe(ContractErrorCode.VALIDATION_FAILED);
+    expect(result.fn).toBe('buildJoinArenaTransaction');
+    expect(result.message).toContain('Invalid public key');
+    expect(result.message).toContain('Amount must be positive');
+  });
+
+  // ── User rejection ───────────────────────────────────────────────
+
+  it('should detect user rejection from wallet', () => {
+    const err = new Error('User rejected the transaction');
+    const result = parseContractError(err, 'submit');
+    expect(result.code).toBe(ContractErrorCode.USER_REJECTED);
+  });
+
+  it('should detect user cancel', () => {
+    const result = parseContractError('user cancel', 'submit');
+    expect(result.code).toBe(ContractErrorCode.USER_REJECTED);
+  });
+
+  // ── Insufficient funds ───────────────────────────────────────────
+
+  it('should detect op_underfunded', () => {
+    const err = new Error('op_underfunded');
+    const result = parseContractError(err, 'submit');
+    expect(result.code).toBe(ContractErrorCode.INSUFFICIENT_FUNDS);
+  });
+
+  it('should detect insufficient balance string', () => {
+    const result = parseContractError('insufficient balance', 'submit');
+    expect(result.code).toBe(ContractErrorCode.INSUFFICIENT_FUNDS);
+  });
+
+  // ── Auth errors ──────────────────────────────────────────────────
+
+  it('should detect tx_bad_auth', () => {
+    const err = new Error('tx_bad_auth');
+    const result = parseContractError(err, 'submit');
+    expect(result.code).toBe(ContractErrorCode.BAD_AUTH);
+  });
+
+  // ── Timeout ──────────────────────────────────────────────────────
+
+  it('should detect tx_too_late', () => {
+    const err = new Error('tx_too_late');
+    const result = parseContractError(err, 'submit');
+    expect(result.code).toBe(ContractErrorCode.TRANSACTION_TIMEOUT);
+  });
+
+  // ── Account not found ────────────────────────────────────────────
+
+  it('should detect account not found', () => {
+    const err = new Error('Account not found on network');
+    const result = parseContractError(err, 'getAccount');
+    expect(result.code).toBe(ContractErrorCode.ACCOUNT_NOT_FOUND);
+  });
+
+  it('should detect 404 status', () => {
+    const err = new Error('Request failed with status 404');
+    const result = parseContractError(err, 'getAccount');
+    expect(result.code).toBe(ContractErrorCode.ACCOUNT_NOT_FOUND);
+  });
+
+  // ── Simulation errors ────────────────────────────────────────────
+
+  it('should detect Soroban simulation error object', () => {
+    const simError = {
+      error: 'HostError: Error(Contract, #4)',
+      message: 'simulation failed',
+    };
+    const result = parseContractError(simError, 'fetchArenaState');
+    expect(result.code).toBe(ContractErrorCode.SIMULATION_FAILED);
+    expect(result.message).toContain('Contract error code 4');
+  });
+
+  it('should detect HostError in message', () => {
+    const err = new Error('HostError: Error(WasmVm, InvalidAction)');
+    const result = parseContractError(err, 'buildStake');
+    expect(result.code).toBe(ContractErrorCode.SIMULATION_FAILED);
+    expect(result.message).toContain('WASM VM error');
+  });
+
+  it('should detect simulation keyword in message', () => {
+    const err = new Error('Transaction simulation failed');
+    const result = parseContractError(err, 'buildStake');
+    expect(result.code).toBe(ContractErrorCode.SIMULATION_FAILED);
+  });
+
+  it('should detect Error(Contract, #N) pattern', () => {
+    const err = { message: 'Error(Contract, #12)' };
+    const result = parseContractError(err, 'test');
+    expect(result.code).toBe(ContractErrorCode.SIMULATION_FAILED);
+    expect(result.message).toContain('Contract error code 12');
+  });
+
+  it('should prefer error field from simulation response objects', () => {
+    const err = { error: 'HostError: Error(Contract, #7)', message: 'simulation failed' };
+    const result = parseContractError(err, 'test');
+    expect(result.code).toBe(ContractErrorCode.SIMULATION_FAILED);
+    expect(result.message).toContain('Contract error code 7');
+  });
+
+  // ── Transaction failures ─────────────────────────────────────────
+
+  it('should detect transaction failed', () => {
+    const err = new Error('Transaction failed: FAILED');
+    const result = parseContractError(err, 'submit');
+    expect(result.code).toBe(ContractErrorCode.TRANSACTION_FAILED);
+  });
+
+  it('should detect validation failed', () => {
+    const err = new Error('Transaction validation failed: FAILED');
+    const result = parseContractError(err, 'submit');
+    expect(result.code).toBe(ContractErrorCode.TRANSACTION_FAILED);
+  });
+
+  // ── Fallback ─────────────────────────────────────────────────────
+
+  it('should fall back to UNKNOWN for unrecognized errors', () => {
+    const err = new Error('something completely unexpected');
+    const result = parseContractError(err, 'test');
+    expect(result.code).toBe(ContractErrorCode.UNKNOWN);
+    expect(result.message).toBe('something completely unexpected');
+    expect(result.fn).toBe('test');
+    expect(result.cause).toBe(err);
+  });
+
+  it('should handle null/undefined gracefully', () => {
+    const result = parseContractError(null, 'test');
+    expect(result.code).toBe(ContractErrorCode.UNKNOWN);
+    expect(result).toBeInstanceOf(ContractError);
+  });
+
+  it('should handle plain string errors', () => {
+    const result = parseContractError('op_underfunded in response', 'test');
+    expect(result.code).toBe(ContractErrorCode.INSUFFICIENT_FUNDS);
+  });
+});

--- a/frontend/src/shared-d/utils/__tests__/fetchArenaState.test.ts
+++ b/frontend/src/shared-d/utils/__tests__/fetchArenaState.test.ts
@@ -1,51 +1,63 @@
 /**
  * Tests for fetchArenaState function
- * 
+ *
  * Note: These are integration tests that require a deployed contract.
  * For local development, you can mock the Server.simulateTransaction response.
  */
 
 import { describe, it, expect } from '@jest/globals';
 import { fetchArenaState } from '../stellar-transactions';
+import { ContractError, ContractErrorCode } from '../contract-error';
 
 describe('fetchArenaState', () => {
-  it('should validate arena ID format', async () => {
-    await expect(
-      fetchArenaState('invalid-id')
-    ).rejects.toThrow();
-  });
-
-  it('should validate user address format when provided', async () => {
-    const validArenaId = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
-    
-    await expect(
-      fetchArenaState(validArenaId, 'invalid-address')
-    ).rejects.toThrow();
-  });
-
-  it('should accept valid stellar contract ID', async () => {
-    const validArenaId = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
-    
-    // This will fail with contract error if contract doesn't exist, but validates the ID format
+  it('should throw ContractError with VALIDATION_FAILED for invalid arena ID', async () => {
     try {
-      await fetchArenaState(validArenaId);
+      await fetchArenaState('invalid-id');
+      fail('Expected ContractError to be thrown');
     } catch (error) {
-      // Expected to fail if contract doesn't exist, but should not be a validation error
-      expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toContain('Arena state fetch failed');
+      expect(error).toBeInstanceOf(ContractError);
+      const ce = error as ContractError;
+      expect(ce.code).toBe(ContractErrorCode.VALIDATION_FAILED);
+      expect(ce.fn).toBe('fetchArenaState');
     }
   });
 
-  it('should return correct response shape', async () => {
-    // This test requires a real deployed contract
-    // For now, we just verify the function signature and error handling
+  it('should throw ContractError with VALIDATION_FAILED for invalid user address', async () => {
+    const validArenaId = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+
+    try {
+      await fetchArenaState(validArenaId, 'invalid-address');
+      fail('Expected ContractError to be thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ContractError);
+      const ce = error as ContractError;
+      expect(ce.code).toBe(ContractErrorCode.VALIDATION_FAILED);
+      expect(ce.fn).toBe('fetchArenaState');
+    }
+  });
+
+  it('should throw ContractError for valid ID when contract does not exist', async () => {
+    const validArenaId = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+
+    try {
+      await fetchArenaState(validArenaId);
+      // If it doesn't throw, the contract exists — that's fine for integration
+    } catch (error) {
+      expect(error).toBeInstanceOf(ContractError);
+      const ce = error as ContractError;
+      expect(ce.fn).toBe('fetchArenaState');
+      // Should be a simulation or unknown error, not a validation error
+      expect(ce.code).not.toBe(ContractErrorCode.VALIDATION_FAILED);
+    }
+  });
+
+  it('should return correct response shape on success', async () => {
     const validArenaId = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
     const validUserAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
-    
+
     try {
       const result = await fetchArenaState(validArenaId, validUserAddress);
-      
-      // If it succeeds, verify the shape
+
       expect(result).toHaveProperty('arenaId');
       expect(result).toHaveProperty('survivorsCount');
       expect(result).toHaveProperty('maxCapacity');
@@ -54,14 +66,14 @@ describe('fetchArenaState', () => {
       expect(result).toHaveProperty('currentStake');
       expect(result).toHaveProperty('potentialPayout');
       expect(result).toHaveProperty('roundNumber');
-      
+
       expect(typeof result.survivorsCount).toBe('number');
       expect(typeof result.maxCapacity).toBe('number');
       expect(typeof result.isUserIn).toBe('boolean');
       expect(typeof result.hasWon).toBe('boolean');
     } catch (error) {
-      // Expected if contract doesn't exist or method names don't match
-      expect(error).toBeInstanceOf(Error);
+      // Expected if contract doesn't exist
+      expect(error).toBeInstanceOf(ContractError);
     }
   });
 });

--- a/frontend/src/shared-d/utils/contract-error.ts
+++ b/frontend/src/shared-d/utils/contract-error.ts
@@ -1,0 +1,291 @@
+/**
+ * Standardized error handling for all Soroban contract interactions.
+ *
+ * Every transaction builder and contract query throws a `ContractError`
+ * on failure so that UI components can catch and display errors uniformly.
+ */
+
+// ── Known error codes ────────────────────────────────────────────────
+export enum ContractErrorCode {
+  /** Input failed Zod / schema validation */
+  VALIDATION_FAILED = "VALIDATION_FAILED",
+  /** Horizon account lookup failed (not funded, network issue) */
+  ACCOUNT_NOT_FOUND = "ACCOUNT_NOT_FOUND",
+  /** Soroban simulation returned an error */
+  SIMULATION_FAILED = "SIMULATION_FAILED",
+  /** Transaction was rejected by the network */
+  TRANSACTION_FAILED = "TRANSACTION_FAILED",
+  /** Transaction timed out waiting for confirmation */
+  TRANSACTION_TIMEOUT = "TRANSACTION_TIMEOUT",
+  /** User cancelled signing in their wallet */
+  USER_REJECTED = "USER_REJECTED",
+  /** Insufficient balance for the operation */
+  INSUFFICIENT_FUNDS = "INSUFFICIENT_FUNDS",
+  /** Authorization / signature issue */
+  BAD_AUTH = "BAD_AUTH",
+  /** Required environment variable or config missing */
+  CONFIG_MISSING = "CONFIG_MISSING",
+  /** Catch-all for unexpected failures */
+  UNKNOWN = "UNKNOWN",
+}
+
+// ── User-friendly default messages per code ──────────────────────────
+const DEFAULT_MESSAGES: Record<ContractErrorCode, string> = {
+  [ContractErrorCode.VALIDATION_FAILED]:
+    "Invalid input. Please check the values and try again.",
+  [ContractErrorCode.ACCOUNT_NOT_FOUND]:
+    "Account not found on network. Please fund it first.",
+  [ContractErrorCode.SIMULATION_FAILED]:
+    "Contract simulation failed. The transaction may not be valid.",
+  [ContractErrorCode.TRANSACTION_FAILED]:
+    "Transaction was rejected by the network.",
+  [ContractErrorCode.TRANSACTION_TIMEOUT]:
+    "Transaction timed out waiting for confirmation. Please try again.",
+  [ContractErrorCode.USER_REJECTED]:
+    "Transaction was cancelled by the user.",
+  [ContractErrorCode.INSUFFICIENT_FUNDS]:
+    "Insufficient balance to cover the transaction and fees.",
+  [ContractErrorCode.BAD_AUTH]:
+    "Invalid or unauthorized transaction. Please check your wallet permissions.",
+  [ContractErrorCode.CONFIG_MISSING]:
+    "Required configuration is missing. Please check your environment setup.",
+  [ContractErrorCode.UNKNOWN]:
+    "An unknown error occurred during the transaction.",
+};
+
+// ── ContractError class ──────────────────────────────────────────────
+export class ContractError extends Error {
+  /** Machine-readable error code */
+  readonly code: ContractErrorCode;
+  /** The builder / function that threw */
+  readonly fn: string;
+  /** Original error (if wrapping) */
+  readonly cause?: unknown;
+
+  constructor(opts: {
+    code: ContractErrorCode;
+    message?: string;
+    fn: string;
+    cause?: unknown;
+  }) {
+    const message = opts.message ?? DEFAULT_MESSAGES[opts.code];
+    super(message);
+    this.name = "ContractError";
+    this.code = opts.code;
+    this.fn = opts.fn;
+    this.cause = opts.cause;
+
+    // Maintains proper stack trace in V8
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ContractError);
+    }
+  }
+}
+
+// ── parseContractError ───────────────────────────────────────────────
+
+/**
+ * Maps a raw error (from Soroban simulation, Horizon, wallet, etc.)
+ * into a typed `ContractError`.
+ *
+ * Call this inside the catch block of any transaction builder so that
+ * callers always receive a `ContractError`.
+ */
+export function parseContractError(
+  error: unknown,
+  fn: string,
+): ContractError {
+  // Already a ContractError — just return it
+  if (error instanceof ContractError) {
+    return error;
+  }
+
+  const msg = extractMessage(error);
+
+  // ── Soroban simulation errors ────────────────────────────────────
+  if (isSimulationError(error) || msg.includes("simulation")) {
+    const detail = extractSimulationDetail(error);
+    return new ContractError({
+      code: ContractErrorCode.SIMULATION_FAILED,
+      message: detail
+        ? `Contract simulation failed: ${detail}`
+        : undefined,
+      fn,
+      cause: error,
+    });
+  }
+
+  // ── Pattern matching on known strings ────────────────────────────
+  if (msg.includes("User rejected") || msg.includes("user cancel")) {
+    return new ContractError({
+      code: ContractErrorCode.USER_REJECTED,
+      fn,
+      cause: error,
+    });
+  }
+
+  if (msg.includes("op_underfunded") || msg.includes("insufficient")) {
+    return new ContractError({
+      code: ContractErrorCode.INSUFFICIENT_FUNDS,
+      fn,
+      cause: error,
+    });
+  }
+
+  if (msg.includes("tx_bad_auth")) {
+    return new ContractError({
+      code: ContractErrorCode.BAD_AUTH,
+      fn,
+      cause: error,
+    });
+  }
+
+  if (msg.includes("tx_too_late")) {
+    return new ContractError({
+      code: ContractErrorCode.TRANSACTION_TIMEOUT,
+      fn,
+      cause: error,
+    });
+  }
+
+  if (msg.includes("Account not found") || msg.includes("status 404")) {
+    return new ContractError({
+      code: ContractErrorCode.ACCOUNT_NOT_FOUND,
+      fn,
+      cause: error,
+    });
+  }
+
+  if (msg.includes("Transaction failed") || msg.includes("validation failed")) {
+    return new ContractError({
+      code: ContractErrorCode.TRANSACTION_FAILED,
+      message: msg,
+      fn,
+      cause: error,
+    });
+  }
+
+  // ── Zod validation errors ────────────────────────────────────────
+  if (isZodError(error)) {
+    const issues = (error as { issues: Array<{ message: string }> }).issues;
+    const detail = issues.map((i) => i.message).join("; ");
+    return new ContractError({
+      code: ContractErrorCode.VALIDATION_FAILED,
+      message: `Validation failed: ${detail}`,
+      fn,
+      cause: error,
+    });
+  }
+
+  // ── Fallback ─────────────────────────────────────────────────────
+  return new ContractError({
+    code: ContractErrorCode.UNKNOWN,
+    message: msg || undefined,
+    fn,
+    cause: error,
+  });
+}
+
+// ── Helpers (private) ────────────────────────────────────────────────
+
+function extractMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error
+  ) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error ?? "");
+}
+
+function isZodError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name: unknown }).name === "ZodError" &&
+    "issues" in error
+  );
+}
+
+/**
+ * Detect Soroban simulation error response objects.
+ * The Stellar SDK returns objects with an `error` field on failed simulations.
+ */
+function isSimulationError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const obj = error as Record<string, unknown>;
+  // Soroban RPC simulation failure shape
+  if ("error" in obj && typeof obj.error === "string") return true;
+  // Wrapped simulation errors from the SDK
+  if (
+    "message" in obj &&
+    typeof obj.message === "string" &&
+    (obj.message.includes("HostError") ||
+      obj.message.includes("Error(Contract") ||
+      obj.message.includes("Error(WasmVm"))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Extract a human-readable detail string from Soroban simulation errors.
+ * Handles the common patterns returned by the Soroban RPC.
+ */
+function extractSimulationDetail(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) return null;
+  const obj = error as Record<string, unknown>;
+
+  // Direct error field from simulation response
+  if ("error" in obj && typeof obj.error === "string") {
+    return parseHostError(obj.error);
+  }
+
+  // Nested in message
+  const msg = extractMessage(error);
+  if (msg.includes("Error(Contract")) {
+    const match = msg.match(/Error\(Contract,\s*#(\d+)\)/);
+    if (match) return `Contract error code ${match[1]}`;
+  }
+  if (msg.includes("HostError")) {
+    return parseHostError(msg);
+  }
+
+  return null;
+}
+
+/**
+ * Parse Soroban HostError strings into something readable.
+ * Example input: "HostError: Error(Contract, #4)"
+ */
+function parseHostError(raw: string): string {
+  // Contract-level error with numeric code
+  const contractMatch = raw.match(/Error\(Contract,\s*#(\d+)\)/);
+  if (contractMatch) {
+    return `Contract error code ${contractMatch[1]}`;
+  }
+
+  // WasmVm errors
+  const wasmMatch = raw.match(/Error\(WasmVm,\s*(\w+)\)/);
+  if (wasmMatch) {
+    return `WASM VM error: ${wasmMatch[1]}`;
+  }
+
+  // Budget exceeded
+  if (raw.includes("Budget") || raw.includes("budget")) {
+    return "Transaction exceeded resource budget limits";
+  }
+
+  // Storage errors
+  if (raw.includes("Storage") || raw.includes("storage")) {
+    return "Contract storage access error";
+  }
+
+  // Return trimmed raw if no pattern matched
+  return raw.length > 200 ? raw.slice(0, 200) + "..." : raw;
+}

--- a/frontend/src/shared-d/utils/stellar-transactions.ts
+++ b/frontend/src/shared-d/utils/stellar-transactions.ts
@@ -26,6 +26,14 @@ import {
   STELLAR_NETWORK,
   TRANSACTION_CONFIG,
 } from "@/components/hook-d/arenaConstants";
+import {
+  ContractError,
+  ContractErrorCode,
+  parseContractError,
+} from "@/shared-d/utils/contract-error";
+
+// Re-export so consumers can import from one place
+export { ContractError, ContractErrorCode, parseContractError } from "@/shared-d/utils/contract-error";
 
 // Constants (Replace with real Contract IDs in production/env)
 export const FACTORY_CONTRACT_ID = STELLAR_NETWORK.CONTRACTS.FACTORY;
@@ -51,20 +59,27 @@ const CreatePoolParamsSchema = z.object({
 /**
  * Helper to get the latest sequence number for an account.
  */
-async function getAccount(publicKey: string): Promise<Account> {
-  const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
+async function getAccount(publicKey: string, fn: string): Promise<Account> {
+  try {
+    const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
 
-  const res = await fetch(
-    `${HORIZON_URL}/accounts/${validatedPublicKey}`,
-  );
-  if (!res.ok) {
-    throw new Error("Account not found on network. Please fund it.");
+    const res = await fetch(
+      `${HORIZON_URL}/accounts/${validatedPublicKey}`,
+    );
+    if (!res.ok) {
+      throw new ContractError({
+        code: ContractErrorCode.ACCOUNT_NOT_FOUND,
+        fn,
+      });
+    }
+
+    const rawData: unknown = await res.json();
+    const data = HorizonAccountResponseSchema.parse(rawData);
+
+    return new Account(validatedPublicKey, data.sequence);
+  } catch (error) {
+    throw parseContractError(error, fn);
   }
-
-  const rawData: unknown = await res.json();
-  const data = HorizonAccountResponseSchema.parse(rawData);
-
-  return new Account(validatedPublicKey, data.sequence);
 }
 
 /**
@@ -79,42 +94,47 @@ export async function buildCreatePoolTransaction(
     arenaCapacity: number;
   },
 ) {
-  const validatedParams = CreatePoolParamsSchema.parse(params);
-  const account = await getAccount(publicKey);
-  const factory = new Contract(FACTORY_CONTRACT_ID);
+  const FN = "buildCreatePoolTransaction";
+  try {
+    const validatedParams = CreatePoolParamsSchema.parse(params);
+    const account = await getAccount(publicKey, FN);
+    const factory = new Contract(FACTORY_CONTRACT_ID);
 
-  // Convert stake amount to stroops/units (7 decimals).
-  const amountBigInt = BigInt(
-    Math.floor(validatedParams.stakeAmount * 10_000_000),
-  );
+    // Convert stake amount to stroops/units (7 decimals).
+    const amountBigInt = BigInt(
+      Math.floor(validatedParams.stakeAmount * 10_000_000),
+    );
 
-  const args = [
-    nativeToScVal(amountBigInt, { type: "i128" }),
-    new Contract(
-      validatedParams.currency === "USDC" ? USDC_CONTRACT_ID : XLM_CONTRACT_ID,
-    )
-      .address()
-      .toScVal(),
-    nativeToScVal(
-      validatedParams.roundSpeed === "30S"
-        ? 30
-        : validatedParams.roundSpeed === "1M"
-          ? 60
-          : 300,
-      { type: "u32" },
-    ),
-    nativeToScVal(validatedParams.arenaCapacity, { type: "u32" }),
-  ];
+    const args = [
+      nativeToScVal(amountBigInt, { type: "i128" }),
+      new Contract(
+        validatedParams.currency === "USDC" ? USDC_CONTRACT_ID : XLM_CONTRACT_ID,
+      )
+        .address()
+        .toScVal(),
+      nativeToScVal(
+        validatedParams.roundSpeed === "30S"
+          ? 30
+          : validatedParams.roundSpeed === "1M"
+            ? 60
+            : 300,
+        { type: "u32" },
+      ),
+      nativeToScVal(validatedParams.arenaCapacity, { type: "u32" }),
+    ];
 
-  const callOperation = factory.call("create_pool", ...args);
+    const callOperation = factory.call("create_pool", ...args);
 
-  return new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(callOperation)
-    .setTimeout(TimeoutInfinite)
-    .build();
+    return new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(callOperation)
+      .setTimeout(TimeoutInfinite)
+      .build();
+  } catch (error) {
+    throw parseContractError(error, FN);
+  }
 }
 
 /**
@@ -125,41 +145,49 @@ export async function buildStakeProtocolTransaction(
   publicKey: string,
   amount: number,
 ) {
-  const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
-  const validatedAmount = PositiveAmountSchema.parse(amount);
+  const FN = "buildStakeProtocolTransaction";
+  try {
+    const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
+    const validatedAmount = PositiveAmountSchema.parse(amount);
 
-  if (
-    !STAKING_CONTRACT_ID ||
-    STAKING_CONTRACT_ID === STAKING_CONTRACT_PLACEHOLDER ||
-    STAKING_CONTRACT_ID.includes("...")
-  ) {
-    throw new Error(
-      "Staking contract not configured. Add NEXT_PUBLIC_STAKING_CONTRACT_ID to .env.local with your Soroban contract address.",
+    if (
+      !STAKING_CONTRACT_ID ||
+      STAKING_CONTRACT_ID === STAKING_CONTRACT_PLACEHOLDER ||
+      STAKING_CONTRACT_ID.includes("...")
+    ) {
+      throw new ContractError({
+        code: ContractErrorCode.CONFIG_MISSING,
+        message:
+          "Staking contract not configured. Add NEXT_PUBLIC_STAKING_CONTRACT_ID to .env.local with your Soroban contract address.",
+        fn: FN,
+      });
+    }
+
+    const server = new Server(SOROBAN_RPC_URL);
+    const account = await getAccount(validatedPublicKey, FN);
+    const stakingContract = new Contract(STAKING_CONTRACT_ID);
+
+    const amountStroops = BigInt(Math.floor(validatedAmount * 10_000_000));
+    const addressScVal = new Address(validatedPublicKey).toScVal();
+
+    const callOperation = stakingContract.call(
+      "stake",
+      addressScVal,
+      nativeToScVal(amountStroops, { type: "i128" }),
     );
+
+    const builtTx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(callOperation)
+      .setTimeout(TimeoutInfinite)
+      .build();
+
+    return server.prepareTransaction(builtTx);
+  } catch (error) {
+    throw parseContractError(error, FN);
   }
-
-  const server = new Server(SOROBAN_RPC_URL);
-  const account = await getAccount(validatedPublicKey);
-  const stakingContract = new Contract(STAKING_CONTRACT_ID);
-
-  const amountStroops = BigInt(Math.floor(validatedAmount * 10_000_000));
-  const addressScVal = new Address(validatedPublicKey).toScVal();
-
-  const callOperation = stakingContract.call(
-    "stake",
-    addressScVal,
-    nativeToScVal(amountStroops, { type: "i128" }),
-  );
-
-  const builtTx = new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(callOperation)
-    .setTimeout(TimeoutInfinite)
-    .build();
-
-  return server.prepareTransaction(builtTx);
 }
 
 /**
@@ -170,21 +198,26 @@ export async function buildJoinArenaTransaction(
   poolId: string,
   amount: number,
 ) {
-  const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
-  const validatedPoolId = StellarContractIdSchema.parse(poolId);
-  PositiveAmountSchema.parse(amount);
+  const FN = "buildJoinArenaTransaction";
+  try {
+    const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
+    const validatedPoolId = StellarContractIdSchema.parse(poolId);
+    PositiveAmountSchema.parse(amount);
 
-  const account = await getAccount(validatedPublicKey);
-  const poolContract = new Contract(validatedPoolId);
-  const callOperation = poolContract.call("join");
+    const account = await getAccount(validatedPublicKey, FN);
+    const poolContract = new Contract(validatedPoolId);
+    const callOperation = poolContract.call("join");
 
-  return new TransactionBuilder(account, {
-    fee: TRANSACTION_CONFIG.JOIN_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(callOperation)
-    .setTimeout(TRANSACTION_CONFIG.TIMEOUT_SECONDS)
-    .build();
+    return new TransactionBuilder(account, {
+      fee: TRANSACTION_CONFIG.JOIN_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(callOperation)
+      .setTimeout(TRANSACTION_CONFIG.TIMEOUT_SECONDS)
+      .build();
+  } catch (error) {
+    throw parseContractError(error, FN);
+  }
 }
 
 /**
@@ -196,30 +229,35 @@ export async function buildSubmitChoiceTransaction(
   choice: "Heads" | "Tails",
   roundNumber: number,
 ) {
-  const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
-  const validatedPoolId = StellarContractIdSchema.parse(poolId);
-  const validatedChoice = RoundChoiceSchema.parse(choice);
-  const validatedRoundNumber = RoundNumberSchema.parse(roundNumber);
+  const FN = "buildSubmitChoiceTransaction";
+  try {
+    const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
+    const validatedPoolId = StellarContractIdSchema.parse(poolId);
+    const validatedChoice = RoundChoiceSchema.parse(choice);
+    const validatedRoundNumber = RoundNumberSchema.parse(roundNumber);
 
-  const account = await getAccount(validatedPublicKey);
-  const poolContract = new Contract(validatedPoolId);
-  const choiceVal = xdr.ScVal.scvSymbol(
-    validatedChoice === "Heads" ? "Heads" : "Tails",
-  );
+    const account = await getAccount(validatedPublicKey, FN);
+    const poolContract = new Contract(validatedPoolId);
+    const choiceVal = xdr.ScVal.scvSymbol(
+      validatedChoice === "Heads" ? "Heads" : "Tails",
+    );
 
-  const callOperation = poolContract.call(
-    "submit_choice",
-    nativeToScVal(validatedRoundNumber, { type: "u32" }),
-    choiceVal,
-  );
+    const callOperation = poolContract.call(
+      "submit_choice",
+      nativeToScVal(validatedRoundNumber, { type: "u32" }),
+      choiceVal,
+    );
 
-  return new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(callOperation)
-    .setTimeout(TRANSACTION_CONFIG.TIMEOUT_SECONDS)
-    .build();
+    return new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(callOperation)
+      .setTimeout(TRANSACTION_CONFIG.TIMEOUT_SECONDS)
+      .build();
+  } catch (error) {
+    throw parseContractError(error, FN);
+  }
 }
 
 /**
@@ -229,26 +267,37 @@ export async function buildClaimWinningsTransaction(
   publicKey: string,
   poolId: string,
 ) {
-  const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
-  const validatedPoolId = StellarContractIdSchema.parse(poolId);
+  const FN = "buildClaimWinningsTransaction";
+  try {
+    const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
+    const validatedPoolId = StellarContractIdSchema.parse(poolId);
 
-  const account = await getAccount(validatedPublicKey);
-  const poolContract = new Contract(validatedPoolId);
-  const callOperation = poolContract.call("claim");
+    const account = await getAccount(validatedPublicKey, FN);
+    const poolContract = new Contract(validatedPoolId);
+    const callOperation = poolContract.call("claim");
 
-  return new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
-    .addOperation(callOperation)
-    .setTimeout(30)
-    .build();
+    return new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(callOperation)
+      .setTimeout(30)
+      .build();
+  } catch (error) {
+    throw parseContractError(error, FN);
+  }
 }
 
 /**
  * Parse Stellar error results to user-friendly messages.
+ * Now ContractError-aware: if the error is already a ContractError,
+ * returns its message directly.
  */
 export function parseStellarError(error: unknown): string {
+  if (error instanceof ContractError) {
+    return error.message;
+  }
+
   const errorString =
     error instanceof Error
       ? error.message
@@ -296,12 +345,13 @@ export async function fetchArenaState(
   arenaId: string,
   userAddress?: string
 ): Promise<ArenaStateResponse> {
-  const validatedArenaId = StellarContractIdSchema.parse(arenaId);
-  const validatedUserAddress = userAddress
-    ? StellarPublicKeySchema.parse(userAddress)
-    : undefined;
-
+  const FN = "fetchArenaState";
   try {
+    const validatedArenaId = StellarContractIdSchema.parse(arenaId);
+    const validatedUserAddress = userAddress
+      ? StellarPublicKeySchema.parse(userAddress)
+      : undefined;
+
     const server = new Server(SOROBAN_RPC_URL);
     const arenaContract = new Contract(validatedArenaId);
 
@@ -334,15 +384,17 @@ export async function fetchArenaState(
     ) {
       const errorMsg =
         "error" in stateSimulation ? stateSimulation.error : "Unknown error";
-      throw new Error(`Failed to fetch arena state: ${errorMsg}`);
+      throw new ContractError({
+        code: ContractErrorCode.SIMULATION_FAILED,
+        message: `Failed to fetch arena state: ${errorMsg}`,
+        fn: FN,
+      });
     }
 
     // Parse the contract response
-    // Adjust parsing based on your contract's return structure
     const stateData = stateSimulation.result.retval;
-    
+
     // Extract values from the contract response
-    // This assumes the contract returns a struct/map with these fields
     const survivorsCount = extractU32FromScVal(stateData, "survivors_count") || 0;
     const maxCapacity = extractU32FromScVal(stateData, "max_capacity") || 0;
     const roundNumber = extractU32FromScVal(stateData, "round_number") || 0;
@@ -391,9 +443,7 @@ export async function fetchArenaState(
       roundNumber,
     };
   } catch (error) {
-    // Provide structured error handling
-    const errorMessage = parseStellarError(error);
-    throw new Error(`Arena state fetch failed: ${errorMessage}`);
+    throw parseContractError(error, FN);
   }
 }
 
@@ -405,7 +455,7 @@ function extractU32FromScVal(scVal: xdr.ScVal, fieldName?: string): number | nul
     if (fieldName && scVal.switch().name === "scvMap") {
       const map = scVal.map();
       if (!map) return null;
-      
+
       for (const entry of map) {
         const key = entry.key();
         if (key.switch().name === "scvSymbol" && key.sym().toString() === fieldName) {
@@ -417,7 +467,7 @@ function extractU32FromScVal(scVal: xdr.ScVal, fieldName?: string): number | nul
       }
       return null;
     }
-    
+
     if (scVal.switch().name === "scvU32") {
       return scVal.u32();
     }
@@ -435,7 +485,7 @@ function extractI128FromScVal(scVal: xdr.ScVal, fieldName?: string): number | nu
     if (fieldName && scVal.switch().name === "scvMap") {
       const map = scVal.map();
       if (!map) return null;
-      
+
       for (const entry of map) {
         const key = entry.key();
         if (key.switch().name === "scvSymbol" && key.sym().toString() === fieldName) {
@@ -452,7 +502,7 @@ function extractI128FromScVal(scVal: xdr.ScVal, fieldName?: string): number | nu
       }
       return null;
     }
-    
+
     if (scVal.switch().name === "scvI128") {
       const i128Parts = scVal.i128();
       const hi = i128Parts.hi().toBigInt();
@@ -474,7 +524,7 @@ function extractBoolFromScVal(scVal: xdr.ScVal, fieldName?: string): boolean | n
     if (fieldName && scVal.switch().name === "scvMap") {
       const map = scVal.map();
       if (!map) return null;
-      
+
       for (const entry of map) {
         const key = entry.key();
         if (key.switch().name === "scvSymbol" && key.sym().toString() === fieldName) {
@@ -486,7 +536,7 @@ function extractBoolFromScVal(scVal: xdr.ScVal, fieldName?: string): boolean | n
       }
       return null;
     }
-    
+
     if (scVal.switch().name === "scvBool") {
       return scVal.b();
     }
@@ -500,40 +550,60 @@ function extractBoolFromScVal(scVal: xdr.ScVal, fieldName?: string): boolean | n
  * Submit a signed transaction to the network.
  */
 export async function submitSignedTransaction(signedXdr: string) {
-  const validatedSignedXdr = SignedXdrSchema.parse(signedXdr);
-  const server = new Server(SOROBAN_RPC_URL);
+  const FN = "submitSignedTransaction";
+  try {
+    const validatedSignedXdr = SignedXdrSchema.parse(signedXdr);
+    const server = new Server(SOROBAN_RPC_URL);
 
-  const tx = TransactionBuilder.fromXDR(validatedSignedXdr, NETWORK_PASSPHRASE);
-  const response = await server.sendTransaction(tx);
+    const tx = TransactionBuilder.fromXDR(validatedSignedXdr, NETWORK_PASSPHRASE);
+    const response = await server.sendTransaction(tx);
 
-  if (response.status !== "PENDING") {
-    throw new Error(`Transaction failed: ${response.status}`);
-  }
-
-  const hash = response.hash;
-  let getTxResponse: Awaited<ReturnType<Server["getTransaction"]>> | undefined;
-
-  const MAX_RETRIES = TRANSACTION_CONFIG.MAX_RETRIES;
-  let retries = 0;
-
-  while (retries < MAX_RETRIES) {
-    await new Promise((resolve) =>
-      setTimeout(resolve, TRANSACTION_CONFIG.RETRY_INTERVAL_MS),
-    );
-    try {
-      getTxResponse = await server.getTransaction(hash);
-      if (getTxResponse.status !== "NOT_FOUND") {
-        break;
-      }
-    } catch {
-      // Ignore transient fetch failures while polling.
+    if (response.status !== "PENDING") {
+      throw new ContractError({
+        code: ContractErrorCode.TRANSACTION_FAILED,
+        message: `Transaction rejected by network: ${response.status}`,
+        fn: FN,
+      });
     }
-    retries++;
-  }
 
-  if (!getTxResponse || getTxResponse.status !== "SUCCESS") {
-    throw new Error(`Transaction validation failed: ${getTxResponse?.status}`);
-  }
+    const hash = response.hash;
+    let getTxResponse: Awaited<ReturnType<Server["getTransaction"]>> | undefined;
 
-  return getTxResponse;
+    const MAX_RETRIES = TRANSACTION_CONFIG.MAX_RETRIES;
+    let retries = 0;
+
+    while (retries < MAX_RETRIES) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, TRANSACTION_CONFIG.RETRY_INTERVAL_MS),
+      );
+      try {
+        getTxResponse = await server.getTransaction(hash);
+        if (getTxResponse.status !== "NOT_FOUND") {
+          break;
+        }
+      } catch {
+        // Ignore transient fetch failures while polling.
+      }
+      retries++;
+    }
+
+    if (!getTxResponse) {
+      throw new ContractError({
+        code: ContractErrorCode.TRANSACTION_TIMEOUT,
+        fn: FN,
+      });
+    }
+
+    if (getTxResponse.status !== "SUCCESS") {
+      throw new ContractError({
+        code: ContractErrorCode.TRANSACTION_FAILED,
+        message: `Transaction confirmation failed: ${getTxResponse.status}`,
+        fn: FN,
+      });
+    }
+
+    return getTxResponse;
+  } catch (error) {
+    throw parseContractError(error, FN);
+  }
 }


### PR DESCRIPTION
## Summary
Standardizes contract error handling across all transaction builders in `stellar-transactions.ts` by introducing a typed `ContractError` class and a unified `parseContractError()` function. Previously, builders had inconsistent error patterns — some threw raw `Error`, some let Zod errors propagate unhandled, and `fetchArenaState` wrapped errors in a generic `new Error()` losing context. Now every builder throws a typed `ContractError` with a machine-readable code, user-friendly message, and originating function name.

Closes #244

## Changes

### New: `frontend/src/shared-d/utils/contract-error.ts`
- **`ContractErrorCode` enum** — 10 error codes: `VALIDATION_FAILED`, `ACCOUNT_NOT_FOUND`, `SIMULATION_FAILED`, `TRANSACTION_FAILED`, `TRANSACTION_TIMEOUT`, `USER_REJECTED`, `INSUFFICIENT_FUNDS`, `BAD_AUTH`, `CONFIG_MISSING`, `UNKNOWN`
- **`ContractError` class** — extends `Error` with `code`, `fn` (originating function), and `cause` fields. Each code has a default user-facing message.
- **`parseContractError(error, fn)`** — maps any raw error (Zod validation, Soroban simulation `HostError`/`Error(Contract, #N)`, Stellar network errors, wallet rejection) into a typed `ContractError`

### Modified: `frontend/src/shared-d/utils/stellar-transactions.ts`
- All 7 exported functions (`buildCreatePoolTransaction`, `buildStakeProtocolTransaction`, `buildJoinArenaTransaction`, `buildSubmitChoiceTransaction`, `buildClaimWinningsTransaction`, `fetchArenaState`, `submitSignedTransaction`) now wrap their body in try/catch and throw `ContractError` via `parseContractError()`
- `getAccount` helper now accepts `fn` parameter for proper error attribution
- `parseStellarError()` now returns `ContractError.message` directly when receiving a `ContractError`
- `submitSignedTransaction` now distinguishes `TRANSACTION_FAILED` vs `TRANSACTION_TIMEOUT` instead of throwing generic errors
- Re-exports `ContractError`, `ContractErrorCode`, `parseContractError` for single-import convenience

### Modified: `frontend/src/components/modals/TransactionModal.tsx`
- Changed `catch (err: any)` to `catch (err: unknown)` and removed `console.error` — error display handled uniformly via `parseStellarError()`

### Modified: `frontend/src/components/modals/StakeModal.tsx`
- Replaced manual `err instanceof Error ? err.message : fallback` with `parseStellarError(err)` for consistent error display

### New: `frontend/src/shared-d/utils/__tests__/contract-error.test.ts`
- 25 tests covering `ContractError` class behavior and `parseContractError()` detection of all error patterns (Zod, user rejection, insufficient funds, bad auth, timeouts, account not found, Soroban simulation errors, transaction failures, null/undefined, plain strings)

### Updated: `frontend/src/shared-d/utils/__tests__/fetchArenaState.test.ts`
- Updated to assert `ContractError` instances with correct error codes instead of generic `Error`

## Test plan
- [x] `contract-error.test.ts` — 25 tests passing
- [x] `fetchArenaState.test.ts` — 4 tests passing
- [x] TypeScript compilation passes with no errors in changed files
- [x] Build failure in `examples/arena-state-usage.tsx` is pre-existing on `main` (broken import unrelated to this PR)
- [ ] Manual: trigger wallet rejection in UI → verify user-friendly error message displays
- [ ] Manual: submit transaction with insufficient funds → verify correct error code and message


