### PR TITLE
Fix join() allowing late entries after game completion

### DIFF
--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -19,6 +19,7 @@ const CAPACITY_KEY: Symbol = symbol_short!("CAPACITY");
 const TOKEN_KEY: Symbol = symbol_short!("TOKEN");
 const PRIZE_POOL_KEY: Symbol = symbol_short!("PRIZE_P");
 const GAME_STATUS_KEY: Symbol = symbol_short!("G_STATUS");
+const GAME_FINISHED_KEY: Symbol = symbol_short!("G_FIN");
 
 // ── Timelock: 48 hours in seconds ─────────────────────────────────────────────
 const TIMELOCK_PERIOD: u64 = 48 * 60 * 60;
@@ -264,6 +265,14 @@ impl ArenaContract {
     pub fn join(env: Env, player: Address, amount: i128) -> Result<(), ArenaError> {
         player.require_auth();
         require_not_paused(&env)?;
+        if env
+            .storage()
+            .instance()
+            .get::<_, bool>(&GAME_FINISHED_KEY)
+            .unwrap_or(false)
+        {
+            return Err(ArenaError::GameAlreadyFinished);
+        }
         if amount <= 0 {
             return Err(ArenaError::InvalidAmount);
         }
@@ -314,6 +323,14 @@ impl ArenaContract {
 
     pub fn start_round(env: Env) -> Result<RoundState, ArenaError> {
         require_not_paused(&env)?;
+        if env
+            .storage()
+            .instance()
+            .get::<_, bool>(&GAME_FINISHED_KEY)
+            .unwrap_or(false)
+        {
+            return Err(ArenaError::GameAlreadyFinished);
+        }
         env.storage()
             .instance()
             .extend_ttl(GAME_TTL_THRESHOLD, GAME_TTL_EXTEND_TO);
@@ -426,6 +443,7 @@ impl ArenaContract {
         env.storage().instance().set(&PRIZE_POOL_KEY, &0i128);
         token::Client::new(&env, &token).transfer(&env.current_contract_address(), &winner, &prize);
         env.storage().instance().set(&GAME_STATUS_KEY, &false);
+        env.storage().instance().set(&GAME_FINISHED_KEY, &true);
         // Mark round as finished after prize is claimed
         if let Some(mut round) = storage(&env).get::<_, RoundState>(&DataKey::Round) {
             round.finished = true;

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -1666,6 +1666,39 @@ fn claim_already_claimed_returns_error() {
     assert_eq!(err, Err(Ok(ArenaError::AlreadyClaimed)));
 }
 
+#[test]
+fn join_rejects_after_game_is_finished() {
+    let (env, admin, client) = setup_with_admin();
+    let (asset, token_id) = setup_token(&env, &admin);
+    client.set_token(&token_id);
+
+    let winner = Address::generate(&env);
+    client.set_winner(&winner, &600i128, &400i128);
+    asset.mint(&client.address, &1_000i128);
+    client.claim(&winner);
+
+    let player = Address::generate(&env);
+    asset.mint(&player, &100i128);
+    let err = client.try_join(&player, &100i128);
+    assert_eq!(err, Err(Ok(ArenaError::GameAlreadyFinished)));
+}
+
+#[test]
+fn start_round_rejects_after_game_is_finished() {
+    let (env, admin, client) = setup_with_admin();
+    let (asset, token_id) = setup_token(&env, &admin);
+    client.set_token(&token_id);
+
+    client.init(&5);
+    let winner = Address::generate(&env);
+    client.set_winner(&winner, &600i128, &400i128);
+    asset.mint(&client.address, &1_000i128);
+    client.claim(&winner);
+
+    let err = client.try_start_round();
+    assert_eq!(err, Err(Ok(ArenaError::GameAlreadyFinished)));
+}
+
 // ── Issue #XXX: join() CEI ordering and retry after failed join ───────────────
 
 #[test]


### PR DESCRIPTION
Description
Prevent players from joining or starting new rounds after the arena has been finished by a successful claim.

Changes
- Added a durable `GAME_FINISHED_KEY` flag in `claim()` after payout succeeds.
- Added guards in `join()` and `start_round()` to return `GameAlreadyFinished` once the game is finished.
- Added tests covering `join()` after claim and `start_round()` after claim.

Closes
- Closes #361

Notes
- `GAME_STATUS_KEY` remains the reentrancy guard and is separate from the new permanent finished-state flag.