### PR TITLE
fix: typed errors for upgrade fns, InvalidCapacity for set_capacity, …

### DIFF
--- a/contract/ERRORS.md
+++ b/contract/ERRORS.md
@@ -97,6 +97,12 @@ The arena pool contract uses `#[contracterror]` with **explicit** `repr(u32)` va
 | 18 | `GameAlreadyFinished` | Game ended |
 | 19 | `TokenNotSet` | Token not configured |
 | 20 | `MaxSubmissionsPerRound` | Per-round submission bound (`contract/BOUNDS.md`) |
+| 21 | `PlayerEliminated` | Eliminated player attempted action |
+| 22 | `WrongRoundNumber` | Submitted for wrong round |
+| 23 | `NotEnoughPlayers` | Too few players to start/resolve round |
+| 24 | `InvalidCapacity` | `set_capacity` value out of `[MIN, MAX]` range |
+| 25 | `NoPendingUpgrade` | `execute_upgrade`/`cancel_upgrade` with no proposal |
+| 26 | `TimelockNotExpired` | `execute_upgrade` called before 48-hour timelock |
 
 **ABI snapshot:** `contract/arena/abi_snapshot.json` guards these ordinals in CI (`abi_guard` tests).
 

--- a/contract/arena/abi_snapshot.json
+++ b/contract/arena/abi_snapshot.json
@@ -24,7 +24,10 @@
     "MaxSubmissionsPerRound": 20,
     "PlayerEliminated": 21,
     "WrongRoundNumber": 22,
-    "NotEnoughPlayers": 23
+    "NotEnoughPlayers": 23,
+    "InvalidCapacity": 24,
+    "NoPendingUpgrade": 25,
+    "TimelockNotExpired": 26
   },
   "event_topics": [
     "UP_PROP",

--- a/contract/arena/src/abi_guard.rs
+++ b/contract/arena/src/abi_guard.rs
@@ -40,6 +40,9 @@ fn arena_error_codes_match_abi_snapshot() {
         ("PlayerEliminated", ArenaError::PlayerEliminated),
         ("WrongRoundNumber", ArenaError::WrongRoundNumber),
         ("NotEnoughPlayers", ArenaError::NotEnoughPlayers),
+        ("InvalidCapacity", ArenaError::InvalidCapacity),
+        ("NoPendingUpgrade", ArenaError::NoPendingUpgrade),
+        ("TimelockNotExpired", ArenaError::TimelockNotExpired),
     ];
 
     assert_eq!(

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -71,6 +71,9 @@ pub enum ArenaError {
     PlayerEliminated = 21,
     WrongRoundNumber = 22,
     NotEnoughPlayers = 23,
+    InvalidCapacity = 24,
+    NoPendingUpgrade = 25,
+    TimelockNotExpired = 26,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -244,7 +247,7 @@ impl ArenaContract {
             .ok_or(ArenaError::NotInitialized)?;
         admin.require_auth();
         if !(bounds::MIN_ARENA_PARTICIPANTS..=bounds::MAX_ARENA_PARTICIPANTS).contains(&capacity) {
-            return Err(ArenaError::InvalidAmount);
+            return Err(ArenaError::InvalidCapacity);
         }
         env.storage().instance().set(&CAPACITY_KEY, &capacity);
         Ok(())
@@ -644,12 +647,12 @@ impl ArenaContract {
         })
     }
 
-    pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+    pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), ArenaError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&ADMIN_KEY)
-            .expect("not initialized");
+            .ok_or(ArenaError::NotInitialized)?;
         admin.require_auth();
         let execute_after: u64 = env.ledger().timestamp() + TIMELOCK_PERIOD;
         env.storage()
@@ -660,48 +663,51 @@ impl ArenaContract {
             .set(&EXECUTE_AFTER_KEY, &execute_after);
         env.events()
             .publish((TOPIC_UPGRADE_PROPOSED,), (new_wasm_hash, execute_after));
+        Ok(())
     }
 
-    pub fn execute_upgrade(env: Env) {
+    pub fn execute_upgrade(env: Env) -> Result<(), ArenaError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&ADMIN_KEY)
-            .expect("not initialized");
+            .ok_or(ArenaError::NotInitialized)?;
         admin.require_auth();
         let execute_after: u64 = env
             .storage()
             .instance()
             .get(&EXECUTE_AFTER_KEY)
-            .expect("no pending upgrade");
+            .ok_or(ArenaError::NoPendingUpgrade)?;
         if env.ledger().timestamp() < execute_after {
-            panic!("timelock has not expired");
+            return Err(ArenaError::TimelockNotExpired);
         }
         let new_wasm_hash: BytesN<32> = env
             .storage()
             .instance()
             .get(&PENDING_HASH_KEY)
-            .expect("no pending upgrade");
+            .ok_or(ArenaError::NoPendingUpgrade)?;
         env.storage().instance().remove(&PENDING_HASH_KEY);
         env.storage().instance().remove(&EXECUTE_AFTER_KEY);
         env.events()
             .publish((TOPIC_UPGRADE_EXECUTED,), new_wasm_hash.clone());
         env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 
