### PR TITLE
feat: #271 contract: define pause policy for governance/upgrade functions

### DIFF
--- a/contract/DATA_MODEL.md
+++ b/contract/DATA_MODEL.md
@@ -77,9 +77,11 @@ No custom Soroban storage keys are currently defined or used.
 | `get_round` | `Round` | — | — |
 | `get_choice` | `Submission(n, player)` | — | — |
 | `initialize` | `ADMIN` (instance) | `ADMIN` (instance) | — |
-| `propose_upgrade` | `ADMIN` (instance) | `P_HASH`, `P_AFTER` (instance) | — |
-| `execute_upgrade` | `ADMIN`, `P_AFTER`, `P_HASH` (instance) | removes `P_HASH`, `P_AFTER` (instance) | — |
-| `cancel_upgrade` | `ADMIN`, `P_HASH` (instance) | removes `P_HASH`, `P_AFTER` (instance) | — |
+| `propose_upgrade` ¹ | `ADMIN` (instance) | `P_HASH`, `P_AFTER` (instance) | — |
+| `execute_upgrade` ¹ | `ADMIN`, `P_AFTER`, `P_HASH` (instance) | removes `P_HASH`, `P_AFTER` (instance) | — |
+| `cancel_upgrade` ¹ | `ADMIN`, `P_HASH` (instance) | removes `P_HASH`, `P_AFTER` (instance) | — |
+
+¹ Exempt from the global pause check — see [Emergency Pause Policy](#emergency-pause-policy) below.
 
 ## TTL Policy Baseline
 
@@ -140,6 +142,53 @@ Round lifecycle state machine:
     ▼
 [Round { active: true, round_number + 1 }] ...
 ```
+
+## Emergency Pause Policy
+
+### Overview
+
+The arena contract exposes a global pause mechanism (`pause` / `unpause`, admin-only).
+When paused, all state-mutating game functions reject calls with `ArenaError::Paused`.
+
+**However, governance/upgrade functions are explicitly exempt from the pause check.**
+
+### Exempt functions
+
+| Function | Pause exempt? | Reason |
+| --- | --- | --- |
+| `propose_upgrade` | **Yes** | Admin must be able to queue a recovery upgrade at any time |
+| `execute_upgrade` | **Yes** | Admin must be able to deploy the recovery upgrade after the timelock |
+| `cancel_upgrade` | **Yes** | Admin must be able to retract an incorrect proposal before correcting it |
+| `pause` | **Yes** | Admin must always be able to pause |
+| `unpause` | **Yes** | Admin must always be able to unpause |
+
+### Non-exempt functions (blocked when paused)
+
+| Function | Blocked when paused? |
+| --- | --- |
+| `start_round` | Yes |
+| `submit_choice` | Yes |
+| `timeout_round` | Yes |
+| `join` | Yes |
+| `claim` | Yes |
+
+### Rationale
+
+A global pause is an emergency safety measure (e.g. to halt activity during a
+critical bug discovery). If the pause also blocked upgrade functions, a paused
+contract could become permanently locked with no recovery path. By keeping
+governance functions exempt, the admin retains full ability to:
+
+1. Propose a corrective WASM upgrade while the contract is paused.
+2. Wait for the 48-hour timelock to elapse.
+3. Execute the upgrade and restore normal operation.
+4. Unpause.
+
+### Invariant
+
+> `propose_upgrade`, `execute_upgrade`, and `cancel_upgrade` MUST NOT call
+> `require_not_paused`. Any future addition of new governance functions should
+> follow the same exemption rule and update this table.
 
 ## Historical baseline note
 

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -454,6 +454,22 @@ impl ArenaContract {
 
     // ── Upgrade mechanism ────────────────────────────────────────────────────
 
+    // ── Emergency Pause Policy ───────────────────────────────────────────────
+    //
+    // Governance/upgrade functions (`propose_upgrade`, `execute_upgrade`,
+    // `cancel_upgrade`) are EXEMPT from the global pause check.
+    //
+    // Rationale: A global pause is an emergency safety measure. If it also
+    // blocked upgrade/recovery functions, a paused contract could become
+    // permanently locked with no way out. Admin must always be able to propose,
+    // execute, or cancel an upgrade — even while the contract is paused — so
+    // that recovery or corrective upgrades remain possible.
+    //
+    // All other state-mutating functions (`start_round`, `submit_choice`,
+    // `timeout_round`, `join`, `claim`) continue to require the contract to be
+    // unpaused before proceeding.
+    // ────────────────────────────────────────────────────────────────────────
+
     /// Propose a WASM upgrade. The new hash is stored together with the
     /// earliest timestamp at which `execute_upgrade` may be called (now + 48 h).
     ///
@@ -467,10 +483,15 @@ impl ArenaContract {
     /// # Authorization
     /// Requires admin signature (`admin.require_auth()`).
     ///
+    /// # Pause Policy
+    /// **Exempt from pause.** This function may be called by the admin even when
+    /// the contract is paused, allowing upgrade proposals during an emergency.
+    ///
     /// # Events
     /// Emits `UpgradeProposed(new_wasm_hash, execute_after)`.
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) {
-        require_not_paused(&env).unwrap();
+        // NOTE: pause check intentionally omitted — governance functions are
+        // exempt so that admin can always initiate a recovery upgrade.
         let admin: Address = env
             .storage()
             .instance()
@@ -503,10 +524,14 @@ impl ArenaContract {
     /// # Authorization
     /// Requires admin signature (`admin.require_auth()`).
     ///
+    /// # Pause Policy
+    /// **Exempt from pause.** This function may be called by the admin even when
+    /// the contract is paused, enabling deployment of a recovery upgrade.
+    ///
     /// # Events
     /// Emits `UpgradeExecuted(new_wasm_hash)`.
     pub fn execute_upgrade(env: Env) {
-        require_not_paused(&env).unwrap();
+        // NOTE: pause check intentionally omitted — see Emergency Pause Policy.
         let admin: Address = env
             .storage()
             .instance()
@@ -552,10 +577,15 @@ impl ArenaContract {
     /// # Authorization
     /// Requires admin signature (`admin.require_auth()`).
     ///
+    /// # Pause Policy
+    /// **Exempt from pause.** This function may be called by the admin even when
+    /// the contract is paused, allowing cancellation of an incorrect proposal
+    /// before executing a correct recovery upgrade.
+    ///
     /// # Events
     /// Emits `UpgradeCancelled`.
     pub fn cancel_upgrade(env: Env) {
-        require_not_paused(&env).unwrap();
+        // NOTE: pause check intentionally omitted — see Emergency Pause Policy.
         let admin: Address = env
             .storage()
             .instance()

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -1142,7 +1142,7 @@ fn test_functions_fail_when_paused() {
 #[test]
 fn test_unpause_restores_functionality() {
     let (env, _admin, client) = setup_with_admin();
-    
+
     client.init(&10);
     client.pause();
     client.unpause();
@@ -1150,4 +1150,176 @@ fn test_unpause_restores_functionality() {
     // Should succeed now
     let round = client.start_round();
     assert_eq!(round.round_number, 1);
+}
+
+// ── Issue #271: Emergency Pause Policy — governance/upgrade exemption ──────────
+//
+// Policy: propose_upgrade, execute_upgrade, and cancel_upgrade must be callable
+// by ADMIN even when the contract is paused, so that a recovery upgrade can
+// always be initiated without first unpausing.
+
+/// When paused, propose_upgrade still succeeds for the admin.
+#[test]
+fn test_propose_upgrade_succeeds_when_paused() {
+    let (env, _admin, client) = setup_with_admin();
+    let hash = dummy_hash(&env);
+
+    client.pause();
+    assert!(client.is_paused(), "contract must be paused for this test");
+
+    // Must NOT panic or return Paused error — governance is exempt.
+    client.propose_upgrade(&hash);
+
+    let pending = client.pending_upgrade();
+    assert!(pending.is_some(), "proposal must be stored even when contract is paused");
+    assert_eq!(pending.unwrap().0, hash);
+}
+
+/// When paused, cancel_upgrade still succeeds for the admin.
+#[test]
+fn test_cancel_upgrade_succeeds_when_paused() {
+    let (env, _admin, client) = setup_with_admin();
+    let hash = dummy_hash(&env);
+
+    // Propose first, then pause.
+    client.propose_upgrade(&hash);
+    client.pause();
+    assert!(client.is_paused());
+
+    // Cancel must succeed even while paused.
+    client.cancel_upgrade();
+
+    assert!(
+        client.pending_upgrade().is_none(),
+        "proposal must be cleared even when contract is paused"
+    );
+}
+
+/// When paused, cancel_upgrade can be called after a proposal made while paused.
+#[test]
+fn test_cancel_upgrade_after_paused_propose() {
+    let (env, _admin, client) = setup_with_admin();
+    let hash = dummy_hash(&env);
+
+    client.pause();
+    assert!(client.is_paused());
+
+    // Propose while paused — must succeed.
+    client.propose_upgrade(&hash);
+    assert!(client.pending_upgrade().is_some());
+
+    // Cancel while still paused — must also succeed.
+    client.cancel_upgrade();
+    assert!(client.pending_upgrade().is_none());
+}
+
+/// When paused, normal game functions are blocked but governance functions are not.
+/// This is the core invariant of the Emergency Pause Policy.
+#[test]
+fn test_paused_blocks_game_functions_not_governance() {
+    let (env, _admin, client) = setup_with_admin();
+    let player = Address::generate(&env);
+    let hash = dummy_hash(&env);
+
+    client.init(&10);
+    client.pause();
+    assert!(client.is_paused());
+
+    // Game functions MUST be blocked when paused.
+    assert_eq!(
+        client.try_start_round(),
+        Err(Ok(ArenaError::Paused)),
+        "start_round must fail when paused"
+    );
+    assert_eq!(
+        client.try_timeout_round(),
+        Err(Ok(ArenaError::Paused)),
+        "timeout_round must fail when paused"
+    );
+    assert_eq!(
+        client.try_submit_choice(&player, &Choice::Heads),
+        Err(Ok(ArenaError::Paused)),
+        "submit_choice must fail when paused"
+    );
+
+    // Governance functions MUST succeed even when paused.
+    client.propose_upgrade(&hash);
+    assert!(
+        client.pending_upgrade().is_some(),
+        "propose_upgrade must succeed when paused"
+    );
+
+    client.cancel_upgrade();
+    assert!(
+        client.pending_upgrade().is_none(),
+        "cancel_upgrade must succeed when paused"
+    );
+}
+
+/// After unpausing, all functions — game and governance — work normally.
+#[test]
+fn test_all_functions_work_after_unpause() {
+    let (env, _admin, client) = setup_with_admin();
+    let hash = dummy_hash(&env);
+
+    client.init(&10);
+    client.pause();
+    client.unpause();
+    assert!(!client.is_paused());
+
+    // Game functions must work again.
+    let round = client.start_round();
+    assert_eq!(round.round_number, 1);
+    assert!(round.active);
+
+    // Governance functions must also still work unpaused.
+    client.propose_upgrade(&hash);
+    assert!(client.pending_upgrade().is_some());
+
+    client.cancel_upgrade();
+    assert!(client.pending_upgrade().is_none());
+}
+
+/// Propose while paused, then unpause and verify the proposal persists so
+/// execute_upgrade can be called after the timelock elapses.
+#[test]
+fn test_paused_proposal_persists_after_unpause() {
+    let (env, _admin, client) = setup_with_admin();
+    let hash = dummy_hash(&env);
+
+    client.pause();
+    client.propose_upgrade(&hash);
+
+    let pending_paused = client.pending_upgrade().expect("proposal must exist while paused");
+    assert_eq!(pending_paused.0, hash);
+
+    // Unpause — proposal must survive.
+    client.unpause();
+    assert!(!client.is_paused());
+
+    let pending_unpaused = client.pending_upgrade().expect("proposal must persist after unpause");
+    assert_eq!(pending_unpaused.0, hash);
+    assert_eq!(pending_paused.1, pending_unpaused.1, "execute_after timestamp must be unchanged");
+}
+
+/// is_paused() view function reflects pause/unpause state transitions correctly.
+#[test]
+fn test_is_paused_reflects_state_transitions() {
+    let (_env, _admin, client) = setup_with_admin();
+
+    assert!(!client.is_paused(), "contract starts unpaused");
+
+    client.pause();
+    assert!(client.is_paused(), "must be paused after pause()");
+
+    client.unpause();
+    assert!(!client.is_paused(), "must be unpaused after unpause()");
+
+    // Toggle multiple times — state must always match the last call.
+    client.pause();
+    client.pause(); // idempotent
+    assert!(client.is_paused());
+
+    client.unpause();
+    assert!(!client.is_paused());
 }


### PR DESCRIPTION
## Summary

- Removes `require_not_paused` from `propose_upgrade`, `execute_upgrade`, and `cancel_upgrade` so that ADMIN can always initiate or complete a recovery upgrade even while the contract is paused
- Documents the **Emergency Pause Policy** in `contract/DATA_MODEL.md` with a dedicated section covering exempt functions, non-exempt functions, rationale, and an invariant
- Adds 7 targeted tests covering paused/unpaused governance behavior and the core policy invariant

## Problem

A global pause was blocking `propose_upgrade`, `execute_upgrade`, and `cancel_upgrade`. This meant a paused contract could become permanently locked with no recovery path — the admin would need to unpause first, which may itself be unsafe during an active incident.

## Solution

Governance/upgrade functions are now **explicitly exempt** from the pause check. All normal game functions (`start_round`, `submit_choice`, `timeout_round`, `join`, `claim`) remain blocked when paused.

## Acceptance Criteria

- [x] Policy documented in `contract/DATA_MODEL.md` (new "Emergency Pause Policy" section)
- [x] Policy implemented in `contract/arena/src/lib.rs` with clear code comments
- [x] Tests cover paused state → game functions fail, governance functions succeed for ADMIN
- [x] Tests cover unpaused state → all functions work normally

## Tests Added

| Test | What it verifies |
| --- | --- |
| `test_propose_upgrade_succeeds_when_paused` | Proposal stored correctly while paused |
| `test_cancel_upgrade_succeeds_when_paused` | Cancel works while paused |
| `test_cancel_upgrade_after_paused_propose` | Propose + cancel, both while paused |
| `test_paused_blocks_game_functions_not_governance` | Core invariant: game → `Paused` error, governance → success |
| `test_all_functions_work_after_unpause` | Everything works normally after unpause |
| `test_paused_proposal_persists_after_unpause` | Proposal made while paused survives unpause |
| `test_is_paused_reflects_state_transitions` | Pause/unpause toggle and idempotency |

Closes #271