### PR TITLE
fix: harden arena round lifecycle and bounds

### DIFF
--- a/contract/arena/abi_snapshot.json
+++ b/contract/arena/abi_snapshot.json
@@ -21,7 +21,10 @@
     "NotASurvivor": 17,
     "GameAlreadyFinished": 18,
     "TokenNotSet": 19,
-    "MaxSubmissionsPerRound": 20
+    "MaxSubmissionsPerRound": 20,
+    "PlayerEliminated": 21,
+    "WrongRoundNumber": 22,
+    "NotEnoughPlayers": 23
   },
   "event_topics": [
     "UP_PROP",
@@ -29,9 +32,9 @@
     "UP_CANC",
     "PAUSED",
     "UNPAUSED",
-    "G_END",
     "R_START",
     "R_TOUT",
+    "RSLVD",
     "WIN_SET",
     "CLAIM"
   ],
@@ -52,6 +55,7 @@
     "start_round",
     "submit_choice",
     "timeout_round",
+    "resolve_round",
     "get_config",
     "get_round",
     "get_choice",

--- a/contract/arena/src/abi_guard.rs
+++ b/contract/arena/src/abi_guard.rs
@@ -19,7 +19,10 @@ fn arena_error_codes_match_abi_snapshot() {
         ("RoundAlreadyActive", ArenaError::RoundAlreadyActive),
         ("NoActiveRound", ArenaError::NoActiveRound),
         ("SubmissionWindowClosed", ArenaError::SubmissionWindowClosed),
-        ("SubmissionAlreadyExists", ArenaError::SubmissionAlreadyExists),
+        (
+            "SubmissionAlreadyExists",
+            ArenaError::SubmissionAlreadyExists,
+        ),
         ("RoundStillOpen", ArenaError::RoundStillOpen),
         ("RoundDeadlineOverflow", ArenaError::RoundDeadlineOverflow),
         ("NotInitialized", ArenaError::NotInitialized),
@@ -34,6 +37,9 @@ fn arena_error_codes_match_abi_snapshot() {
         ("GameAlreadyFinished", ArenaError::GameAlreadyFinished),
         ("TokenNotSet", ArenaError::TokenNotSet),
         ("MaxSubmissionsPerRound", ArenaError::MaxSubmissionsPerRound),
+        ("PlayerEliminated", ArenaError::PlayerEliminated),
+        ("WrongRoundNumber", ArenaError::WrongRoundNumber),
+        ("NotEnoughPlayers", ArenaError::NotEnoughPlayers),
     ];
 
     assert_eq!(
@@ -47,7 +53,8 @@ fn arena_error_codes_match_abi_snapshot() {
             .get(*name)
             .unwrap_or_else(|| panic!("missing arena_error key {name}"))
             .as_u64()
-            .unwrap_or_else(|| panic!("arena_error[{name}] must be a u64")) as u32;
+            .unwrap_or_else(|| panic!("arena_error[{name}] must be a u64"))
+            as u32;
         assert_eq!(code, *expected as u32, "mismatch for {name}");
     }
 }
@@ -80,6 +87,7 @@ fn exported_functions_match_abi_snapshot() {
         "start_round",
         "submit_choice",
         "timeout_round",
+        "resolve_round",
         "get_config",
         "get_round",
         "get_choice",
@@ -89,7 +97,10 @@ fn exported_functions_match_abi_snapshot() {
         "pending_upgrade",
     ];
 
-    assert_eq!(names, expected, "exported_functions snapshot drift — bump schema_version if intentional");
+    assert_eq!(
+        names, expected,
+        "exported_functions snapshot drift — bump schema_version if intentional"
+    );
 }
 
 #[test]
@@ -104,17 +115,12 @@ fn event_topics_match_abi_snapshot() {
         .collect();
 
     let expected: &[&str] = &[
-        "UP_PROP",
-        "UP_EXEC",
-        "UP_CANC",
-        "PAUSED",
-        "UNPAUSED",
-        "G_END",
-        "R_START",
-        "R_TOUT",
-        "WIN_SET",
-        "CLAIM",
+        "UP_PROP", "UP_EXEC", "UP_CANC", "PAUSED", "UNPAUSED", "R_START", "R_TOUT", "RSLVD",
+        "WIN_SET", "CLAIM",
     ];
 
-    assert_eq!(names, expected, "event_topics snapshot drift — bump schema_version if intentional");
+    assert_eq!(
+        names, expected,
+        "event_topics snapshot drift — bump schema_version if intentional"
+    );
 }

--- a/contract/arena/src/bounds.rs
+++ b/contract/arena/src/bounds.rs
@@ -3,6 +3,9 @@
 //! Documented in `contract/BOUNDS.md`. Production limits use the `not(test)` values.
 //! Unit tests compile with **lower** caps so boundary cases (N−1, N, N+1) stay fast in CI.
 
+/// Minimum registered survivors needed for a resolvable arena round.
+pub const MIN_ARENA_PARTICIPANTS: u32 = 2;
+
 /// Maximum registered survivors (`DataKey::Survivor` entries + `S_COUNT`).
 #[cfg(test)]
 pub const MAX_ARENA_PARTICIPANTS: u32 = 64;

--- a/contract/arena/src/integration_tests.rs
+++ b/contract/arena/src/integration_tests.rs
@@ -8,6 +8,8 @@
 
 extern crate std;
 
+use std::vec;
+
 use factory::{FactoryContract, FactoryContractClient};
 use payout::{PayoutContract, PayoutContractClient};
 use soroban_sdk::{
@@ -78,6 +80,20 @@ fn deploy_arena(
     arena
 }
 
+fn join_players(
+    env: &Env,
+    arena: &ArenaContractClient<'_>,
+    token: &StellarAssetClient<'_>,
+    players: &[Address],
+    stake: i128,
+) {
+    env.mock_all_auths();
+    for player in players {
+        token.mint(player, &(stake * 10));
+        arena.join(player, &stake);
+    }
+}
+
 // ── AC: Full lifecycle runs without error ─────────────────────────────────────
 
 /// Complete game lifecycle: factory creates pool → arena runs 3 rounds with
@@ -91,9 +107,13 @@ fn lifecycle_full_game_three_rounds_eight_players() {
     let admin = Address::generate(&env);
     let (_factory, payout) = deploy_all(&env, &admin);
 
-    let xlm_address = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token = StellarAssetClient::new(&env, &xlm_address);
     let round_speed = 10u32;
-    let capacity = 8u32;
+    let _capacity = 8u32;
     let stake = 10_000_000i128;
 
     let arena = deploy_arena(&env, &admin, round_speed, &xlm_address);
@@ -101,6 +121,7 @@ fn lifecycle_full_game_three_rounds_eight_players() {
     // ── Step 2: Rounds ────────────────────────────────────────────────────────
     // Generate 8 players.
     let players: std::vec::Vec<Address> = (0..8).map(|_| Address::generate(&env)).collect();
+    join_players(&env, &arena, &token, &players, stake);
 
     // ── Step 3: Round 1 — all 8 players submit ────────────────────────────────
     set_seq(&env, 1_010);
@@ -125,6 +146,7 @@ fn lifecycle_full_game_three_rounds_eight_players() {
     // ── Step 6: Payout — distribute winnings using the payout contract ───────
     let winner = players[0].clone();
     let prize_amount = 80_000_000i128;
+    token.mint(&payout.address, &prize_amount);
 
     payout.set_treasury(&admin); // Dust goes to admin for this test
     payout.distribute_prize(
@@ -177,7 +199,12 @@ fn test_payout_rounding_and_dust() {
     payout.set_treasury(&treasury);
 
     let total_prize = 100i128;
-    let currency = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token = StellarAssetClient::new(&env, &currency);
+    token.mint(&payout.address, &total_prize);
     let winners = soroban_sdk::vec![
         &env,
         Address::generate(&env),
@@ -198,8 +225,14 @@ fn test_emergency_pause_and_resume() {
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let (_factory, _) = deploy_all(&env, &admin);
-    let xlm_address = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token = StellarAssetClient::new(&env, &xlm_address);
     let arena = deploy_arena(&env, &admin, 10u32, &xlm_address);
+    let players = vec![Address::generate(&env), Address::generate(&env)];
+    join_players(&env, &arena, &token, &players, 100i128);
 
     // Pause
     arena.pause();

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -4,7 +4,7 @@ mod bounds;
 mod invariants;
 
 use soroban_sdk::{
-    Address, BytesN, Env, Symbol, contract, contracterror, contractimpl, contracttype,
+    Address, BytesN, Env, Symbol, Vec, contract, contracterror, contractimpl, contracttype,
     symbol_short, token,
 };
 
@@ -33,6 +33,9 @@ const TOPIC_UPGRADE_EXECUTED: Symbol = symbol_short!("UP_EXEC");
 const TOPIC_UPGRADE_CANCELLED: Symbol = symbol_short!("UP_CANC");
 const TOPIC_PAUSED: Symbol = symbol_short!("PAUSED");
 const TOPIC_UNPAUSED: Symbol = symbol_short!("UNPAUSED");
+const TOPIC_ROUND_STARTED: Symbol = symbol_short!("R_START");
+const TOPIC_ROUND_TIMEOUT: Symbol = symbol_short!("R_TOUT");
+const TOPIC_ROUND_RESOLVED: Symbol = symbol_short!("RSLVD");
 const TOPIC_WINNER_SET: Symbol = symbol_short!("WIN_SET");
 const TOPIC_CLAIM: Symbol = symbol_short!("CLAIM");
 
@@ -66,6 +69,7 @@ pub enum ArenaError {
     MaxSubmissionsPerRound = 20,
     PlayerEliminated = 21,
     WrongRoundNumber = 22,
+    NotEnoughPlayers = 23,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -130,6 +134,8 @@ enum DataKey {
     Config,
     Round,
     Submission(u32, Address),
+    HeadsSubmitters(u32),
+    TailsSubmitters(u32),
     Survivor(Address),
     PrizeClaimed(Address),
     Winner(Address),
@@ -228,14 +234,18 @@ impl ArenaContract {
         env.storage().instance().set(&TOKEN_KEY, &token);
     }
 
-    pub fn set_capacity(env: Env, capacity: u32) {
+    pub fn set_capacity(env: Env, capacity: u32) -> Result<(), ArenaError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&ADMIN_KEY)
-            .expect("not initialized");
+            .ok_or(ArenaError::NotInitialized)?;
         admin.require_auth();
+        if !(bounds::MIN_ARENA_PARTICIPANTS..=bounds::MAX_ARENA_PARTICIPANTS).contains(&capacity) {
+            return Err(ArenaError::InvalidAmount);
+        }
         env.storage().instance().set(&CAPACITY_KEY, &capacity);
+        Ok(())
     }
 
     pub fn set_winner(
@@ -322,6 +332,14 @@ impl ArenaContract {
         if previous_round.active {
             return Err(ArenaError::RoundAlreadyActive);
         }
+        let survivor_count: u32 = env
+            .storage()
+            .instance()
+            .get(&SURVIVOR_COUNT_KEY)
+            .unwrap_or(0u32);
+        if survivor_count < bounds::MIN_ARENA_PARTICIPANTS {
+            return Err(ArenaError::NotEnoughPlayers);
+        }
         let round_start_ledger = env.ledger().sequence();
         let round_deadline_ledger = round_start_ledger
             .checked_add(config.round_speed_in_ledgers)
@@ -337,6 +355,15 @@ impl ArenaContract {
         };
         storage(&env).set(&DataKey::Round, &next_round);
         bump(&env, &DataKey::Round);
+        env.events().publish(
+            (TOPIC_ROUND_STARTED,),
+            (
+                next_round.round_number,
+                next_round.round_start_ledger,
+                next_round.round_deadline_ledger,
+                EVENT_VERSION,
+            ),
+        );
         Ok(next_round)
     }
 
@@ -358,6 +385,9 @@ impl ArenaContract {
         if round_number != round.round_number {
             return Err(ArenaError::WrongRoundNumber);
         }
+        if !storage(&env).has(&DataKey::Survivor(player.clone())) {
+            return Err(ArenaError::PlayerEliminated);
+        }
         if env.ledger().sequence() > round.round_deadline_ledger {
             return Err(ArenaError::SubmissionWindowClosed);
         }
@@ -370,6 +400,14 @@ impl ArenaContract {
         }
         storage(&env).set(&submission_key, &choice);
         bump(&env, &submission_key);
+        let submitters_key = match choice {
+            Choice::Heads => DataKey::HeadsSubmitters(round.round_number),
+            Choice::Tails => DataKey::TailsSubmitters(round.round_number),
+        };
+        let mut submitters = get_submitters(&env, &submitters_key);
+        submitters.push_back(player.clone());
+        storage(&env).set(&submitters_key, &submitters);
+        bump(&env, &submitters_key);
         round.total_submissions += 1;
         storage(&env).set(&DataKey::Round, &round);
         bump(&env, &DataKey::Round);
@@ -392,6 +430,83 @@ impl ArenaContract {
         round.timed_out = true;
         storage(&env).set(&DataKey::Round, &round);
         bump(&env, &DataKey::Round);
+        env.events().publish(
+            (TOPIC_ROUND_TIMEOUT,),
+            (round.round_number, round.total_submissions, EVENT_VERSION),
+        );
+        Ok(round)
+    }
+
+    pub fn resolve_round(env: Env) -> Result<RoundState, ArenaError> {
+        require_not_paused(&env)?;
+        env.storage()
+            .instance()
+            .extend_ttl(GAME_TTL_THRESHOLD, GAME_TTL_EXTEND_TO);
+        let mut round = get_round(&env)?;
+        if round.finished {
+            return Err(ArenaError::GameAlreadyFinished);
+        }
+        if round.active {
+            if env.ledger().sequence() <= round.round_deadline_ledger {
+                return Err(ArenaError::RoundStillOpen);
+            }
+            round.active = false;
+            round.timed_out = true;
+        }
+
+        let heads_key = DataKey::HeadsSubmitters(round.round_number);
+        let tails_key = DataKey::TailsSubmitters(round.round_number);
+        let heads_submitters = get_submitters(&env, &heads_key);
+        let tails_submitters = get_submitters(&env, &tails_key);
+        let heads_count = heads_submitters.len();
+        let tails_count = tails_submitters.len();
+
+        let surviving_choice =
+            choose_surviving_side(&env, round.round_number, heads_count, tails_count);
+        let eliminated_players = match surviving_choice {
+            Some(Choice::Heads) => tails_submitters,
+            Some(Choice::Tails) => heads_submitters,
+            None => Vec::new(&env),
+        };
+
+        let mut eliminated_count = 0u32;
+        for player in eliminated_players.iter() {
+            let survivor_key = DataKey::Survivor(player.clone());
+            if storage(&env).has(&survivor_key) {
+                storage(&env).remove(&survivor_key);
+                eliminated_count += 1;
+            }
+        }
+
+        let survivor_count: u32 = env
+            .storage()
+            .instance()
+            .get(&SURVIVOR_COUNT_KEY)
+            .unwrap_or(0u32);
+        let updated_survivor_count = survivor_count
+            .checked_sub(eliminated_count)
+            .ok_or(ArenaError::InvalidAmount)?;
+        env.storage()
+            .instance()
+            .set(&SURVIVOR_COUNT_KEY, &updated_survivor_count);
+
+        round.finished = true;
+        storage(&env).set(&DataKey::Round, &round);
+        bump(&env, &DataKey::Round);
+
+        env.events().publish(
+            (TOPIC_ROUND_RESOLVED,),
+            (
+                round.round_number,
+                heads_count,
+                tails_count,
+                outcome_symbol(&surviving_choice),
+                eliminated_count,
+                updated_survivor_count,
+                EVENT_VERSION,
+            ),
+        );
+
         Ok(round)
     }
 
@@ -594,12 +709,48 @@ fn require_not_paused(env: &Env) -> Result<(), ArenaError> {
     Ok(())
 }
 
+fn get_submitters(env: &Env, key: &DataKey) -> Vec<Address> {
+    storage(env).get(key).unwrap_or(Vec::new(env))
+}
+
+fn choose_surviving_side(
+    env: &Env,
+    round_number: u32,
+    heads_count: u32,
+    tails_count: u32,
+) -> Option<Choice> {
+    match (heads_count, tails_count) {
+        (0, 0) => None,
+        (0, _) => Some(Choice::Tails),
+        (_, 0) => Some(Choice::Heads),
+        _ if heads_count == tails_count => {
+            if ((env.ledger().sequence() ^ round_number) & 1) == 0 {
+                Some(Choice::Heads)
+            } else {
+                Some(Choice::Tails)
+            }
+        }
+        _ if heads_count < tails_count => Some(Choice::Heads),
+        _ => Some(Choice::Tails),
+    }
+}
+
+fn outcome_symbol(outcome: &Option<Choice>) -> Symbol {
+    match outcome {
+        Some(Choice::Heads) => symbol_short!("HEADS"),
+        Some(Choice::Tails) => symbol_short!("TAILS"),
+        None => symbol_short!("NONE"),
+    }
+}
+
 fn bump(env: &Env, key: &DataKey) {
     env.storage()
         .persistent()
         .extend_ttl(key, GAME_TTL_THRESHOLD, GAME_TTL_EXTEND_TO);
 }
 
+#[cfg(test)]
+mod abi_guard;
 #[cfg(all(test, feature = "integration-tests"))]
 mod integration_tests;
 #[cfg(test)]

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -127,6 +127,58 @@ fn setup_token<'a>(env: &'a Env, admin: &Address) -> (StellarAssetClient<'a>, Ad
     (asset, token_id)
 }
 
+fn seed_joined_players(
+    env: &Env,
+    client: &ArenaContractClient<'_>,
+    token_id: &Address,
+    player_count: u32,
+) -> Vec<Address> {
+    let asset = StellarAssetClient::new(env, token_id);
+    let mut players = Vec::new();
+    for _ in 0..player_count {
+        let player = Address::generate(env);
+        asset.mint(&player, &1_000_000i128);
+        client.join(&player, &100i128);
+        players.push(player);
+    }
+    players
+}
+
+fn configure_arena(
+    env: &Env,
+    client: &ArenaContractClient<'_>,
+    round_speed: u32,
+    player_count: u32,
+) -> (Address, Address, Vec<Address>) {
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    let (_asset, token_id) = setup_token(env, &admin);
+    client.set_token(&token_id);
+    client.init(&round_speed);
+    env.mock_all_auths();
+    let players = seed_joined_players(env, client, &token_id, player_count);
+    (admin, token_id, players)
+}
+
+fn setup_game(
+    round_speed: u32,
+    player_count: u32,
+) -> (
+    Env,
+    Address,
+    ArenaContractClient<'static>,
+    Address,
+    Vec<Address>,
+) {
+    let (env, admin, client) = setup_with_admin();
+    let (_asset, token_id) = setup_token(&env, &admin);
+    client.set_token(&token_id);
+    client.init(&round_speed);
+    env.mock_all_auths();
+    let players = seed_joined_players(&env, &client, &token_id, player_count);
+    (env, admin, client, token_id, players)
+}
+
 // ── round_speed bounds ────────────────────────────────────────────────────────
 
 #[test]
@@ -164,10 +216,8 @@ fn test_init_above_max_round_speed_returns_invalid() {
 
 #[test]
 fn basic_init_and_round_cycle() {
-    let env = make_env();
-    let client = create_client(&env);
+    let (env, _admin, client, _token_id, _players) = setup_game(5, 2);
     set_ledger(&env, 100);
-    client.init(&5);
     let r = client.start_round();
     assert_eq!(r.round_number, 1);
     assert!(r.active);
@@ -181,12 +231,8 @@ fn basic_init_and_round_cycle() {
 
 #[test]
 fn start_round_records_start_and_deadline_ledgers() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(5, 2);
     set_ledger_sequence(&env, 100);
-
-    client.init(&5);
     let round = client.start_round();
 
     assert_eq!(
@@ -205,14 +251,9 @@ fn start_round_records_start_and_deadline_ledgers() {
 
 #[test]
 fn submit_choice_allows_submission_on_deadline_ledger() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let client = create_client(&env);
-    let player = Address::generate(&env);
-
+    let (env, _admin, client, _token_id, players) = setup_game(5, 2);
+    let player = players[0].clone();
     set_ledger_sequence(&env, 200);
-    client.init(&5);
     client.start_round();
 
     set_ledger_sequence(&env, 205);
@@ -224,14 +265,9 @@ fn submit_choice_allows_submission_on_deadline_ledger() {
 
 #[test]
 fn submit_choice_rejects_late_submissions() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let client = create_client(&env);
-    let player = Address::generate(&env);
-
+    let (env, _admin, client, _token_id, players) = setup_game(5, 2);
+    let player = players[0].clone();
     set_ledger_sequence(&env, 300);
-    client.init(&5);
     client.start_round();
 
     set_ledger_sequence(&env, 306);
@@ -242,11 +278,8 @@ fn submit_choice_rejects_late_submissions() {
 
 #[test]
 fn timeout_round_is_callable_by_anyone_after_deadline() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(3, 2);
     set_ledger_sequence(&env, 400);
-    client.init(&3);
     client.start_round();
 
     set_ledger_sequence(&env, 404);
@@ -260,11 +293,8 @@ fn timeout_round_is_callable_by_anyone_after_deadline() {
 
 #[test]
 fn timeout_round_rejects_calls_before_deadline() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(4, 2);
     set_ledger_sequence(&env, 500);
-    client.init(&4);
     client.start_round();
 
     set_ledger_sequence(&env, 504);
@@ -275,11 +305,8 @@ fn timeout_round_rejects_calls_before_deadline() {
 
 #[test]
 fn new_round_can_start_after_timeout() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(2, 2);
     set_ledger_sequence(&env, 600);
-    client.init(&2);
     client.start_round();
 
     set_ledger_sequence(&env, 603);
@@ -310,15 +337,12 @@ fn data_model_doc_covers_required_sections() {
 
 #[test]
 fn state_survives_expected_game_duration() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let client = create_client(&env);
-    let player = Address::generate(&env);
+    let (env, _admin, client, _token_id, players) = setup_game(20_000, 2);
+    let player = players[0].clone();
 
     // Initialise and start a round at ledger 1_000.  Use a large round window
     // (20_000 ledgers) so the round remains open when we advance the ledger.
     set_ledger_sequence(&env, 1_000);
-    client.init(&20_000);
     client.start_round();
 
     // Submit a choice while still within the round window.
@@ -349,18 +373,21 @@ fn get_full_state_returns_combined_arena_and_user_state() {
     let (asset, token_id) = setup_token(&env, &admin);
     client.set_token(&token_id);
     let player = Address::generate(&env);
+    let other = Address::generate(&env);
     asset.mint(&player, &100i128);
+    asset.mint(&other, &100i128);
 
     set_ledger_sequence(&env, 800);
     client.init(&5);
 
     client.join(&player, &10i128);
+    client.join(&other, &10i128);
     client.start_round();
     client.submit_choice(&player, &1u32, &Choice::Heads);
 
     let full = client.get_full_state(&player);
     assert_eq!(full.round_number, 1);
-    assert_eq!(full.survivors_count, 1);
+    assert_eq!(full.survivors_count, 2);
     assert!(full.is_active);
     assert!(!full.has_won);
 }
@@ -510,7 +537,7 @@ proptest! {
         let env = make_env();
         let client = create_client(&env);
         set_ledger(&env, 1_000);
-        client.init(&round_speed);
+        let _ = configure_arena(&env, &client, round_speed, 2);
 
         let observed = run_cycles(&env, &client, round_speed, cycles);
 
@@ -536,16 +563,11 @@ proptest! {
         let client = create_client(&env);
 
         advance_ledger_with_auth(&env, 500);
-        client.init(&round_speed);
+        let survivor_count = core::cmp::max(player_count as u32, bounds::MIN_ARENA_PARTICIPANTS);
+        let (_, _, players) = configure_arena(&env, &client, round_speed, survivor_count);
         client.start_round();
 
-        let mut players: Vec<Address> = Vec::new();
-        for _ in 0..player_count {
-            let p = Address::generate(&env);
-            players.push(p);
-        }
-
-        for p in &players {
+        for p in players.iter().take(player_count) {
             client.submit_choice(p, &1u32, &Choice::Heads);
         }
 
@@ -569,10 +591,10 @@ proptest! {
         let client = create_client(&env);
 
         advance_ledger_with_auth(&env, 1_000);
-        client.init(&round_speed);
+        let (_, _, players) = configure_arena(&env, &client, round_speed, 2);
         client.start_round();
 
-        let player = Address::generate(&env);
+        let player = players[0].clone();
         client.submit_choice(&player, &1u32, &Choice::Heads);
 
         let result = client.try_submit_choice(&player, &1u32, &Choice::Tails);
@@ -598,10 +620,10 @@ proptest! {
         let client = create_client(&env);
 
         advance_ledger_with_auth(&env, 200);
-        client.init(&round_speed);
+        let (_, _, players) = configure_arena(&env, &client, round_speed, 2);
         client.start_round();
 
-        let player   = Address::generate(&env);
+        let player   = players[0].clone();
         let absent   = Address::generate(&env);
         let expected = if submit_heads { Choice::Heads } else { Choice::Tails };
 
@@ -626,12 +648,12 @@ proptest! {
         let client = create_client(&env);
 
         advance_ledger_with_auth(&env, 0);
-        client.init(&round_speed);
+        let survivor_count = core::cmp::max(player_count as u32, bounds::MIN_ARENA_PARTICIPANTS);
+        let (_, _, players) = configure_arena(&env, &client, round_speed, survivor_count);
         client.start_round();
 
-        for _ in 0..player_count {
-            let p = Address::generate(&env);
-            client.submit_choice(&p, &1u32, &Choice::Heads);
+        for p in players.iter().take(player_count) {
+            client.submit_choice(p, &1u32, &Choice::Heads);
         }
 
         let round = client.get_round();
@@ -658,12 +680,12 @@ proptest! {
         let client = create_client(&env);
 
         advance_ledger_with_auth(&env, 1_000);
-        client.init(&round_speed);
+        let survivor_count = core::cmp::max(early_submitters as u32, bounds::MIN_ARENA_PARTICIPANTS);
+        let (_, _, players) = configure_arena(&env, &client, round_speed, survivor_count);
         client.start_round();
 
-        for _ in 0..early_submitters {
-            let p = Address::generate(&env);
-            client.submit_choice(&p, &1u32, &Choice::Tails);
+        for p in players.iter().take(early_submitters) {
+            client.submit_choice(p, &1u32, &Choice::Tails);
         }
 
         advance_ledger_with_auth(&env, 1_000 + round_speed + 1);
@@ -732,7 +754,7 @@ proptest! {
         let client = create_client(&env);
 
         set_ledger(&env, start_ledger);
-        client.init(&round_speed);
+        let _ = configure_arena(&env, &client, round_speed, 2);
         let round = client.start_round();
 
         prop_assert_eq!(round.round_start_ledger, start_ledger);
@@ -756,7 +778,7 @@ proptest! {
         let client = create_client(&env);
 
         set_ledger(&env, 100);
-        client.init(&round_speed);
+        let _ = configure_arena(&env, &client, round_speed, 2);
         client.start_round();
 
         set_ledger(&env, 100 + round_speed);
@@ -780,7 +802,7 @@ fn smoke_10000_round_cycles_without_panic() {
     let client = create_client(&env);
 
     set_ledger(&env, 1_000);
-    client.init(&SPEED);
+    let _ = configure_arena(&env, &client, SPEED, 2);
 
     let numbers = run_cycles(&env, &client, SPEED, CYCLES);
 
@@ -855,11 +877,8 @@ fn test_unauthorized_cancel_upgrade_panics() {
 // AC: Timeout callable after deadline passes
 #[test]
 fn timeout_round_succeeds_one_ledger_after_deadline() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(10, 2);
     set_ledger_sequence(&env, 1000);
-    client.init(&10);
     client.start_round();
 
     // deadline = 1010; advance one past it
@@ -874,11 +893,8 @@ fn timeout_round_succeeds_one_ledger_after_deadline() {
 // AC: Timeout callable after deadline passes (exact boundary)
 #[test]
 fn timeout_round_succeeds_just_after_deadline() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(5, 2);
     set_ledger_sequence(&env, 500);
-    client.init(&5);
     client.start_round(); // deadline = 505
 
     set_ledger_sequence(&env, 506);
@@ -891,11 +907,8 @@ fn timeout_round_succeeds_just_after_deadline() {
 // AC: timeout_round fails before deadline (round still open)
 #[test]
 fn timeout_round_fails_at_deadline_ledger() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(4, 2);
     set_ledger_sequence(&env, 200);
-    client.init(&4);
     client.start_round(); // deadline = 204
 
     set_ledger_sequence(&env, 204); // exactly at deadline — still open
@@ -906,11 +919,8 @@ fn timeout_round_fails_at_deadline_ledger() {
 
 #[test]
 fn timeout_round_fails_before_deadline() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(20, 2);
     set_ledger_sequence(&env, 100);
-    client.init(&20);
     client.start_round(); // deadline = 120
 
     set_ledger_sequence(&env, 115);
@@ -938,14 +948,9 @@ fn timeout_round_fails_when_no_active_round() {
 // AC: Game resolves correctly after timeout — state is consistent
 #[test]
 fn round_state_is_consistent_after_timeout() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let client = create_client(&env);
-
-    let player = Address::generate(&env);
-
+    let (env, _admin, client, _token_id, players) = setup_game(5, 2);
+    let player = players[0].clone();
     set_ledger_sequence(&env, 300);
-    client.init(&5); // deadline = 305
     client.start_round();
 
     // player submits within window
@@ -970,14 +975,9 @@ fn round_state_is_consistent_after_timeout() {
 // AC: Funds remain accessible after timeout — choices/data still readable
 #[test]
 fn player_choice_accessible_after_timeout() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let client = create_client(&env);
-
-    let player = Address::generate(&env);
-
+    let (env, _admin, client, _token_id, players) = setup_game(3, 2);
+    let player = players[0].clone();
     set_ledger_sequence(&env, 400);
-    client.init(&3);
     client.start_round(); // deadline = 403
 
     set_ledger_sequence(&env, 401);
@@ -995,11 +995,8 @@ fn player_choice_accessible_after_timeout() {
 // AC: All-absent scenario — no submissions, game still resolves via timeout
 #[test]
 fn timeout_works_when_no_player_submitted() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(5, 2);
     set_ledger_sequence(&env, 600);
-    client.init(&5);
     let round = client.start_round(); // deadline = 605
     assert_eq!(round.total_submissions, 0);
 
@@ -1014,11 +1011,8 @@ fn timeout_works_when_no_player_submitted() {
 // AC: All-absent scenario — multiple players, none submit, timeout resolves
 #[test]
 fn timeout_with_multiple_absent_players_resolves_gracefully() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(8, 3);
     set_ledger_sequence(&env, 700);
-    client.init(&8); // deadline = 708
     client.start_round();
 
     // generate some player addresses but have none submit
@@ -1042,14 +1036,9 @@ fn timeout_with_multiple_absent_players_resolves_gracefully() {
 // AC: Submissions after timeout are rejected
 #[test]
 fn submit_choice_rejected_after_deadline() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let client = create_client(&env);
-
-    let player = Address::generate(&env);
-
+    let (env, _admin, client, _token_id, players) = setup_game(5, 2);
+    let player = players[0].clone();
     set_ledger_sequence(&env, 800);
-    client.init(&5); // deadline = 805
     client.start_round();
 
     set_ledger_sequence(&env, 806);
@@ -1061,11 +1050,8 @@ fn submit_choice_rejected_after_deadline() {
 // AC: New round starts cleanly after a timed-out round
 #[test]
 fn new_round_starts_after_timeout_with_fresh_state() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(5, 2);
     set_ledger_sequence(&env, 900);
-    client.init(&5); // deadline = 905
     client.start_round();
 
     set_ledger_sequence(&env, 906);
@@ -1085,11 +1071,8 @@ fn new_round_starts_after_timeout_with_fresh_state() {
 // AC: Starting a round while one is already active fails
 #[test]
 fn start_round_fails_when_active_round_exists() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(10, 2);
     set_ledger_sequence(&env, 1000);
-    client.init(&10);
     client.start_round();
 
     set_ledger_sequence(&env, 1005);
@@ -1101,11 +1084,8 @@ fn start_round_fails_when_active_round_exists() {
 // AC: timeout_round cannot be called twice on the same round
 #[test]
 fn timeout_round_fails_on_already_timed_out_round() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(3, 2);
     set_ledger_sequence(&env, 1100);
-    client.init(&3); // deadline = 1103
     client.start_round();
 
     set_ledger_sequence(&env, 1104);
@@ -1118,11 +1098,8 @@ fn timeout_round_fails_on_already_timed_out_round() {
 // AC: round number increments correctly across multiple timeout cycles
 #[test]
 fn round_number_increments_across_timeout_cycles() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(2, 2);
     set_ledger_sequence(&env, 0);
-    client.init(&2);
 
     for expected_round in 1u32..=5 {
         let start_seq = (expected_round - 1) * 10;
@@ -1140,16 +1117,12 @@ fn round_number_increments_across_timeout_cycles() {
 // AC: partial submissions followed by timeout — present choices preserved
 #[test]
 fn partial_submissions_preserved_after_timeout() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let client = create_client(&env);
-
-    let player_a = Address::generate(&env);
-    let player_b = Address::generate(&env);
+    let (env, _admin, client, _token_id, players) = setup_game(10, 3);
+    let player_a = players[0].clone();
+    let player_b = players[1].clone();
     let player_c = Address::generate(&env);
 
     set_ledger_sequence(&env, 2000);
-    client.init(&10); // deadline = 2010
     client.start_round();
 
     // only player_a and player_b submit
@@ -1167,12 +1140,137 @@ fn partial_submissions_preserved_after_timeout() {
     assert_eq!(client.get_choice(&1, &player_c), None); // absent
 }
 
+#[test]
+fn start_round_rejects_when_no_players_joined() {
+    let (env, admin, client) = setup_with_admin();
+    let (_asset, token_id) = setup_token(&env, &admin);
+    client.set_token(&token_id);
+    client.init(&5);
+
+    let err = client.try_start_round();
+    assert_eq!(err, Err(Ok(ArenaError::NotEnoughPlayers)));
+}
+
+#[test]
+fn start_round_rejects_when_only_one_player_joined() {
+    let (env, _admin, client, token_id, _players) = setup_game(5, 1);
+    let late = Address::generate(&env);
+    let asset = StellarAssetClient::new(&env, &token_id);
+    asset.mint(&late, &1_000_000i128);
+
+    let err = client.try_start_round();
+    assert_eq!(err, Err(Ok(ArenaError::NotEnoughPlayers)));
+}
+
+#[test]
+fn set_capacity_enforces_minimum_and_maximum_bounds() {
+    let (_env, _admin, client) = setup_with_admin();
+
+    assert_eq!(
+        client.try_set_capacity(&0),
+        Err(Ok(ArenaError::InvalidAmount))
+    );
+    assert_eq!(
+        client.try_set_capacity(&1),
+        Err(Ok(ArenaError::InvalidAmount))
+    );
+    assert!(client.try_set_capacity(&2).is_ok());
+    assert_eq!(
+        client.try_set_capacity(&(bounds::MAX_ARENA_PARTICIPANTS + 1)),
+        Err(Ok(ArenaError::InvalidAmount))
+    );
+}
+
+#[test]
+fn resolve_round_advances_minority_survivors() {
+    let (env, _admin, client, _token_id, players) = setup_game(5, 3);
+
+    set_ledger_sequence(&env, 10);
+    client.start_round();
+
+    client.submit_choice(&players[0], &1, &Choice::Heads);
+    client.submit_choice(&players[1], &1, &Choice::Tails);
+    client.submit_choice(&players[2], &1, &Choice::Tails);
+
+    set_ledger_sequence(&env, 16);
+    let resolved = client.resolve_round();
+
+    assert!(!resolved.active);
+    assert!(resolved.finished);
+    assert_eq!(client.get_arena_state().survivors_count, 1);
+    assert!(client.get_user_state(&players[0]).is_active);
+    assert!(!client.get_user_state(&players[1]).is_active);
+    assert!(!client.get_user_state(&players[2]).is_active);
+}
+
+#[test]
+fn resolve_round_tie_breaks_deterministically_from_ledger_sequence() {
+    let (env, _admin, client, _token_id, players) = setup_game(5, 2);
+
+    set_ledger_sequence(&env, 20);
+    client.start_round();
+    client.submit_choice(&players[0], &1, &Choice::Heads);
+    client.submit_choice(&players[1], &1, &Choice::Tails);
+
+    let resolve_ledger = 26;
+    set_ledger_sequence(&env, resolve_ledger);
+    client.resolve_round();
+
+    let heads_survive = ((resolve_ledger ^ 1) & 1) == 0;
+    assert_eq!(client.get_user_state(&players[0]).is_active, heads_survive);
+    assert_eq!(client.get_user_state(&players[1]).is_active, !heads_survive);
+}
+
+#[test]
+fn resolve_round_unanimous_choice_keeps_submitters_alive() {
+    let (env, _admin, client, _token_id, players) = setup_game(5, 3);
+
+    set_ledger_sequence(&env, 30);
+    client.start_round();
+    for player in &players {
+        client.submit_choice(player, &1, &Choice::Heads);
+    }
+
+    set_ledger_sequence(&env, 36);
+    client.resolve_round();
+
+    assert_eq!(client.get_arena_state().survivors_count, 3);
+    for player in &players {
+        assert!(client.get_user_state(player).is_active);
+    }
+}
+
+#[test]
+fn resolve_round_allows_next_round_only_for_remaining_survivors() {
+    let (env, _admin, client, _token_id, players) = setup_game(5, 5);
+
+    set_ledger_sequence(&env, 40);
+    client.start_round();
+    client.submit_choice(&players[0], &1, &Choice::Heads);
+    client.submit_choice(&players[1], &1, &Choice::Heads);
+    client.submit_choice(&players[2], &1, &Choice::Tails);
+    client.submit_choice(&players[3], &1, &Choice::Tails);
+    client.submit_choice(&players[4], &1, &Choice::Tails);
+
+    set_ledger_sequence(&env, 46);
+    client.resolve_round();
+
+    assert_eq!(client.get_arena_state().survivors_count, 2);
+
+    set_ledger_sequence(&env, 50);
+    let next_round = client.start_round();
+    assert_eq!(next_round.round_number, 2);
+    client.submit_choice(&players[0], &2, &Choice::Heads);
+
+    let err = client.try_submit_choice(&players[2], &2, &Choice::Tails);
+    assert_eq!(err, Err(Ok(ArenaError::PlayerEliminated)));
+}
+
 // ── Pause mechanism tests ───────────────────────────────────────────────────
 
 #[test]
 fn test_pause_unpause_admin_only() {
-    let (env, admin, client) = setup_with_admin();
-    let non_admin = Address::generate(&env);
+    let (_env, _admin, client) = setup_with_admin();
 
     assert!(!client.is_paused());
 
@@ -1185,8 +1283,7 @@ fn test_pause_unpause_admin_only() {
     assert!(!client.is_paused());
 
     // Non-admin cannot pause
-    env.mock_all_auths(); // Reset auths
-    let result = client.try_pause();
+    let _ = client.try_pause();
     // This should fail authorize if it was checked correctly,
     // but in tests with mock_all_auths we need to verify it specifically if we want,
     // however, the code uses admin.require_auth() where admin is the stored admin.
@@ -1210,7 +1307,6 @@ fn test_functions_fail_when_paused() {
     );
     assert_eq!(client.try_timeout_round(), Err(Ok(ArenaError::Paused)));
 
-    let hash = dummy_hash(&env);
     // These panic on failure in lib.rs if I used .unwrap(),
     // but I can use try_ versions to check Result.
     // Wait, in lib.rs I used require_not_paused(&env).unwrap() for proposals?
@@ -1220,9 +1316,7 @@ fn test_functions_fail_when_paused() {
 
 #[test]
 fn test_unpause_restores_functionality() {
-    let (env, _admin, client) = setup_with_admin();
-
-    client.init(&10);
+    let (_env, _admin, client, _token_id, _players) = setup_game(10, 2);
     client.pause();
     client.unpause();
 
@@ -1341,10 +1435,9 @@ fn test_paused_blocks_game_functions_not_governance() {
 /// After unpausing, all functions — game and governance — work normally.
 #[test]
 fn test_all_functions_work_after_unpause() {
-    let (env, _admin, client) = setup_with_admin();
+    let (env, _admin, client, _token_id, _players) = setup_game(10, 2);
     let hash = dummy_hash(&env);
 
-    client.init(&10u32);
     client.pause();
     client.unpause();
     assert!(!client.is_paused());
@@ -1432,11 +1525,8 @@ fn get_arena_state_defaults_before_any_action() {
 /// `round_number` in the returned state matches the value returned by `start_round`.
 #[test]
 fn get_arena_state_reflects_round_number() {
-    let env = Env::default();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(5, 2);
     set_ledger_sequence(&env, 100);
-    client.init(&5u32);
     let round = client.start_round();
 
     let state = client.get_arena_state();
@@ -1483,7 +1573,7 @@ fn get_arena_state_reflects_survivor_count() {
 /// After `set_capacity(n)`, `max_capacity` reflects that value.
 #[test]
 fn get_arena_state_reflects_capacity() {
-    let (env, _admin, client) = setup_with_admin();
+    let (_env, _admin, client) = setup_with_admin();
 
     assert_eq!(client.get_arena_state().max_capacity, 0, "default is 0");
 
@@ -1494,12 +1584,8 @@ fn get_arena_state_reflects_capacity() {
 /// Calling `get_arena_state` twice returns identical results with no side effects.
 #[test]
 fn get_arena_state_is_pure_read() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let client = create_client(&env);
-
+    let (env, _admin, client, _token_id, _players) = setup_game(10, 2);
     set_ledger_sequence(&env, 50);
-    client.init(&10u32);
     client.start_round();
 
     let state_a = client.get_arena_state();
@@ -1520,21 +1606,21 @@ fn submission_boundary_n_minus_1_n_n_plus_1() {
     assert!(cap >= 3, "bounds must allow a three-point boundary test");
 
     advance_ledger_with_auth(&env, 500);
-    client.init(&20);
+    let survivor_count = core::cmp::max(cap + 1, bounds::MIN_ARENA_PARTICIPANTS);
+    let (_, _, players) = configure_arena(&env, &client, 20, survivor_count);
     client.start_round();
 
     let n = cap - 1;
-    for _ in 0..n {
-        let p = Address::generate(&env);
+    for p in players.iter().take(n as usize) {
         client.submit_choice(&p, &1u32, &Choice::Heads);
     }
     assert_eq!(client.get_round().total_submissions, n);
 
-    let last_ok = Address::generate(&env);
+    let last_ok = players.get(n as usize).unwrap();
     client.submit_choice(&last_ok, &1u32, &Choice::Tails);
     assert_eq!(client.get_round().total_submissions, cap);
 
-    let too_many = Address::generate(&env);
+    let too_many = players.get(cap as usize).unwrap();
     let err = client.try_submit_choice(&too_many, &1u32, &Choice::Heads);
     assert_eq!(err, Err(Ok(ArenaError::MaxSubmissionsPerRound)));
 }
@@ -1574,10 +1660,8 @@ fn join_boundary_participants_n_minus_1_n_n_plus_1() {
 
 #[test]
 fn round_state_machine_invariant_suite_happy_path() {
-    let env = Env::default();
-    let client = create_client(&env);
+    let (env, _admin, client, _token_id, _players) = setup_game(5, 2);
     set_ledger_sequence(&env, 100);
-    client.init(&5);
     let r0 = client.get_round();
     invariants::check_round_flags(&r0).unwrap();
 
@@ -1640,6 +1724,12 @@ fn claim_last_winner_sets_round_finished() {
 
     // Before claim, start a round so RoundState exists.
     client.init(&5);
+    let participant_a = Address::generate(&env);
+    let participant_b = Address::generate(&env);
+    asset.mint(&participant_a, &100i128);
+    asset.mint(&participant_b, &100i128);
+    client.join(&participant_a, &10i128);
+    client.join(&participant_b, &10i128);
     set_ledger_sequence(&env, 1);
     client.start_round();
 
@@ -1670,7 +1760,7 @@ fn claim_already_claimed_returns_error() {
 
 #[test]
 fn join_fails_when_token_not_set() {
-    let (env, admin, client) = setup_with_admin();
+    let (env, _admin, client) = setup_with_admin();
     // No set_token call — token is unset.
     env.mock_all_auths();
 
@@ -1755,10 +1845,10 @@ fn winner_is_identifiable_before_claim() {
 fn submit_choice_wrong_round_returns_wrong_round_number() {
     let env = make_env();
     let client = create_client(&env);
-    client.init(&10);
+    let (_, _, players) = configure_arena(&env, &client, 10, 2);
     client.start_round();
 
-    let player = Address::generate(&env);
+    let player = players[0].clone();
     let result = client.try_submit_choice(&player, &99u32, &Choice::Heads);
     assert_eq!(result, Err(Ok(ArenaError::WrongRoundNumber)));
 }


### PR DESCRIPTION
Closes #334
Closes #360
Closes #332 

## Changes
- added `MIN_ARENA_PARTICIPANTS = 2` and enforced it in `start_round`
- added `ArenaError::NotEnoughPlayers = 23`
- updated `set_capacity` to return `Result<(), ArenaError>` and reject invalid capacities below 2 or above max
- implemented `resolve_round` with:
  - per-round heads/tails submitter indexes
  - deterministic tie-break behavior
  - survivor elimination by majority side
  - survivor count updates
  - round-finished persistence
  - round lifecycle event emission
- rejected submissions from eliminated/non-survivor players
- updated ABI guard coverage and `abi_snapshot.json`
- added unit coverage for:
  - starting with 0, 1, and 2 survivors
  - capacity boundary values
  - minority resolution
  - tie resolution
  - unanimous-choice resolution
  - survivor-only participation in the next round
- fixed feature-gated integration tests by funding payout balances explicitly

## Testing
- `cargo build -p arena`
- `cargo test -p arena`
- `cargo test -p arena prop_submission_count_equals_unique_submitters -- --nocapture`
- `cargo test -p arena prop_survivor_count_never_exceeds_capacity -- --nocapture`
- `cargo test -p arena --features integration-tests integration_tests::`

## Notes
- `#332` appears stale on current `main`: `GAME_STATUS_KEY` was already deduplicated before this branch. I re-verified the compile acceptance with `cargo build -p arena`, but no source change was needed for that issue.
