### PR TITLE
fix: exempt arena set_token from pause checks

### DIFF
--- a/contract/DATA_MODEL.md
+++ b/contract/DATA_MODEL.md
@@ -85,7 +85,7 @@ No custom Soroban storage keys are currently defined or used.
 | `get_round` | `Round` | — | — |
 | `get_choice` | `Submission(n, player)` | — | — |
 | `join` | `TOKEN`, `CAPACITY`, `S_COUNT`, `PRIZE` (instance), `Survivor(player)` | `Survivor(player)`, `S_COUNT`, `PRIZE` (instance) | `Survivor(player)` |
-| `set_token` | `ADMIN` (instance) | `TOKEN` (instance) | — |
+| `set_token` ¹ | `ADMIN` (instance) | `TOKEN` (instance) | — |
 | `survivor_count` | `S_COUNT` (instance) | — | — |
 | `claim` | `G_FIN`, `S_COUNT`, `Survivor(winner)`, `PrizeClaimed(winner)`, `PRIZE`, `TOKEN` | `PrizeClaimed(winner)`, `PRIZE`, `G_FIN` (instance) | `PrizeClaimed(winner)` |
 | `initialize` | `ADMIN` (instance) | `ADMIN` (instance) | — |
@@ -165,7 +165,7 @@ Round lifecycle state machine:
 The arena contract exposes a global pause mechanism (`pause` / `unpause`, admin-only).
 When paused, all state-mutating game functions reject calls with `ArenaError::Paused`.
 
-**However, governance/upgrade functions are explicitly exempt from the pause check.**
+**However, governance/upgrade functions and admin-only recovery configuration are explicitly exempt from the pause check.**
 
 ### Exempt functions
 
@@ -174,6 +174,7 @@ When paused, all state-mutating game functions reject calls with `ArenaError::Pa
 | `propose_upgrade` | **Yes** | Admin must be able to queue a recovery upgrade at any time |
 | `execute_upgrade` | **Yes** | Admin must be able to deploy the recovery upgrade after the timelock |
 | `cancel_upgrade` | **Yes** | Admin must be able to retract an incorrect proposal before correcting it |
+| `set_token` | **Yes** | Admin must be able to rotate a compromised token address while gameplay is paused |
 | `pause` | **Yes** | Admin must always be able to pause |
 | `unpause` | **Yes** | Admin must always be able to unpause |
 
@@ -201,9 +202,10 @@ governance functions exempt, the admin retains full ability to:
 
 ### Invariant
 
-> `propose_upgrade`, `execute_upgrade`, and `cancel_upgrade` MUST NOT call
-> `require_not_paused`. Any future addition of new governance functions should
-> follow the same exemption rule and update this table.
+> `propose_upgrade`, `execute_upgrade`, `cancel_upgrade`, and `set_token` MUST
+> NOT call `require_not_paused`. Any future addition of new governance or
+> admin-only recovery functions should follow the same exemption rule and update
+> this table.
 
 ## Historical baseline note
 

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -229,7 +229,8 @@ impl ArenaContract {
     }
 
     pub fn set_token(env: Env, token: Address) {
-        require_not_paused(&env).unwrap();
+        // Admin configuration remains available during an emergency pause so the
+        // token can be rotated before gameplay resumes.
         let admin: Address = env
             .storage()
             .instance()

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -1447,6 +1447,28 @@ fn test_cancel_upgrade_after_paused_propose() {
     assert!(client.pending_upgrade().is_none());
 }
 
+/// When paused, admin token rotation still succeeds.
+#[test]
+fn test_set_token_succeeds_when_paused() {
+    let (env, admin, client) = setup_with_admin();
+    let (_old_asset, old_token_id) = setup_token(&env, &admin);
+    let (_new_asset, new_token_id) = setup_token(&env, &admin);
+
+    client.set_token(&old_token_id);
+    client.pause();
+    assert!(client.is_paused());
+
+    client.set_token(&new_token_id);
+
+    let configured_token: Address = env.as_contract(&client.address, || {
+        env.storage()
+            .instance()
+            .get(&TOKEN_KEY)
+            .expect("token must remain configurable while paused")
+    });
+    assert_eq!(configured_token, new_token_id);
+}
+
 /// When paused, normal game functions are blocked but governance functions are not.
 /// This is the core invariant of the Emergency Pause Policy.
 #[test]
@@ -1488,6 +1510,18 @@ fn test_paused_blocks_game_functions_not_governance() {
         client.pending_upgrade().is_none(),
         "cancel_upgrade must succeed when paused"
     );
+
+    let (_old_asset, old_token_id) = setup_token(&env, &_admin);
+    let (_new_asset, new_token_id) = setup_token(&env, &_admin);
+    client.set_token(&old_token_id);
+    client.set_token(&new_token_id);
+    let configured_token: Address = env.as_contract(&client.address, || {
+        env.storage()
+            .instance()
+            .get(&TOKEN_KEY)
+            .expect("set_token must succeed when paused")
+    });
+    assert_eq!(configured_token, new_token_id);
 }
 
 /// After unpausing, all functions — game and governance — work normally.


### PR DESCRIPTION
## Summary
- remove the pause gate from `arena.set_token()` so admin token rotation remains available during an emergency pause
- add a paused-path regression test covering admin token updates while the contract is paused
- update the emergency pause policy docs to list `set_token` as pause-exempt alongside the other recovery/admin functions

## Testing
- cargo fmt --all --check
- git diff --check

## Notes
- targeted `cargo test` and `cargo check` runs for the `arena` contract timed out locally in this environment, so I am not claiming a completed Rust test run here

Closes #380