-    pub fn cancel_upgrade(env: Env) {
+    pub fn cancel_upgrade(env: Env) -> Result<(), ArenaError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&ADMIN_KEY)
-            .expect("not initialized");
+            .ok_or(ArenaError::NotInitialized)?;
         admin.require_auth();
         if !env.storage().instance().has(&PENDING_HASH_KEY) {
-            panic!("no pending upgrade to cancel");
+            return Err(ArenaError::NoPendingUpgrade);
         }
         env.storage().instance().remove(&PENDING_HASH_KEY);
         env.storage().instance().remove(&EXECUTE_AFTER_KEY);
         env.events().publish((TOPIC_UPGRADE_CANCELLED,), ());
+        Ok(())
     }
 
     pub fn pending_upgrade(env: Env) -> Option<(BytesN<32>, u64)> {

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -442,40 +442,48 @@ fn test_propose_upgrade_replaces_previous() {
 }
 
 #[test]
-#[should_panic(expected = "no pending upgrade")]
-fn test_execute_without_proposal_panics() {
+fn test_execute_without_proposal_returns_error() {
     let (_env, _admin, client) = setup_with_admin();
-    client.execute_upgrade();
+    assert_eq!(
+        client.try_execute_upgrade(),
+        Err(Ok(ArenaError::NoPendingUpgrade))
+    );
 }
 
 #[test]
-#[should_panic(expected = "timelock has not expired")]
-fn test_execute_before_timelock_panics() {
+fn test_execute_before_timelock_returns_error() {
     let (env, _admin, client) = setup_with_admin();
     client.propose_upgrade(&dummy_hash(&env));
     env.ledger().with_mut(|l| {
         l.timestamp += 47 * 60 * 60;
     });
-    client.execute_upgrade();
+    assert_eq!(
+        client.try_execute_upgrade(),
+        Err(Ok(ArenaError::TimelockNotExpired))
+    );
 }
 
 #[test]
-#[should_panic(expected = "timelock has not expired")]
-fn test_execute_exactly_at_boundary_panics() {
+fn test_execute_exactly_at_boundary_returns_error() {
     let (env, _admin, client) = setup_with_admin();
     let propose_time = env.ledger().timestamp();
     client.propose_upgrade(&dummy_hash(&env));
     env.ledger().with_mut(|l| {
         l.timestamp = propose_time + TIMELOCK - 1;
     });
-    client.execute_upgrade();
+    assert_eq!(
+        client.try_execute_upgrade(),
+        Err(Ok(ArenaError::TimelockNotExpired))
+    );
 }
 
 #[test]
-#[should_panic(expected = "no pending upgrade to cancel")]
-fn test_cancel_without_proposal_panics() {
+fn test_cancel_without_proposal_returns_error() {
     let (_env, _admin, client) = setup_with_admin();
-    client.cancel_upgrade();
+    assert_eq!(
+        client.try_cancel_upgrade(),
+        Err(Ok(ArenaError::NoPendingUpgrade))
+    );
 }
 
 #[test]
@@ -489,8 +497,7 @@ fn test_cancel_clears_pending_upgrade() {
 }
 
 #[test]
-#[should_panic(expected = "no pending upgrade")]
-fn test_execute_after_cancel_panics() {
+fn test_execute_after_cancel_returns_error() {
     let (env, _admin, client) = setup_with_admin();
     client.propose_upgrade(&dummy_hash(&env));
     client.cancel_upgrade();
@@ -498,16 +505,21 @@ fn test_execute_after_cancel_panics() {
     env.ledger().with_mut(|l| {
         l.timestamp += TIMELOCK + 1;
     });
-    client.execute_upgrade();
+    assert_eq!(
+        client.try_execute_upgrade(),
+        Err(Ok(ArenaError::NoPendingUpgrade))
+    );
 }
 
 #[test]
-#[should_panic(expected = "no pending upgrade to cancel")]
-fn test_double_cancel_panics() {
+fn test_double_cancel_returns_error() {
     let (env, _admin, client) = setup_with_admin();
     client.propose_upgrade(&dummy_hash(&env));
     client.cancel_upgrade();
-    client.cancel_upgrade();
+    assert_eq!(
+        client.try_cancel_upgrade(),
+        Err(Ok(ArenaError::NoPendingUpgrade))
+    );
 }
 
 #[test]
@@ -1168,16 +1180,16 @@ fn set_capacity_enforces_minimum_and_maximum_bounds() {
 
     assert_eq!(
         client.try_set_capacity(&0),
-        Err(Ok(ArenaError::InvalidAmount))
+        Err(Ok(ArenaError::InvalidCapacity))
     );
     assert_eq!(
         client.try_set_capacity(&1),
-        Err(Ok(ArenaError::InvalidAmount))
+        Err(Ok(ArenaError::InvalidCapacity))
     );
     assert!(client.try_set_capacity(&2).is_ok());
     assert_eq!(
         client.try_set_capacity(&(bounds::MAX_ARENA_PARTICIPANTS + 1)),
-        Err(Ok(ArenaError::InvalidAmount))
+        Err(Ok(ArenaError::InvalidCapacity))
     );
 }
 

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -16,9 +16,7 @@ const EXECUTE_AFTER_KEY: Symbol = symbol_short!("P_AFTER");
 const WHITELIST_PREFIX: Symbol = symbol_short!("WL");
 const MIN_STAKE_KEY: Symbol = symbol_short!("MIN_STK");
 const ARENA_WASM_HASH_KEY: Symbol = symbol_short!("AR_WASM");
-const POOL_PREFIX: Symbol = symbol_short!("POOL");
-const ALL_POOLS_KEY: Symbol = symbol_short!("ALL_P");
-const METADATA_PREFIX: Symbol = symbol_short!("META");
+const POOL_COUNT_KEY: Symbol = symbol_short!("P_CNT");
 const SCHEMA_VERSION_KEY: Symbol = symbol_short!("S_VER");
 
 /// Current schema version. Bump this when storage layout changes.
@@ -41,6 +39,7 @@ const MAX_POOL_CAPACITY: u32 = 256;
 #[derive(Clone)]
 pub enum DataKey {
     SupportedToken(Address),
+    Pool(u32),
 }
 
 // ── Timelock constant: 48 hours in seconds ────────────────────────────────────
@@ -330,12 +329,11 @@ impl FactoryContract {
             .get(&ARENA_WASM_HASH_KEY)
             .ok_or(Error::WasmHashNotSet)?;
 
-        let mut all_pools: soroban_sdk::Vec<u32> = env
+        let pool_id: u32 = env
             .storage()
             .instance()
-            .get(&ALL_POOLS_KEY)
-            .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
-        let pool_id = all_pools.len();
+            .get(&POOL_COUNT_KEY)
+            .unwrap_or(0u32);
 
         let metadata = ArenaMetadata {
             pool_id,
@@ -343,8 +341,9 @@ impl FactoryContract {
             capacity,
             stake_amount: stake,
         };
-        let meta_key = (METADATA_PREFIX, pool_id);
-        env.storage().instance().set(&meta_key, &metadata);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Pool(pool_id), &metadata);
 
         // ── Deployment ──────────────────────────────────────────────────────────
 
@@ -395,9 +394,10 @@ impl FactoryContract {
             soroban_sdk::vec![&env, caller.into_val(&env)],
         );
 
-        // Register pool.
-        all_pools.push_back(pool_id);
-        env.storage().instance().set(&ALL_POOLS_KEY, &all_pools);
+        // Increment the pool counter.
+        env.storage()
+            .instance()
+            .set(&POOL_COUNT_KEY, &(pool_id + 1));
 
         env.events().publish(
             (TOPIC_POOL_CREATED,),
@@ -563,27 +563,23 @@ impl FactoryContract {
 
     /// Get metadata for a specific pool.
     pub fn get_arena(env: Env, pool_id: u32) -> Option<ArenaMetadata> {
-        let key = (METADATA_PREFIX, pool_id);
-        env.storage().instance().get(&key)
+        env.storage().persistent().get(&DataKey::Pool(pool_id))
     }
 
     /// Get a paginated list of arena metadata.
     pub fn get_arenas(env: Env, offset: u32, limit: u32) -> soroban_sdk::Vec<ArenaMetadata> {
-        let all_pools: soroban_sdk::Vec<u32> = env
+        let pool_count: u32 = env
             .storage()
             .instance()
-            .get(&ALL_POOLS_KEY)
-            .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+            .get(&POOL_COUNT_KEY)
+            .unwrap_or(0u32);
 
         let mut results = soroban_sdk::Vec::new(&env);
-        let start = offset;
-        let end = core::cmp::min(offset + limit, all_pools.len());
+        let end = core::cmp::min(offset + limit, pool_count);
 
-        for i in start..end {
-            if let Some(pool_id) = all_pools.get(i) {
-                if let Some(meta) = Self::get_arena(env.clone(), pool_id) {
-                    results.push_back(meta);
-                }
+        for i in offset..end {
+            if let Some(meta) = Self::get_arena(env.clone(), i) {
+                results.push_back(meta);
             }
         }
         results


### PR DESCRIPTION
…factory persistent pool storage

- closes #385: convert propose_upgrade/execute_upgrade/cancel_upgrade from TimelockNotExpired (26) typed error codes
- closes #386: set_capacity now returns InvalidCapacity (24) instead of InvalidAmount for out-of-range capacity values
- closes #352: replace Factory ALL_POOLS_KEY unbounded Vec in instance storage with POOL_COUNT_KEY monotonic counter + per-pool persistent DataKey::Pool(u32) storage; update get_arena and get_arenas to use persistent storage
- closes #354: DataKey::Survivor(Address) already unique in current codebase; no duplicate found in the cloned repo
- Update abi_snapshot.json and abi_guard.rs with 3 new error variants
- Convert 6 should_panic upgrade tests to typed Err(Ok(ArenaError::...)) assertions
- Update ERRORS.md with all 26 error codes including new variants

Closes #352, #354, #385, #386