### PR TITLE
fix: resolve contract security and gameplay bugs (#402, #403, #404, #405)

### DIFF
--- a/contract/arena/abi_snapshot.json
+++ b/contract/arena/abi_snapshot.json
@@ -27,7 +27,10 @@
     "NotEnoughPlayers": 23,
     "InvalidCapacity": 24,
     "NoPendingUpgrade": 25,
-    "TimelockNotExpired": 26
+    "TimelockNotExpired": 26,
+    "GameNotFinished": 27,
+    "TokenConfigurationLocked": 28,
+    "UpgradeAlreadyPending": 29
   },
   "event_topics": [
     "UP_PROP",

--- a/contract/arena/src/abi_guard.rs
+++ b/contract/arena/src/abi_guard.rs
@@ -43,6 +43,9 @@ fn arena_error_codes_match_abi_snapshot() {
         ("InvalidCapacity", ArenaError::InvalidCapacity),
         ("NoPendingUpgrade", ArenaError::NoPendingUpgrade),
         ("TimelockNotExpired", ArenaError::TimelockNotExpired),
+        ("GameNotFinished", ArenaError::GameNotFinished),
+        ("TokenConfigurationLocked", ArenaError::TokenConfigurationLocked),
+        ("UpgradeAlreadyPending", ArenaError::UpgradeAlreadyPending),
     ];
 
     assert_eq!(

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -76,6 +76,7 @@ pub enum ArenaError {
     TimelockNotExpired = 26,
     GameNotFinished = 27,
     TokenConfigurationLocked = 28,
+    UpgradeAlreadyPending = 29,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -310,7 +311,14 @@ impl ArenaContract {
             .ok_or(ArenaError::InvalidAmount)?;
         storage(&env).set(&DataKey::Winner(player.clone()), &());
         bump(&env, &DataKey::Winner(player.clone()));
-        env.storage().instance().set(&PRIZE_POOL_KEY, &prize);
+        let existing_pool: i128 = env
+            .storage()
+            .instance()
+            .get(&PRIZE_POOL_KEY)
+            .unwrap_or(0i128);
+        env.storage()
+            .instance()
+            .set(&PRIZE_POOL_KEY, &(existing_pool + prize));
         env.events()
             .publish((TOPIC_WINNER_SET,), (player, stake, yield_comp));
         Ok(())
@@ -620,9 +628,8 @@ impl ArenaContract {
             .set(&SURVIVOR_COUNT_KEY, &updated_survivor_count);
         if updated_survivor_count <= 1 {
             env.storage().instance().set(&GAME_FINISHED_KEY, &true);
+            round.finished = true;
         }
-
-        round.finished = true;
 
         #[cfg(debug_assertions)]
         {
@@ -780,6 +787,9 @@ impl ArenaContract {
             .get(&ADMIN_KEY)
             .ok_or(ArenaError::NotInitialized)?;
         admin.require_auth();
+        if env.storage().instance().has(&PENDING_HASH_KEY) {
+            return Err(ArenaError::UpgradeAlreadyPending);
+        }
         let execute_after: u64 = env.ledger().timestamp() + TIMELOCK_PERIOD;
         env.storage()
             .instance()

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -199,8 +199,11 @@ fn setup_finished_game_with_winner(
     let (env, admin, client, token_id, players) = setup_game(5, 3);
     let asset = StellarAssetClient::new(&env, &token_id);
     let existing_pool = TEST_REQUIRED_STAKE * players.len() as i128;
-    if prize_amount > existing_pool {
-        asset.mint(&client.address, &(prize_amount - existing_pool));
+    // set_winner adds prize_amount to the existing pool (from player joins),
+    // so the contract needs enough balance to cover both.
+    let total_needed = existing_pool + prize_amount;
+    if total_needed > existing_pool {
+        asset.mint(&client.address, &(total_needed - existing_pool));
     }
 
     set_ledger_sequence(&env, 1);
@@ -478,12 +481,28 @@ fn test_propose_upgrade_stores_pending() {
 }
 
 #[test]
-fn test_propose_upgrade_replaces_previous() {
+fn test_propose_upgrade_rejects_when_pending() {
     let (env, _admin, client) = setup_with_admin();
     let hash1 = BytesN::from_array(&env, &[1u8; 32]);
     let hash2 = BytesN::from_array(&env, &[2u8; 32]);
 
     client.propose_upgrade(&hash1);
+    let result = client.try_propose_upgrade(&hash2);
+    assert_eq!(result, Err(Ok(ArenaError::UpgradeAlreadyPending)));
+
+    // Original proposal remains intact.
+    let pending = client.pending_upgrade().unwrap();
+    assert_eq!(pending.0, hash1);
+}
+
+#[test]
+fn test_propose_upgrade_allowed_after_cancel() {
+    let (env, _admin, client) = setup_with_admin();
+    let hash1 = BytesN::from_array(&env, &[1u8; 32]);
+    let hash2 = BytesN::from_array(&env, &[2u8; 32]);
+
+    client.propose_upgrade(&hash1);
+    client.cancel_upgrade();
     client.propose_upgrade(&hash2);
 
     let pending = client.pending_upgrade().unwrap();
@@ -1345,7 +1364,7 @@ fn resolve_round_can_chain_across_multiple_rounds_until_one_survivor_remains() {
 
     set_ledger_sequence(&env, 66);
     let resolved_one = client.resolve_round();
-    assert!(resolved_one.finished);
+    assert!(!resolved_one.finished);
     assert_eq!(client.get_arena_state().survivors_count, 3);
 
     set_ledger_sequence(&env, 70);
@@ -1841,8 +1860,9 @@ fn round_state_machine_invariant_suite_happy_path() {
 fn claim_single_winner_gets_correct_prize() {
     let (_env, _admin, client, _token_id, winner) = setup_finished_game_with_winner(1_500i128);
 
+    // Pool contains player deposits (3 × 100 = 300) + prize_amount (1500) = 1800
     let claimed = client.claim(&winner);
-    assert_eq!(claimed, 1_500i128);
+    assert_eq!(claimed, 1_800i128);
 }
 
 #[test]
@@ -1860,14 +1880,17 @@ fn claim_rejects_before_game_is_finished() {
 }
 
 #[test]
-fn claim_second_set_winner_overwrites_prize_pool() {
-    let (_env, _admin, client, _token_id, winner) = setup_finished_game_with_winner(1_500i128);
-    client.set_winner(&winner, &1_000i128, &500i128);
-    client.set_winner(&winner, &800i128, &200i128);
+fn claim_second_set_winner_adds_to_prize_pool() {
+    let (env, _admin, client, token_id, winner) = setup_finished_game_with_winner(0i128);
+    // Pool starts with 300 (3 players × 100) + 0 (prize_amount) = 300.
+    // set_winner now adds to existing pool instead of overwriting.
+    let asset = StellarAssetClient::new(&env, &token_id);
+    asset.mint(&client.address, &700i128); // total contract balance = 300 + 700 = 1000
+    client.set_winner(&winner, &200i128, &100i128); // pool = 300 + 300 = 600
+    client.set_winner(&winner, &150i128, &50i128); // pool = 600 + 200 = 800
 
-    // The active prize pool is now 1000 (800 + 200), not 1500.
-    let claimed_b = client.claim(&winner);
-    assert_eq!(claimed_b, 1_000i128);
+    let claimed = client.claim(&winner);
+    assert_eq!(claimed, 800i128);
 }
 
 #[test]
@@ -2199,8 +2222,9 @@ fn claim_fails_for_non_designated_winner() {
 fn claim_succeeds_only_for_designated_winner() {
     let (_env, _admin, client, _token_id, winner) = setup_finished_game_with_winner(300i128);
 
+    // Pool contains player deposits (3 × 100 = 300) + prize_amount (300) = 600
     let prize = client.claim(&winner);
-    assert_eq!(prize, 300i128);
+    assert_eq!(prize, 600i128);
 }
 
 #[test]

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -96,7 +96,7 @@ pub enum Error {
     InvalidStakeAmount = 8,
     /// A pool with the given `pool_id` was already registered.
     PoolAlreadyExists = 9,
-    /// Pool capacity is zero or exceeds `MAX_POOL_CAPACITY`.
+    /// Pool capacity is below 2 or exceeds `MAX_POOL_CAPACITY`.
     InvalidCapacity = 10,
     /// `create_pool` called before `set_arena_wasm_hash` has been called.
     WasmHashNotSet = 11,
@@ -104,6 +104,8 @@ pub enum Error {
     MalformedUpgradeState = 12,
     /// `create_pool` called with a token that has not been added via `add_supported_token`.
     UnsupportedToken = 13,
+    /// `propose_upgrade` called while a pending upgrade proposal already exists.
+    UpgradeAlreadyPending = 14,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -300,14 +302,14 @@ impl FactoryContract {
     /// Create a new pool (arena). Only admin or whitelisted hosts can call this.
     ///
     /// The caller must provide a valid stake amount >= minimum stake and a
-    /// capacity in range [1, MAX_POOL_CAPACITY]. `pool_id` must be unique.
+    /// capacity in range [2, MAX_POOL_CAPACITY]. `pool_id` must be unique.
     /// Emits `PoolCreated(pool_id, creator, capacity, stake_amount)`.
     ///
     /// # Errors
     /// * [`Error::NotInitialized`] — contract not initialised.
     /// * [`Error::Unauthorized`] — `caller` is neither admin nor whitelisted.
     /// * [`Error::PoolAlreadyExists`] — a pool with `pool_id` already exists.
-    /// * [`Error::InvalidCapacity`] — `capacity` is 0 or > `MAX_POOL_CAPACITY`.
+    /// * [`Error::InvalidCapacity`] — `capacity` is < 2 or > `MAX_POOL_CAPACITY`.
     /// * [`Error::InvalidStakeAmount`] — `stake_amount` is zero or negative.
     /// * [`Error::StakeBelowMinimum`] — `stake_amount` is below the configured minimum.
     /// * [`Error::WasmHashNotSet`] — `set_arena_wasm_hash` has not been called yet.
@@ -338,7 +340,7 @@ impl FactoryContract {
             return Err(Error::UnsupportedToken);
         }
 
-        if capacity == 0 || capacity > MAX_POOL_CAPACITY {
+        if capacity < 2 || capacity > MAX_POOL_CAPACITY {
             return Err(Error::InvalidCapacity);
         }
 
@@ -424,6 +426,12 @@ impl FactoryContract {
             soroban_sdk::vec![&env, currency.into_val(&env)],
         );
 
+        env.invoke_contract::<()>(
+            &arena_address,
+            &soroban_sdk::Symbol::new(&env, "set_capacity"),
+            soroban_sdk::vec![&env, capacity.into_val(&env)],
+        );
+
         // 3. Transfer admin to the caller after factory-owned initialization is complete.
         env.invoke_contract::<()>(
             &arena_address,
@@ -500,6 +508,10 @@ impl FactoryContract {
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
         let admin = require_admin(&env)?;
         admin.require_auth();
+
+        if env.storage().instance().has(&PENDING_HASH_KEY) {
+            return Err(Error::UpgradeAlreadyPending);
+        }
 
         let execute_after: u64 = env.ledger().timestamp() + TIMELOCK_PERIOD;
         env.storage()

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -267,11 +267,20 @@ fn test_create_pool_without_wasm_hash_returns_wasm_hash_not_set() {
 // ── create_pool capacity validation ───────────────────────────────────────────
 
 #[test]
-fn test_create_pool_with_capacity_one_succeeds() {
+fn test_create_pool_with_capacity_one_returns_invalid_capacity() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &1u32);
+    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &1u32);
+    assert_eq!(result, Err(Ok(Error::InvalidCapacity)));
+}
+
+#[test]
+fn test_create_pool_with_capacity_two_succeeds() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &2u32);
 }
 
 #[test]
@@ -392,12 +401,28 @@ fn test_propose_upgrade_stores_pending() {
 }
 
 #[test]
-fn test_propose_upgrade_replaces_previous() {
+fn test_propose_upgrade_rejects_when_pending() {
     let (env, _admin, client) = setup();
     let hash1 = BytesN::from_array(&env, &[1u8; 32]);
     let hash2 = BytesN::from_array(&env, &[2u8; 32]);
 
     client.propose_upgrade(&hash1);
+    let result = client.try_propose_upgrade(&hash2);
+    assert_eq!(result, Err(Ok(Error::UpgradeAlreadyPending)));
+
+    // Original proposal remains intact.
+    let pending = client.pending_upgrade().unwrap();
+    assert_eq!(pending.0, hash1);
+}
+
+#[test]
+fn test_propose_upgrade_allowed_after_cancel() {
+    let (env, _admin, client) = setup();
+    let hash1 = BytesN::from_array(&env, &[1u8; 32]);
+    let hash2 = BytesN::from_array(&env, &[2u8; 32]);
+
+    client.propose_upgrade(&hash1);
+    client.cancel_upgrade();
     client.propose_upgrade(&hash2);
 
     let pending = client.pending_upgrade().unwrap();

--- a/contract/factory/test_snapshots/test/test_admin_can_create_pool.1.json
+++ b/contract/factory/test_snapshots/test/test_admin_can_create_pool.1.json
@@ -111,6 +111,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 8
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -624,6 +638,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 8
                         }
                       },
                       {

--- a/contract/factory/test_snapshots/test/test_create_pool_allows_whitelisted_host_in_mock_auth_env.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_allows_whitelisted_host_in_mock_auth_env.1.json
@@ -130,6 +130,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 8
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -691,6 +705,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 8
                         }
                       },
                       {

--- a/contract/factory/test_snapshots/test/test_create_pool_increments_id.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_increments_id.1.json
@@ -111,6 +111,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 8
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -164,6 +178,20 @@
                   "args": [
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 8
                     }
                   ]
                 }
@@ -805,6 +833,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 8
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
@@ -1005,6 +1041,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 8
                         }
                       },
                       {

--- a/contract/factory/test_snapshots/test/test_create_pool_with_capacity_one_returns_invalid_capacity.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_capacity_one_returns_invalid_capacity.1.json
@@ -1,0 +1,283 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_arena_wasm_hash",
+              "args": [
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_supported_token",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "AR_WASM"
+                        },
+                        "val": {
+                          "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "MIN_STK"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 10000000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "S_VER"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SupportedToken"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contract/factory/test_snapshots/test/test_create_pool_with_capacity_two_succeeds.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_capacity_two_succeeds.1.json
@@ -87,7 +87,7 @@
                   "u32": 10
                 },
                 {
-                  "u32": 1
+                  "u32": 2
                 }
               ]
             }
@@ -101,6 +101,20 @@
                   "args": [
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 2
                     }
                   ]
                 }
@@ -178,7 +192,7 @@
                         "symbol": "capacity"
                       },
                       "val": {
-                        "u32": 1
+                        "u32": 2
                       }
                     },
                     {
@@ -628,6 +642,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
@@ -692,7 +714,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "u32": 1
+                  "u32": 2
                 },
                 {
                   "i128": {

--- a/contract/factory/test_snapshots/test/test_create_pool_with_max_capacity_succeeds.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_max_capacity_succeeds.1.json
@@ -111,6 +111,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 256
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -624,6 +638,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 256
                         }
                       },
                       {

--- a/contract/factory/test_snapshots/test/test_create_pool_with_stake_equal_to_minimum_succeeds.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_stake_equal_to_minimum_succeeds.1.json
@@ -111,6 +111,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 8
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -624,6 +638,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 8
                         }
                       },
                       {

--- a/contract/factory/test_snapshots/test/test_get_arena.1.json
+++ b/contract/factory/test_snapshots/test/test_get_arena.1.json
@@ -111,6 +111,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 10
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -625,6 +639,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 10
                         }
                       },
                       {

--- a/contract/factory/test_snapshots/test/test_get_arenas_pagination.1.json
+++ b/contract/factory/test_snapshots/test/test_get_arenas_pagination.1.json
@@ -111,6 +111,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 10
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -174,6 +188,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 10
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -227,6 +255,20 @@
                   "args": [
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CDTGMSXLPVPOZUWY4W73JFCKSAKESWZSSXQBJ3SWQWDJAU7IRFDK7T6B",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 10
                     }
                   ]
                 }
@@ -290,6 +332,20 @@
                   "args": [
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CDRS74TAHZSJNMABUU4H3KI5XFH27KY7O7W6GGWPILTOUYMB7A4JDGO4",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 10
                     }
                   ]
                 }
@@ -353,6 +409,20 @@
                   "args": [
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CCLYKFC5EX4TUBSS56XDVPFJFMO33W7WP7MTMK25EJVV7JKPCJJSXTBI",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 10
                     }
                   ]
                 }
@@ -1340,6 +1410,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 10
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
@@ -1540,6 +1618,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 10
                         }
                       },
                       {
@@ -1748,6 +1834,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 10
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
@@ -1952,6 +2046,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 10
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
@@ -2152,6 +2254,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 10
                         }
                       },
                       {

--- a/contract/factory/test_snapshots/test/test_propose_upgrade_allowed_after_cancel.1.json
+++ b/contract/factory/test_snapshots/test/test_propose_upgrade_allowed_after_cancel.1.json
@@ -1,0 +1,324 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "propose_upgrade",
+              "args": [
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "cancel_upgrade",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "propose_upgrade",
+              "args": [
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "MIN_STK"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 10000000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "P_AFTER"
+                        },
+                        "val": {
+                          "u64": 172800
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "P_HASH"
+                        },
+                        "val": {
+                          "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "S_VER"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contract/factory/test_snapshots/test/test_propose_upgrade_rejects_when_pending.1.json
+++ b/contract/factory/test_snapshots/test/test_propose_upgrade_rejects_when_pending.1.json
@@ -43,25 +43,7 @@
         }
       ]
     ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "propose_upgrade",
-              "args": [
-                {
-                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
+    [],
     []
   ],
   "ledger": {
@@ -129,7 +111,7 @@
                           "symbol": "P_HASH"
                         },
                         "val": {
-                          "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                          "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
                         }
                       },
                       {
@@ -172,39 +154,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
                   }
                 },
                 "durability": "temporary",

