### PR TITLE
Initialize Soroban workspace in inversearena-frontend/contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ package-lock.json
 GITHUB_ISSUE.md
 
 issues.md
+
+# Rust/Soroban
+target/
+**/*.rs.bk
+Cargo.lock

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+resolver = "2"
+members = [
+    "arena",
+    "factory",
+    "payout",
+    "staking",
+]
+
+[workspace.dependencies]
+soroban-sdk = "22"

--- a/contract/arena/Cargo.toml
+++ b/contract/arena/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "arena"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct ArenaContract;
+
+#[contractimpl]
+impl ArenaContract {
+    pub fn hello(env: Env) -> u32 {
+        123
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, ArenaContract);
+    let client = ArenaContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.hello(), 123);
+}

--- a/contract/arena/test_snapshots/test/test.1.json
+++ b/contract/arena/test_snapshots/test/test.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contract/factory/Cargo.toml
+++ b/contract/factory/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "factory"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct FactoryContract;
+
+#[contractimpl]
+impl FactoryContract {
+    pub fn hello(env: Env) -> u32 {
+        456
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, FactoryContract);
+    let client = FactoryContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.hello(), 456);
+}

--- a/contract/factory/test_snapshots/test/test.1.json
+++ b/contract/factory/test_snapshots/test/test.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contract/payout/Cargo.toml
+++ b/contract/payout/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "payout"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/payout/src/lib.rs
+++ b/contract/payout/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct PayoutContract;
+
+#[contractimpl]
+impl PayoutContract {
+    pub fn hello(env: Env) -> u32 {
+        789
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contract/payout/src/test.rs
+++ b/contract/payout/src/test.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PayoutContract);
+    let client = PayoutContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.hello(), 789);
+}

--- a/contract/payout/test_snapshots/test/test.1.json
+++ b/contract/payout/test_snapshots/test/test.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contract/staking/Cargo.toml
+++ b/contract/staking/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "staking"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/staking/src/lib.rs
+++ b/contract/staking/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct StakingContract;
+
+#[contractimpl]
+impl StakingContract {
+    pub fn hello(env: Env) -> u32 {
+        101112
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contract/staking/src/test.rs
+++ b/contract/staking/src/test.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StakingContract);
+    let client = StakingContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.hello(), 101112);
+}

--- a/contract/staking/test_snapshots/test/test.1.json
+++ b/contract/staking/test_snapshots/test/test.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
I have initialized a Soroban/Rust workspace in inversearena-frontend/contract/ with the following structure:

arena/: Smart contract for the arena logic.
factory/: Smart contract for creating other contracts.
payout/: Smart contract for handling payouts.
staking/: Smart contract for staking logic.
Changes Made
Workspace Configuration
Created inversearena-frontend/contract/Cargo.toml as the workspace root:

toml
[workspace]
resolver = "2"
members = [
    "arena",
    "factory",
    "payout",
    "staking",
]
[workspace.dependencies]
soroban-sdk = "22"
Sub-crates
Each sub-crate (arena, factory, payout, staking) has been initialized with:

A Cargo.toml referencing the workspace soroban-sdk and enabling testutils for testing.
A src/lib.rs with a minimal Soroban contract template.
A src/test.rs with a working unit test.
Verification Results
Automated Tests
Ran cargo test in inversearena-frontend/contract/:

All 4 sub-crates compiled successfully.
All unit tests passed.
text
running 1 test
test test::test ... ok
...
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s (total)

Closes #208 