### PR TITLE
fix(contract): add pre-upgrade state validation

### DIFF
--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -680,11 +680,19 @@ impl ArenaContract {
             .expect("not initialized");
         admin.require_auth();
 
+        let has_pending_hash = env.storage().instance().has(&PENDING_HASH_KEY);
+        let has_execute_after = env.storage().instance().has(&EXECUTE_AFTER_KEY);
+        match (has_pending_hash, has_execute_after) {
+            (false, false) => panic!("no pending upgrade"),
+            (true, false) | (false, true) => panic!("malformed upgrade state"),
+            (true, true) => {}
+        }
+
         let execute_after: u64 = env
             .storage()
             .instance()
             .get(&EXECUTE_AFTER_KEY)
-            .expect("no pending upgrade");
+            .expect("malformed upgrade state");
 
         if env.ledger().timestamp() < execute_after {
             panic!("timelock has not expired");
@@ -694,7 +702,7 @@ impl ArenaContract {
             .storage()
             .instance()
             .get(&PENDING_HASH_KEY)
-            .expect("no pending upgrade");
+            .expect("malformed upgrade state");
 
         // Clear pending state before upgrading.
         env.storage().instance().remove(&PENDING_HASH_KEY);

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -347,6 +347,34 @@ fn test_execute_without_proposal_panics() {
 }
 
 #[test]
+#[should_panic(expected = "malformed upgrade state")]
+fn test_execute_upgrade_rejects_missing_execute_after() {
+    let (env, _admin, client) = setup_with_admin();
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&PENDING_HASH_KEY, &dummy_hash(&env));
+    });
+
+    client.execute_upgrade();
+}
+
+#[test]
+#[should_panic(expected = "malformed upgrade state")]
+fn test_execute_upgrade_rejects_missing_pending_hash() {
+    let (env, _admin, client) = setup_with_admin();
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&EXECUTE_AFTER_KEY, &(env.ledger().timestamp() + TIMELOCK + 1));
+    });
+
+    client.execute_upgrade();
+}
+
+#[test]
 #[should_panic(expected = "timelock has not expired")]
 fn test_execute_before_timelock_panics() {
     let (env, _admin, client) = setup_with_admin();

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -83,6 +83,8 @@ pub enum Error {
     InvalidCapacity = 10,
     /// `create_pool` called before `set_arena_wasm_hash` has been called.
     WasmHashNotSet = 11,
+    /// Pending upgrade state is only partially present.
+    MalformedUpgradeState = 12,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -394,11 +396,19 @@ impl FactoryContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
 
+        let has_pending_hash = env.storage().instance().has(&PENDING_HASH_KEY);
+        let has_execute_after = env.storage().instance().has(&EXECUTE_AFTER_KEY);
+        match (has_pending_hash, has_execute_after) {
+            (false, false) => return Err(Error::NoPendingUpgrade),
+            (true, false) | (false, true) => return Err(Error::MalformedUpgradeState),
+            (true, true) => {}
+        }
+
         let execute_after: u64 = env
             .storage()
             .instance()
             .get(&EXECUTE_AFTER_KEY)
-            .ok_or(Error::NoPendingUpgrade)?;
+            .ok_or(Error::MalformedUpgradeState)?;
 
         if env.ledger().timestamp() < execute_after {
             return Err(Error::TimelockNotExpired);
@@ -408,7 +418,7 @@ impl FactoryContract {
             .storage()
             .instance()
             .get(&PENDING_HASH_KEY)
-            .ok_or(Error::NoPendingUpgrade)?;
+            .ok_or(Error::MalformedUpgradeState)?;
 
         // Clear pending state before upgrading.
         env.storage().instance().remove(&PENDING_HASH_KEY);

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -273,6 +273,34 @@ fn test_execute_without_proposal_returns_no_pending_upgrade() {
 }
 
 #[test]
+fn test_execute_with_only_pending_hash_returns_malformed_upgrade_state() {
+    let (env, _admin, client) = setup();
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&PENDING_HASH_KEY, &dummy_hash(&env));
+    });
+
+    let result = client.try_execute_upgrade();
+    assert_eq!(result, Err(Ok(Error::MalformedUpgradeState)));
+}
+
+#[test]
+fn test_execute_with_only_execute_after_returns_malformed_upgrade_state() {
+    let (env, _admin, client) = setup();
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&EXECUTE_AFTER_KEY, &(env.ledger().timestamp() + TIMELOCK + 1));
+    });
+
+    let result = client.try_execute_upgrade();
+    assert_eq!(result, Err(Ok(Error::MalformedUpgradeState)));
+}
+
+#[test]
 fn test_execute_before_timelock_returns_timelock_not_expired() {
     let (env, _admin, client) = setup();
     client.propose_upgrade(&dummy_hash(&env));


### PR DESCRIPTION
## Summary
- reject malformed pending upgrade state when only one of the upgrade keys is present
- preserve the existing no-proposal and timelock guards while tightening both arena and factory execution paths
- add regression tests for both malformed-state branches in both contracts

## Testing
- cargo test -p arena test_execute_upgrade_rejects_missing_execute_after
- cargo test -p arena test_execute_upgrade_rejects_missing_pending_hash
- cargo test -p factory test_execute_with_only_pending_hash_returns_malformed_upgrade_state
- cargo test -p factory test_execute_with_only_execute_after_returns_malformed_upgrade_state

Closes #281