--- a/contract/factory/test_snapshots/test/test_whitelisted_host_can_create_pool.1.json
+++ b/contract/factory/test_snapshots/test/test_whitelisted_host_can_create_pool.1.json
@@ -130,6 +130,20 @@
               "function": {
                 "contract_fn": {
                   "contract_address": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
+                  "function_name": "set_capacity",
+                  "args": [
+                    {
+                      "u32": 8
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            },
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
                   "function_name": "set_admin",
                   "args": [
                     {
@@ -691,6 +705,14 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CAPACITY"
+                        },
+                        "val": {
+                          "u32": 8
                         }
                       },
                       {


### PR DESCRIPTION
## Summary

This PR addresses four contract security and gameplay bugs:

Closes #402 — `resolve_round` premature termination
Closes #403 — `create_pool` missing `set_capacity` call
Closes #404 — `set_winner` overwrites prize pool instead of accumulating
Closes #405 — `propose_upgrade` allows overwriting pending upgrades

---

### Fix #405: Guard `propose_upgrade` against overwriting pending upgrades

**Arena**: Added `UpgradeAlreadyPending` error (code 29). `propose_upgrade` now checks if `PENDING_HASH_KEY` already exists in storage and returns an error if so. Admins must explicitly `cancel_upgrade` before proposing a new one.

**Factory**: Added `UpgradeAlreadyPending` error (code 14) with the same guard logic.

### Fix #404: Make `set_winner` additive

`set_winner` now reads the existing prize pool and adds the new prize amount instead of overwriting it. This prevents loss of player-deposited funds (join stakes) that accumulate in the pool.

### Fix #402: Fix `resolve_round` premature termination

`round.finished = true` is now only set when `updated_survivor_count <= 1`, allowing multi-round games to continue through intermediate rounds where multiple survivors remain. The `GAME_FINISHED_KEY` was already correctly gated (upstream fix), but `round.finished` was being set unconditionally.

### Fix #403: Add `set_capacity` call in factory `create_pool`

After deploying and initializing a new arena, the factory now invokes `set_capacity` on the arena contract to enforce capacity bounds. The factory's own capacity validation was also tightened from `capacity >= 1` to `capacity >= 2` to match the arena's `MIN_ARENA_PARTICIPANTS` bound.

---

### Additional changes
- Updated ABI snapshot (`abi_snapshot.json`) and guard (`abi_guard.rs`) with new error codes
- Renamed and updated tests to cover new behaviors (reject-on-pending, additive pool, conditional round finish)
- Added/removed/updated factory test snapshots for renamed and new tests
- All 225 tests pass across the workspace (arena: 129, factory: 66, payout: 16, staking: 14)