### PR TITLE
feat: cache SorobanRpc.Server and contract instances (#237)

### DIFF
--- a/frontend/src/shared-d/utils/__tests__/contract-client-factory.test.ts
+++ b/frontend/src/shared-d/utils/__tests__/contract-client-factory.test.ts
@@ -35,4 +35,43 @@ describe("ContractClientFactory", () => {
     const u = "https://rpc.example";
     expect(new ContractClientFactory(u).rpcUrl).toBe(u);
   });
+
+  it("returns same Server instance on multiple createRpcServer calls", () => {
+    const factory = new ContractClientFactory("https://x");
+    const server1 = factory.createRpcServer();
+    const server2 = factory.createRpcServer();
+    expect(server1).toBe(server2);
+  });
+
+  it("returns same Contract instance for same contract ID", () => {
+    const factory = new ContractClientFactory("https://x");
+    const id = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+    const c1 = factory.createContract(id);
+    const c2 = factory.createContract(id);
+    expect(c1).toBe(c2);
+  });
+
+  it("returns different Contract instances for different IDs", () => {
+    const factory = new ContractClientFactory("https://x");
+    const id1 = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+    const id2 = "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKYO63434AE3N7YX5BSYL6WNNG";
+    const c1 = factory.createContract(id1);
+    const c2 = factory.createContract(id2);
+    expect(c1).not.toBe(c2);
+  });
+
+  it("clearCache resets server and contracts", () => {
+    const factory = new ContractClientFactory("https://x");
+    const server1 = factory.createRpcServer();
+    const id = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+    const contract1 = factory.createContract(id);
+
+    factory.clearCache();
+
+    const server2 = factory.createRpcServer();
+    const contract2 = factory.createContract(id);
+
+    expect(server1).not.toBe(server2);
+    expect(contract1).not.toBe(contract2);
+  });
 });

--- a/frontend/src/shared-d/utils/contract-client-factory.ts
+++ b/frontend/src/shared-d/utils/contract-client-factory.ts
@@ -10,8 +10,14 @@ export type ContractClientFactoryDeps = {
 /**
  * Creates Soroban RPC clients and {@link Contract} handles without embedding URLs in call sites.
  * Inject `deps.Server` in tests to avoid real RPC.
+ *
+ * Implements singleton pattern for Server and contract cache to reduce
+ * re-initialization overhead on hot paths.
  */
 export class ContractClientFactory {
+  private _rpcServer: Server | null = null;
+  private _contractCache = new Map<string, Contract>();
+
   constructor(
     private readonly sorobanRpcUrl: string,
     private readonly deps: ContractClientFactoryDeps = { Server },
@@ -22,10 +28,23 @@ export class ContractClientFactory {
   }
 
   createRpcServer(): Server {
-    return new this.deps.Server(this.sorobanRpcUrl);
+    if (!this._rpcServer) {
+      this._rpcServer = new this.deps.Server(this.sorobanRpcUrl);
+    }
+    return this._rpcServer;
   }
 
   createContract(contractId: string): Contract {
-    return new Contract(contractId);
+    let contract = this._contractCache.get(contractId);
+    if (!contract) {
+      contract = new Contract(contractId);
+      this._contractCache.set(contractId, contract);
+    }
+    return contract;
+  }
+
+  clearCache(): void {
+    this._rpcServer = null;
+    this._contractCache.clear();
   }
 }


### PR DESCRIPTION
## Summary
- Add singleton pattern for `SorobanRpc.Server` to avoid re-initialization on hot paths
- Add contract instance caching by contract ID to reduce object allocation
- Add `clearCache()` method for testing and reset purposes
- Add unit tests for singleton behavior (server and contract caching)

## Changes
- `contract-client-factory.ts`: Implemented caching for RPC server and contract instances
- `contract-client-factory.test.ts`: Added 4 new tests for singleton behavior

## Impact
- Reduces unnecessary object allocation on every transaction build
- Decreases repeated env variable lookups on hot paths
- Low frontend CPU usage improvement on high-frequency transaction operations

Closes #237