### PR TITLE
fix: add require_auth() to prevent admin spoofing in distribute_winnings

### DIFF
--- a/contract/payout/src/lib.rs
+++ b/contract/payout/src/lib.rs
@@ -229,6 +229,8 @@ impl PayoutContract {
             panic_with_error!(&env, PayoutError::UnauthorizedCaller);
         }
 
+        caller.require_auth();
+
         if amount <= 0 {
             panic_with_error!(&env, PayoutError::InvalidAmount);
         }

--- a/contract/payout/src/test.rs
+++ b/contract/payout/src/test.rs
@@ -65,8 +65,30 @@ fn test_unauthorized_caller_cannot_distribute() {
     let currency = symbol_short!("XLM");
 
     let result =
-        client.try_distribute_winnings(&unauthorized, &idempotency_key, &winner, &amount, &currency);
+        client.try_distribute_winnings(&unauthorized, &ctx, &pool_id, &round_id, &winner, &amount, &currency);
     assert_eq!(result, Err(Ok(PayoutError::UnauthorizedCaller)));
+}
+
+/// Verify that passing the admin address as `caller` without signing
+/// the transaction is rejected by `require_auth()`.
+#[test]
+fn test_admin_spoofing_rejected_without_auth() {
+    let env = Env::default();
+    // Intentionally do NOT call env.mock_all_auths() — no auth is mocked.
+    let contract_id = env.register(PayoutContract, ());
+    let client = PayoutContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let winner = Address::generate(&env);
+    let ctx = symbol_short!("arena_1");
+
+    // A spoofed caller passes the real admin address but has not signed.
+    // require_auth() must reject this.
+    let result = client.try_distribute_winnings(
+        &admin, &ctx, &1u32, &1u32, &winner, &1000i128, &symbol_short!("XLM"),
+    );
+    assert!(result.is_err());
 }
 
 #[test]
@@ -76,9 +98,10 @@ fn test_zero_amount_panics() {
     let ctx = symbol_short!("arena_1");
     let pool_id = 1u32;
     let round_id = 1u32;
+    let amount = 0i128;
     let currency = symbol_short!("XLM");
 
-    let result = client.try_distribute_winnings(&admin, &idempotency_key, &winner, &amount, &currency);
+    let result = client.try_distribute_winnings(&admin, &ctx, &pool_id, &round_id, &winner, &amount, &currency);
     assert_eq!(result, Err(Ok(PayoutError::InvalidAmount)));
 }
 
@@ -89,9 +112,10 @@ fn test_negative_amount_panics() {
     let ctx = symbol_short!("arena_1");
     let pool_id = 1u32;
     let round_id = 1u32;
+    let amount = -500i128;
     let currency = symbol_short!("XLM");
 
-    let result = client.try_distribute_winnings(&admin, &idempotency_key, &winner, &amount, &currency);
+    let result = client.try_distribute_winnings(&admin, &ctx, &pool_id, &round_id, &winner, &amount, &currency);
     assert_eq!(result, Err(Ok(PayoutError::InvalidAmount)));
 }
 
@@ -105,14 +129,14 @@ fn test_idempotency_prevents_double_pay_same_amount() {
     let amount = 1000i128;
     let currency = symbol_short!("XLM");
 
-    client.distribute_winnings(&admin, &idempotency_key, &winner, &amount, &currency);
+    client.distribute_winnings(&admin, &ctx, &pool_id, &round_id, &winner, &amount, &currency);
 
     let second_attempt =
-        client.try_distribute_winnings(&admin, &idempotency_key, &winner, &amount, &currency);
+        client.try_distribute_winnings(&admin, &ctx, &pool_id, &round_id, &winner, &amount, &currency);
     assert_eq!(second_attempt, Err(Ok(PayoutError::AlreadyPaid)));
 
     // The persisted payout amount must remain unchanged after the failed retry.
-    let payout = client.get_payout(&idempotency_key, &winner).unwrap();
+    let payout = client.get_payout(&ctx, &pool_id, &round_id, &winner).unwrap();
     assert_eq!(payout.amount, amount);
 }
 
@@ -120,31 +144,24 @@ fn test_idempotency_prevents_double_pay_same_amount() {
 fn test_idempotency_prevents_double_pay_different_amount() {
     let (env, admin, client) = setup();
     let winner = Address::generate(&env);
-    let idempotency_key = 99u32;
+    let ctx = symbol_short!("arena_1");
+    let pool_id = 99u32;
+    let round_id = 1u32;
     let first_amount = 1000i128;
     let second_amount = 9999i128;
     let currency = symbol_short!("USDC");
 
-    client
-        .distribute_winnings(
-            &admin,
-            &idempotency_key,
-            &winner,
-            &first_amount,
-            &currency,
-        );
+    client.distribute_winnings(
+        &admin, &ctx, &pool_id, &round_id, &winner, &first_amount, &currency,
+    );
 
     let second_attempt = client.try_distribute_winnings(
-        &admin,
-        &idempotency_key,
-        &winner,
-        &second_amount,
-        &currency,
+        &admin, &ctx, &pool_id, &round_id, &winner, &second_amount, &currency,
     );
     assert_eq!(second_attempt, Err(Ok(PayoutError::AlreadyPaid)));
 
     // Balance-equivalent assertion: only the original payout record is retained.
-    let payout = client.get_payout(&idempotency_key, &winner).unwrap();
+    let payout = client.get_payout(&ctx, &pool_id, &round_id, &winner).unwrap();
     assert_eq!(payout.amount, first_amount);
 }
 


### PR DESCRIPTION
## Summary

- Add `caller.require_auth()` to `distribute_winnings` in the Payout contract to prevent admin address spoofing
- Add test verifying that passing the admin address without a valid signature is rejected
- Fix broken test references to match the current API signature

## Problem

The `distribute_winnings` function checked `if caller != admin` but never called `caller.require_auth()`. This meant any user could pass the admin's address as the `caller` argument, bypassing the identity check entirely and distributing arbitrary winnings to themselves.

## Changes

### `contract/payout/src/lib.rs`
- Added `caller.require_auth();` after the `caller != admin` check (line 232)
- This ensures the transaction must be cryptographically signed by the caller

### `contract/payout/src/test.rs`
- **Added** `test_admin_spoofing_rejected_without_auth` — creates an environment without `mock_all_auths()` and verifies that calling `distribute_winnings` with the real admin address (but no signature) fails
- **Fixed** `test_unauthorized_caller_cannot_distribute` — updated to use current API signature `(context, pool_id, round_id, winner)` instead of undefined `idempotency_key`
- **Fixed** `test_zero_amount_panics` — added missing `amount = 0i128` variable and correct API call
- **Fixed** `test_negative_amount_panics` — added missing `amount = -500i128` variable and correct API call
- **Fixed** `test_idempotency_prevents_double_pay_same_amount` — updated to use `(ctx, pool_id, round_id)` tuple
- **Fixed** `test_idempotency_prevents_double_pay_different_amount` — updated to use `(ctx, pool_id, round_id)` tuple

## Test plan

- [ ] `test_admin_spoofing_rejected_without_auth` — spoofed admin address without signing is rejected
- [ ] `test_unauthorized_caller_cannot_distribute` — non-admin caller is rejected
- [ ] `test_admin_can_distribute_winnings` — legitimate admin call succeeds
- [ ] All existing payout tests pass with corrected API signatures

Closes #314