### PR TITLE
Implement unstake() for Staking contract and frontend transaction composer

### DIFF
--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -42,6 +42,8 @@ dependencies = [
 name = "arena"
 version = "0.1.0"
 dependencies = [
+ "factory",
+ "payout",
  "proptest",
  "serde_json",
  "soroban-sdk",
@@ -597,6 +599,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 name = "factory"
 version = "0.1.0"
 dependencies = [
+ "arena",
  "soroban-sdk",
 ]
 

--- a/contract/staking/src/integration_tests.rs
+++ b/contract/staking/src/integration_tests.rs
@@ -104,3 +104,107 @@ fn integration_stake_flow_and_yield_mimic() {
     );
 }
 
+#[test]
+fn integration_unstake_after_yield() {
+    let (env, _admin, staker1, staker2, client, token_client) = setup();
+    let contract_address = client.address.clone();
+
+    let balance1_before = token_client.balance(&staker1);
+    let balance2_before = token_client.balance(&staker2);
+
+    // Both stakers deposit equal amounts.
+    let amount1 = 200_000_000i128;
+    let amount2 = 200_000_000i128;
+    let minted1 = client.stake(&staker1, &amount1);
+    let minted2 = client.stake(&staker2, &amount2);
+
+    assert_eq!(minted1, amount1); // first stake: shares == amount
+    assert_eq!(minted2, amount2); // equal ratio => same shares
+
+    // Mimic yield accrual: TOTAL_STAKED increases by 100M (50M effective per staker
+    // proportional to shares) without minting new shares.
+    let yield_amount = 100_000_000i128;
+    let new_total_staked = amount1 + amount2 + yield_amount; // 500M
+
+    env.as_contract(&contract_address, || {
+        env.storage()
+            .instance()
+            .set(&TOTAL_STAKED_KEY, &new_total_staked);
+    });
+
+    // Also mint yield tokens into the contract so the transfer can succeed.
+    let token_admin_client =
+        token::StellarAssetClient::new(&env, &client.token());
+    token_admin_client.mint(&contract_address, &yield_amount);
+
+    let total_shares_before = client.total_shares(); // 400M
+
+    // Staker1 unstakes ALL shares.
+    // Expected token_amount = minted1 * new_total_staked / total_shares
+    //                       = 200M * 500M / 400M = 250M
+    let returned1 = client.unstake(&staker1, &minted1);
+    let expected_returned1 = minted1
+        .checked_mul(new_total_staked)
+        .and_then(|v| v.checked_div(total_shares_before))
+        .expect("math");
+    assert_eq!(returned1, expected_returned1);
+    assert_eq!(returned1, 250_000_000); // principal 200M + yield 50M
+
+    // Staker1 balance restored with yield.
+    assert_eq!(
+        token_client.balance(&staker1),
+        balance1_before + 50_000_000 // net gain = yield portion
+    );
+
+    // Staker1 position fully removed.
+    assert_eq!(
+        client.get_position(&staker1),
+        StakePosition {
+            amount: 0,
+            shares: 0,
+        }
+    );
+
+    // Global totals reflect only staker2's remaining position.
+    let remaining_staked = new_total_staked - returned1; // 250M
+    let remaining_shares = total_shares_before - minted1; // 200M
+    assert_eq!(client.total_staked(), remaining_staked);
+    assert_eq!(client.total_shares(), remaining_shares);
+
+    // Staker2's position is unchanged (only staker1 unstaked).
+    let pos2 = client.get_position(&staker2);
+    assert_eq!(pos2.shares, minted2);
+    assert_eq!(pos2.amount, amount2);
+
+    // Staker2 partial unstake: half of their shares.
+    let half_shares2 = minted2 / 2; // 100M
+    // Expected: 100M * 250M / 200M = 125M
+    let returned2 = client.unstake(&staker2, &half_shares2);
+    let expected_returned2 = half_shares2
+        .checked_mul(remaining_staked)
+        .and_then(|v| v.checked_div(remaining_shares))
+        .expect("math");
+    assert_eq!(returned2, expected_returned2);
+    assert_eq!(returned2, 125_000_000);
+
+    // Staker2 balance: original - 200M (staked) + 125M (partial unstake)
+    assert_eq!(
+        token_client.balance(&staker2),
+        balance2_before - amount2 + returned2
+    );
+
+    // Staker2 position should be halved in shares, amount proportionally reduced.
+    let pos2_after = client.get_position(&staker2);
+    assert_eq!(pos2_after.shares, half_shares2); // 100M shares remain
+    // amount = original_amount * remaining_shares / original_shares = 200M * 100M / 200M = 100M
+    let expected_amount2 = amount2
+        .checked_mul(half_shares2)
+        .and_then(|v| v.checked_div(minted2))
+        .expect("math");
+    assert_eq!(pos2_after.amount, expected_amount2);
+
+    // Final totals
+    assert_eq!(client.total_staked(), remaining_staked - returned2); // 125M
+    assert_eq!(client.total_shares(), remaining_shares - half_shares2); // 100M
+}
+

--- a/contract/staking/src/lib.rs
+++ b/contract/staking/src/lib.rs
@@ -9,6 +9,7 @@ const TOKEN_KEY: Symbol = symbol_short!("TOKEN");
 const TOTAL_STAKED_KEY: Symbol = symbol_short!("T_STAKE");
 const TOTAL_SHARES_KEY: Symbol = symbol_short!("T_SHARE");
 const TOPIC_STAKED: Symbol = symbol_short!("STAKED");
+const TOPIC_UNSTAKED: Symbol = symbol_short!("UNSTAKD");
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -18,6 +19,8 @@ pub enum StakingError {
     NotInitialized = 2,
     InvalidAmount = 3,
     ZeroShareMint = 4,
+    InsufficientShares = 5,
+    ZeroShares = 6,
 }
 
 #[contracttype]
@@ -113,6 +116,75 @@ impl StakingContract {
         );
 
         Ok(minted_shares)
+    }
+
+    pub fn unstake(env: Env, staker: Address, shares: i128) -> Result<i128, StakingError> {
+        let token_contract = get_token_contract(&env)?;
+        staker.require_auth();
+
+        // Checks
+        if shares <= 0 {
+            return Err(StakingError::ZeroShares);
+        }
+
+        let position_key = DataKey::Position(staker.clone());
+        let position: StakePosition = env
+            .storage()
+            .persistent()
+            .get(&position_key)
+            .ok_or(StakingError::InsufficientShares)?;
+
+        if shares > position.shares {
+            return Err(StakingError::InsufficientShares);
+        }
+
+        let total_staked = Self::total_staked(env.clone())?;
+        let total_shares = Self::total_shares(env.clone())?;
+
+        // Compute token amount: shares * total_staked / total_shares
+        let token_amount = shares
+            .checked_mul(total_staked)
+            .and_then(|v| v.checked_div(total_shares))
+            .ok_or(StakingError::ZeroShareMint)?;
+
+        // Effects (before external call — CEI pattern)
+        let new_shares = position.shares - shares;
+        if new_shares == 0 {
+            env.storage().persistent().remove(&position_key);
+        } else {
+            let new_amount = position
+                .amount
+                .checked_mul(new_shares)
+                .and_then(|v| v.checked_div(position.shares))
+                .ok_or(StakingError::ZeroShareMint)?;
+            env.storage().persistent().set(
+                &position_key,
+                &StakePosition {
+                    amount: new_amount,
+                    shares: new_shares,
+                },
+            );
+        }
+
+        env.storage()
+            .instance()
+            .set(&TOTAL_STAKED_KEY, &(total_staked - token_amount));
+        env.storage()
+            .instance()
+            .set(&TOTAL_SHARES_KEY, &(total_shares - shares));
+
+        // Interaction
+        let contract_address = env.current_contract_address();
+        let token_client = token::TokenClient::new(&env, &token_contract);
+        token_client.transfer(&contract_address, &staker, &token_amount);
+
+        // Event
+        env.events().publish(
+            (TOPIC_UNSTAKED, staker, token_contract),
+            (token_amount, shares),
+        );
+
+        Ok(token_amount)
     }
 
     pub fn get_position(env: Env, staker: Address) -> StakePosition {

--- a/contract/staking/src/test.rs
+++ b/contract/staking/src/test.rs
@@ -116,3 +116,101 @@ fn stake_rejects_non_positive_amounts() {
         Err(Ok(StakingError::InvalidAmount))
     );
 }
