### PR TITLE
Fix #219: Implement access control for admin-only contract functions

### DIFF
--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -140,6 +140,17 @@ impl ArenaContract {
             .expect("not initialized")
     }
 
+    /// Set a new admin address. Only the current admin can call this.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN_KEY)
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&ADMIN_KEY, &new_admin);
+    }
+
     // ── Round state machine ──────────────────────────────────────────────────
 
     pub fn start_round(env: Env) -> Result<RoundState, ArenaError> {
@@ -261,10 +272,8 @@ impl ArenaContract {
             .instance()
             .set(&EXECUTE_AFTER_KEY, &execute_after);
 
-        env.events().publish(
-            (TOPIC_UPGRADE_PROPOSED,),
-            (new_wasm_hash, execute_after),
-        );
+        env.events()
+            .publish((TOPIC_UPGRADE_PROPOSED,), (new_wasm_hash, execute_after));
     }
 
     /// Execute a previously proposed upgrade after the 48-hour timelock.
@@ -301,8 +310,7 @@ impl ArenaContract {
         env.events()
             .publish((TOPIC_UPGRADE_EXECUTED,), new_wasm_hash.clone());
 
-        env.deployer()
-            .update_current_contract_wasm(new_wasm_hash);
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 
     /// Cancel a pending upgrade proposal. Admin-only.

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -710,8 +710,68 @@ fn smoke_10000_round_cycles_without_panic() {
 
     assert_eq!(numbers.len(), CYCLES as usize);
     for (i, &n) in numbers.iter().enumerate() {
-        assert_eq!(n, (i + 1) as u32, "round number out of sequence at index {i}");
+        assert_eq!(
+            n,
+            (i + 1) as u32,
+            "round number out of sequence at index {i}"
+        );
     }
+}
+
+// ── Admin access control tests ────────────────────────────────────────────────
+
+#[test]
+fn test_set_admin_changes_admin() {
+    let (env, _admin, client) = setup_with_admin();
+    let new_admin = Address::generate(&env);
+    client.set_admin(&new_admin);
+    assert_eq!(client.admin(), new_admin);
+}
+
+#[test]
+#[should_panic(expected = "not initialized")]
+fn test_set_admin_fails_without_admin() {
+    let env = Env::default();
+    let contract_id = env.register(ArenaContract, ());
+    let client = ArenaContractClient::new(&env, &contract_id);
+    let new_admin = Address::generate(&env);
+    client.set_admin(&new_admin);
+}
+
+#[test]
+#[should_panic(expected = "authorize")]
+fn test_unauthorized_propose_upgrade_panics() {
+    let env = Env::default();
+    let contract_id = env.register(ArenaContract, ());
+    let client = ArenaContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.propose_upgrade(&dummy_hash(&env));
+}
+
+#[test]
+#[should_panic(expected = "authorize")]
+fn test_unauthorized_execute_upgrade_panics() {
+    let env = Env::default();
+    let contract_id = env.register(ArenaContract, ());
+    let client = ArenaContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.execute_upgrade();
+}
+
+#[test]
+#[should_panic(expected = "authorize")]
+fn test_unauthorized_cancel_upgrade_panics() {
+    let env = Env::default();
+    let contract_id = env.register(ArenaContract, ());
+    let client = ArenaContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.cancel_upgrade();
 }
 
 // ── Issue #232: round timeout and stalled game recovery ──────────────────────

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol,
+};
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
@@ -55,6 +57,17 @@ impl FactoryContract {
             .expect("not initialized")
     }
 
+    /// Set a new admin address. Only the current admin can call this.
+    pub fn set_admin(env: Env, new_admin: Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN_KEY)
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&ADMIN_KEY, &new_admin);
+    }
+
     // ── Upgrade mechanism ────────────────────────────────────────────────────
 
     /// Propose a WASM upgrade. The new hash is stored together with the
@@ -76,10 +89,8 @@ impl FactoryContract {
             .instance()
             .set(&EXECUTE_AFTER_KEY, &execute_after);
 
-        env.events().publish(
-            (TOPIC_UPGRADE_PROPOSED,),
-            (new_wasm_hash, execute_after),
-        );
+        env.events()
+            .publish((TOPIC_UPGRADE_PROPOSED,), (new_wasm_hash, execute_after));
     }
 
     /// Execute a previously proposed upgrade after the 48-hour timelock.
@@ -116,8 +127,7 @@ impl FactoryContract {
         env.events()
             .publish((TOPIC_UPGRADE_EXECUTED,), new_wasm_hash.clone());
 
-        env.deployer()
-            .update_current_contract_wasm(new_wasm_hash);
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 
     /// Cancel a pending upgrade proposal. Admin-only.

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -158,3 +158,59 @@ fn test_pending_upgrade_none_after_cancel() {
     client.cancel_upgrade();
     assert!(client.pending_upgrade().is_none());
 }
+
+// ── Admin access control tests ────────────────────────────────────────────────
+
+#[test]
+fn test_set_admin_changes_admin() {
+    let (env, _admin, client) = setup();
+    let new_admin = Address::generate(&env);
+    client.set_admin(&new_admin);
+    assert_eq!(client.admin(), new_admin);
+}
+
+#[test]
+#[should_panic(expected = "not initialized")]
+fn test_set_admin_fails_without_admin() {
+    let env = Env::default();
+    let contract_id = env.register(FactoryContract, ());
+    let client = FactoryContractClient::new(&env, &contract_id);
+    let new_admin = Address::generate(&env);
+    client.set_admin(&new_admin);
+}
+
+#[test]
+#[should_panic(expected = "authorize")]
+fn test_unauthorized_propose_upgrade_panics() {
+    let env = Env::default();
+    let contract_id = env.register(FactoryContract, ());
+    let client = FactoryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.propose_upgrade(&dummy_hash(&env));
+}
+
+#[test]
+#[should_panic(expected = "authorize")]
+fn test_unauthorized_execute_upgrade_panics() {
+    let env = Env::default();
+    let contract_id = env.register(FactoryContract, ());
+    let client = FactoryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.execute_upgrade();
+}
+
+#[test]
+#[should_panic(expected = "authorize")]
+fn test_unauthorized_cancel_upgrade_panics() {
+    let env = Env::default();
+    let contract_id = env.register(FactoryContract, ());
+    let client = FactoryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.cancel_upgrade();
+}


### PR DESCRIPTION
## Summary
- Added `set_admin()` function to arena and factory contracts for admin transfer
- Added tests for unauthorized access to admin-only functions (propose_upgrade, execute_upgrade, cancel_upgrade)
- Tests verify that unauthorized callers are rejected

Closes #219