### PR TITLE
fix: reject zero min_stake in set_min_stake to match create_pool validation

### DIFF
--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -256,11 +256,11 @@ impl FactoryContract {
     ///
     /// # Errors
     /// * [`Error::NotInitialized`] — contract not initialised.
-    /// * [`Error::InvalidStakeAmount`] — `min_stake` is negative.
+    /// * [`Error::InvalidStakeAmount`] — `min_stake` is zero or negative.
     pub fn set_min_stake(env: Env, min_stake: i128) -> Result<(), Error> {
         let admin = require_admin(&env)?;
         admin.require_auth();
-        if min_stake < 0 {
+        if min_stake <= 0 {
             return Err(Error::InvalidStakeAmount);
         }
         env.storage().instance().set(&MIN_STAKE_KEY, &min_stake);

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -124,6 +124,13 @@ fn test_set_negative_min_stake_returns_invalid_stake_amount() {
     assert_eq!(result, Err(Ok(Error::InvalidStakeAmount)));
 }
 
+#[test]
+fn test_set_zero_min_stake_returns_invalid_stake_amount() {
+    let (_env, _admin, client) = setup();
+    let result = client.try_set_min_stake(&0);
+    assert_eq!(result, Err(Ok(Error::InvalidStakeAmount)));
+}
+
 // ── create_pool authorization ──────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Unify stake validation: `set_min_stake` now rejects zero, matching `create_pool`'s `stake <= 0` guard
- Add test confirming zero is rejected with `InvalidStakeAmount`

## Problem

`set_min_stake` only rejected negative values (`min_stake < 0`), allowing an admin to set `min_stake = 0`. However, `create_pool` rejects `stake <= 0` with `InvalidStakeAmount`. This created a contradictory state where:

1. Admin calls `set_min_stake(0)` — succeeds
2. Admin calls `create_pool(..., stake: 0, ...)` — fails with `InvalidStakeAmount`
3. Admin calls `create_pool(..., stake: 1, ...)` — fails with `StakeBelowMinimum` (since `1 < 0` is false but the real minimum is effectively undefined)

## Changes

### `contract/factory/src/lib.rs`
- Changed `set_min_stake` guard from `min_stake < 0` to `min_stake <= 0` (line 263)
- Updated doc comment to reflect "zero or negative"

### `contract/factory/src/test.rs`
- Added `test_set_zero_min_stake_returns_invalid_stake_amount` — confirms `set_min_stake(0)` returns `InvalidStakeAmount`

## Test plan

- [ ] `test_set_zero_min_stake_returns_invalid_stake_amount` — zero rejected
- [ ] `test_set_negative_min_stake_returns_invalid_stake_amount` — negative still rejected
- [ ] `test_set_min_stake` — valid positive value still accepted
- [ ] `test_create_pool_with_zero_stake_returns_invalid_stake_amount` — create_pool zero guard unchanged
- [ ] CI passes

Closes #321