+
+#[test]
+fn test_unstake_full_withdrawal() {
+    let (_env, _admin, staker, client, token_client) = setup();
+    let contract_address = client.address.clone();
+
+    let balance_before = token_client.balance(&staker);
+    let minted = client.stake(&staker, &250_000_000i128);
+    assert_eq!(minted, 250_000_000);
+
+    let returned = client.unstake(&staker, &minted);
+    assert_eq!(returned, 250_000_000);
+
+    // Token balance fully restored
+    assert_eq!(token_client.balance(&staker), balance_before);
+    assert_eq!(token_client.balance(&contract_address), 0);
+
+    // Position removed — defaults to (0, 0)
+    assert_eq!(
+        client.get_position(&staker),
+        StakePosition {
+            amount: 0,
+            shares: 0,
+        }
+    );
+
+    // Global totals reset
+    assert_eq!(client.total_staked(), 0);
+    assert_eq!(client.total_shares(), 0);
+}
+
+#[test]
+fn test_unstake_partial() {
+    let (_env, _admin, staker, client, token_client) = setup();
+    let contract_address = client.address.clone();
+
+    let balance_before = token_client.balance(&staker);
+    let minted = client.stake(&staker, &250_000_000i128);
+    let half_shares = minted / 2; // 125_000_000
+
+    let returned = client.unstake(&staker, &half_shares);
+    assert_eq!(returned, 125_000_000);
+
+    // Half the tokens returned
+    assert_eq!(
+        token_client.balance(&staker),
+        balance_before - 125_000_000
+    );
+    assert_eq!(token_client.balance(&contract_address), 125_000_000);
+
+    // Position halved
+    let pos = client.get_position(&staker);
+    assert_eq!(pos.shares, 125_000_000);
+    assert_eq!(pos.amount, 125_000_000);
+
+    // Global totals halved
+    assert_eq!(client.total_staked(), 125_000_000);
+    assert_eq!(client.total_shares(), 125_000_000);
+}
+
+#[test]
+fn test_unstake_insufficient_shares() {
+    let (_env, _admin, staker, client, _token_client) = setup();
+
+    client.stake(&staker, &100_000_000i128);
+
+    assert_eq!(
+        client.try_unstake(&staker, &200_000_000i128),
+        Err(Ok(StakingError::InsufficientShares))
+    );
+}
+
+#[test]
+fn test_unstake_zero_shares() {
+    let (_env, _admin, staker, client, _token_client) = setup();
+
+    assert_eq!(
+        client.try_unstake(&staker, &0i128),
+        Err(Ok(StakingError::ZeroShares))
+    );
+
+    // Negative shares also rejected
+    assert_eq!(
+        client.try_unstake(&staker, &-1i128),
+        Err(Ok(StakingError::ZeroShares))
+    );
+}
+
+#[test]
+fn test_unstake_no_position() {
+    let (_env, _admin, staker, client, _token_client) = setup();
+
+    // Never staked — no position exists
+    assert_eq!(
+        client.try_unstake(&staker, &100i128),
+        Err(Ok(StakingError::InsufficientShares))
+    );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -821,6 +821,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/@creit-tech/stellar-wallets-kit/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@creit.tech/xbull-wallet-connect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.4.0.tgz",

--- a/frontend/src/shared-d/utils/__tests__/soroban-transaction-composer.test.ts
+++ b/frontend/src/shared-d/utils/__tests__/soroban-transaction-composer.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "@jest/globals";
 import { Account, Contract } from "@stellar/stellar-sdk";
 import {
   buildJoinCallOperation,
+  buildStakeCallOperation,
+  buildUnstakeCallOperation,
   composeUnsignedTransaction,
   roundSpeedToSeconds,
   buildCreatePoolCallOperation,
@@ -53,5 +55,41 @@ describe("soroban-transaction-composer", () => {
 
     expect(op).toBeDefined();
     expect(typeof (op as { body?: unknown }).body).toBe("function");
+  });
+
+  it("buildStakeCallOperation returns an invoke operation", () => {
+    const staking = new Contract(VALID_CONTRACT);
+    const op = buildStakeCallOperation(
+      staking,
+      BigInt(250_000_000),
+      "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    );
+
+    expect(op).toBeDefined();
+    expect(typeof (op as { body?: unknown }).body).toBe("function");
+  });
+
+  it("buildUnstakeCallOperation returns an invoke operation", () => {
+    const staking = new Contract(VALID_CONTRACT);
+    const op = buildUnstakeCallOperation(
+      staking,
+      BigInt(125_000_000),
+      "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    );
+
+    expect(op).toBeDefined();
+    expect(typeof (op as { body?: unknown }).body).toBe("function");
+  });
+
+  it("buildUnstakeCallOperation accepts zero-value bigint without throwing", () => {
+    const staking = new Contract(VALID_CONTRACT);
+    // The composer layer doesn't validate amounts — that's the contract's job.
+    const op = buildUnstakeCallOperation(
+      staking,
+      BigInt(0),
+      "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    );
+
+    expect(op).toBeDefined();
   });
 });

--- a/frontend/src/shared-d/utils/soroban-transaction-composer.ts
+++ b/frontend/src/shared-d/utils/soroban-transaction-composer.ts
@@ -76,6 +76,18 @@ export function buildStakeCallOperation(
   );
 }
 
+export function buildUnstakeCallOperation(
+  stakingContract: Contract,
+  sharesStroops: bigint,
+  stakerPublicKey: string,
+): Operation {
+  return stakingContract.call(
+    "unstake",
+    encodeAddress(stakerPublicKey),
+    encodeAmount(sharesStroops),
+  );
+}
+
 export function buildJoinCallOperation(poolContract: Contract): Operation {
   return poolContract.call("join");
 }

--- a/frontend/src/shared-d/utils/stellar-transactions.ts
+++ b/frontend/src/shared-d/utils/stellar-transactions.ts
@@ -42,6 +42,7 @@ import {
   buildJoinCallOperation,
   buildStakeCallOperation,
   buildSubmitChoiceCallOperation,
+  buildUnstakeCallOperation,
   composeUnsignedTransaction,
 } from "@/shared-d/utils/soroban-transaction-composer";
 import { CreatePoolParamsSchema } from "@/shared-d/utils/stellar-transaction-schemas";
@@ -162,6 +163,56 @@ export async function buildStakeProtocolTransaction(
     const operation = buildStakeCallOperation(
       stakingContract,
       amountStroops,
+      validatedPublicKey,
+    );
+
+    const builtTx = composeUnsignedTransaction(account, {
+      fee: getDefaultInvokeBaseFee(),
+      networkPassphrase: NETWORK_PASSPHRASE,
+      timeout: getInfiniteTimeout(),
+      operation,
+    });
+
+    return server.prepareTransaction(builtTx);
+  } catch (error) {
+    throw parseContractError(error, FN);
+  }
+}
+
+/**
+ * Build an unsigned transaction to unstake shares via the protocol contract.
+ * Uses Soroban prepareTransaction for correct footprint and fees.
+ */
+export async function buildUnstakeProtocolTransaction(
+  publicKey: string,
+  shares: bigint,
+) {
+  const FN = "buildUnstakeProtocolTransaction";
+  try {
+    const validatedPublicKey = StellarPublicKeySchema.parse(publicKey);
+
+    if (
+      !STAKING_CONTRACT_ID ||
+      STAKING_CONTRACT_ID === STAKING_CONTRACT_PLACEHOLDER ||
+      STAKING_CONTRACT_ID.includes("...")
+    ) {
+      throw new ContractError({
+        code: ContractErrorCode.CONFIG_MISSING,
+        message:
+          "Staking contract not configured. Add NEXT_PUBLIC_STAKING_CONTRACT_ID to .env.local with your Soroban contract address.",
+        fn: FN,
+      });
+    }
+
+    const server = defaultSorobanClients.createRpcServer();
+    const account = await getAccount(validatedPublicKey, FN);
+    const stakingContract = defaultSorobanClients.createContract(
+      STAKING_CONTRACT_ID,
+    );
+
+    const operation = buildUnstakeCallOperation(
+      stakingContract,
+      shares,
       validatedPublicKey,
     );
 


### PR DESCRIPTION
This PR adds the `unstake()` entry point to the Soroban staking contract in `contract/staking/src/lib.rs` and wires it through the frontend transaction layer. The contract function takes a staker address and a share count, computes the proportional token amount via `shares * total_staked / total_shares`, updates (or removes) the caller's `StakePosition`, decrements the global `TOTAL_STAKED` / `TOTAL_SHARES` counters, and transfers tokens back to the staker — all following the Checks-Effects-Interactions pattern so state is committed before the external `token::transfer` call. Two new error variants (`InsufficientShares`, `ZeroShares`) and a `TOPIC_UNSTAKED` event round out the contract side.

On the frontend, `buildUnstakeCallOperation()` was added to `soroban-transaction-composer.ts` mirroring the existing `buildStakeCallOperation` signature, and `buildUnstakeProtocolTransaction()` in `stellar-transactions.ts` handles RPC preparation with the same config-validation and error-wrapping pattern already used by `buildStakeProtocolTransaction`. Jest tests in `soroban-transaction-composer.test.ts` confirm both the stake and unstake composers produce valid invoke operations, including a zero-value edge case that proves the composer delegates validation to the contract rather than throwing client-side.

The contract is covered by five unit tests in `test.rs` (full withdrawal, partial withdrawal, insufficient-shares rejection, zero-shares rejection, no-position rejection) and one integration test in `integration_tests.rs` that simulates yield accrual by bumping `TOTAL_STAKED` without minting shares, then asserts that two stakers each receive the correct principal-plus-yield amounts through full and partial unstake sequences. All Rust tests were run locally with `cargo test` inside the `contract/` workspace and pass without panics.

Closes https://github.com/INVERSEARENA/inversearena-frontend/issues/340