### PR TITLE
fix(contract): remove duplicate ArenaState struct and fixed compilation

### DIFF
--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -96,16 +96,6 @@ pub struct RoundState {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ArenaState {
-    pub survivors_count: u32,
-    pub max_capacity: u32,
-    pub round_number: u32,
-    pub current_stake: i128,
-    pub potential_payout: i128,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ArenaStateView {
     pub survivors_count: u32,
     pub max_capacity: u32,


### PR DESCRIPTION
Closes #333 

## Summary
- Removed both duplicate \`ArenaState\` struct definitions (lines 138–154) that caused a hard compiler error
- Fixed additional merge artifacts: duplicate imports, duplicate \`GAME_STATUS_KEY\` constant, duplicate \`Survivor(Address)\` enum variant, and duplicate \`set_winner\` method
- Added missing \`mod bounds;\` declaration, \`player_can_submit\` helper, and event constants (\`TOPIC_WINNER_SET\`, \`TOPIC_CLAIM\`, \`EVENT_VERSION\`)
- Fixed move-after-use bug in \`submit_choice\` where \`player\` was consumed before being passed to \`player_can_submit\`
- All arena state reads use the existing \`ArenaStateView\` struct

## Test plan
- [x] \`cargo build\` passes without errors
- [x] Verify \`get_arena_state()\` returns \`ArenaStateView\` correctly
- [x] No remaining references to the removed \`ArenaState\` type in contract code

