### PR TITLE
Fix/arena factory event security bugs

### DIFF
--- a/contract/EVENTS.md
+++ b/contract/EVENTS.md
@@ -1,6 +1,6 @@
 # Contract Event Reference
 
-All events include a version marker (`v: u32`) as the first field of the
+Arena and factory events include a version marker (`v: u32`) in the
 data payload. Consumers should check this field to detect schema changes
 without requiring redeployment.
 
@@ -20,9 +20,8 @@ Current payload version: **1**
 | `R_START`     | `start_round()`        | `(round_number: u32, round_start_ledger: u32, round_deadline_ledger: u32, v)` |
 | `R_TOUT`      | `timeout_round()`      | `(round_number: u32, total_submissions: u32, v)` |
 | `RSLVD`       | `resolve_round()`      | `(round_number: u32, heads_count: u32, tails_count: u32, outcome: Symbol, eliminated_count: u32, survivor_count: u32, v)` |
-| `WIN_SET`     | `set_winner()`         | `(player: Address, stake: i128, yield_comp: i128)` |
+| `WIN_SET`     | `set_winner()`         | `(player: Address, stake: i128, yield_comp: i128, v)` |
 | `CLAIM`       | `claim()`              | `(winner: Address, prize: i128, v)`      |
-| `G_END`       | *(reserved)*           | *(not currently emitted)*                |
 
 ## Factory Contract
 
@@ -61,6 +60,6 @@ address, amounts) is in the data payload so indexers can filter on `STAKED` /
 
 ## Versioning Policy
 
-- The `v` field is always the **first** element of the data tuple.
+- The `v` field is included in every arena/factory event payload.
 - When fields are added, removed, or reordered the version is bumped.
 - Consumers should fall back gracefully on unknown versions.

--- a/contract/arena/abi_snapshot.json
+++ b/contract/arena/abi_snapshot.json
@@ -30,7 +30,8 @@
     "TimelockNotExpired": 26,
     "GameNotFinished": 27,
     "TokenConfigurationLocked": 28,
-    "UpgradeAlreadyPending": 29
+    "UpgradeAlreadyPending": 29,
+    "WinnerAlreadySet": 30
   },
   "event_topics": [
     "UP_PROP",

--- a/contract/arena/abi_snapshot.json
+++ b/contract/arena/abi_snapshot.json
@@ -31,7 +31,8 @@
     "GameNotFinished": 27,
     "TokenConfigurationLocked": 28,
     "UpgradeAlreadyPending": 29,
-    "WinnerAlreadySet": 30
+    "WinnerAlreadySet": 30,
+    "WinnerNotSet": 31
   },
   "event_topics": [
     "UP_PROP",

--- a/contract/arena/src/abi_guard.rs
+++ b/contract/arena/src/abi_guard.rs
@@ -46,6 +46,7 @@ fn arena_error_codes_match_abi_snapshot() {
         ("GameNotFinished", ArenaError::GameNotFinished),
         ("TokenConfigurationLocked", ArenaError::TokenConfigurationLocked),
         ("UpgradeAlreadyPending", ArenaError::UpgradeAlreadyPending),
+        ("WinnerAlreadySet", ArenaError::WinnerAlreadySet),
     ];
 
     assert_eq!(

--- a/contract/arena/src/abi_guard.rs
+++ b/contract/arena/src/abi_guard.rs
@@ -47,6 +47,7 @@ fn arena_error_codes_match_abi_snapshot() {
         ("TokenConfigurationLocked", ArenaError::TokenConfigurationLocked),
         ("UpgradeAlreadyPending", ArenaError::UpgradeAlreadyPending),
         ("WinnerAlreadySet", ArenaError::WinnerAlreadySet),
+        ("WinnerNotSet", ArenaError::WinnerNotSet),
     ];
 
     assert_eq!(

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -243,14 +243,14 @@ impl ArenaContract {
         let admin = Self::admin(env.clone());
         admin.require_auth();
         env.storage().instance().set(&PAUSED_KEY, &true);
-        env.events().publish((TOPIC_PAUSED,), ());
+        env.events().publish((TOPIC_PAUSED,), (EVENT_VERSION,));
     }
 
     pub fn unpause(env: Env) {
         let admin = Self::admin(env.clone());
         admin.require_auth();
         env.storage().instance().set(&PAUSED_KEY, &false);
-        env.events().publish((TOPIC_UNPAUSED,), ());
+        env.events().publish((TOPIC_UNPAUSED,), (EVENT_VERSION,));
     }
 
     pub fn is_paused(env: Env) -> bool {
@@ -332,7 +332,7 @@ impl ArenaContract {
             .instance()
             .set(&PRIZE_POOL_KEY, &(existing_pool + prize));
         env.events()
-            .publish((TOPIC_WINNER_SET,), (player, stake, yield_comp));
+            .publish((TOPIC_WINNER_SET,), (player, stake, yield_comp, EVENT_VERSION));
         Ok(())
     }
 
@@ -851,8 +851,10 @@ impl ArenaContract {
         env.storage()
             .instance()
             .set(&EXECUTE_AFTER_KEY, &execute_after);
-        env.events()
-            .publish((TOPIC_UPGRADE_PROPOSED,), (new_wasm_hash, execute_after));
+        env.events().publish(
+            (TOPIC_UPGRADE_PROPOSED,),
+            (EVENT_VERSION, new_wasm_hash, execute_after),
+        );
         Ok(())
     }
 
@@ -878,8 +880,10 @@ impl ArenaContract {
             .ok_or(ArenaError::NoPendingUpgrade)?;
         env.storage().instance().remove(&PENDING_HASH_KEY);
         env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events()
-            .publish((TOPIC_UPGRADE_EXECUTED,), new_wasm_hash.clone());
+        env.events().publish(
+            (TOPIC_UPGRADE_EXECUTED,),
+            (EVENT_VERSION, new_wasm_hash.clone()),
+        );
         env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }
@@ -896,7 +900,8 @@ impl ArenaContract {
         }
         env.storage().instance().remove(&PENDING_HASH_KEY);
         env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events().publish((TOPIC_UPGRADE_CANCELLED,), ());
+        env.events()
+            .publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
         Ok(())
     }
 

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -20,6 +20,7 @@ const TOKEN_KEY: Symbol = symbol_short!("TOKEN");
 const PRIZE_POOL_KEY: Symbol = symbol_short!("PRIZE_P");
 const GAME_STATUS_KEY: Symbol = symbol_short!("G_STATUS");
 const GAME_FINISHED_KEY: Symbol = symbol_short!("G_FIN");
+const WINNER_SET_KEY: Symbol = symbol_short!("W_SET");
 
 // ── Timelock: 48 hours in seconds ─────────────────────────────────────────────
 const TIMELOCK_PERIOD: u64 = 48 * 60 * 60;
@@ -78,6 +79,7 @@ pub enum ArenaError {
     GameNotFinished = 27,
     TokenConfigurationLocked = 28,
     UpgradeAlreadyPending = 29,
+    WinnerAlreadySet = 30,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -304,6 +306,14 @@ impl ArenaContract {
         require_not_paused(&env)?;
         let admin = Self::admin(env.clone());
         admin.require_auth();
+        if env
+            .storage()
+            .instance()
+            .get::<_, bool>(&WINNER_SET_KEY)
+            .unwrap_or(false)
+        {
+            return Err(ArenaError::WinnerAlreadySet);
+        }
         if stake < 0 || yield_comp < 0 {
             return Err(ArenaError::InvalidAmount);
         }
@@ -312,6 +322,7 @@ impl ArenaContract {
             .ok_or(ArenaError::InvalidAmount)?;
         storage(&env).set(&DataKey::Winner(player.clone()), &());
         bump(&env, &DataKey::Winner(player.clone()));
+        env.storage().instance().set(&WINNER_SET_KEY, &true);
         let existing_pool: i128 = env
             .storage()
             .instance()

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -80,6 +80,7 @@ pub enum ArenaError {
     TokenConfigurationLocked = 28,
     UpgradeAlreadyPending = 29,
     WinnerAlreadySet = 30,
+    WinnerNotSet = 31,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -726,11 +727,24 @@ impl ArenaContract {
         {
             return Err(ArenaError::GameNotFinished);
         }
-        // Verify caller is the address designated by set_winner(); any other
-        // survivor could otherwise pass require_auth() with their own address
-        // and drain the prize pool.
+        // Primary claim path uses an explicit admin-designated winner. If no
+        // winner has been set, allow a fallback only when exactly one survivor
+        // remains and the caller is that survivor.
         if !storage(&env).has(&DataKey::Winner(winner.clone())) {
-            return Err(ArenaError::NotASurvivor);
+            let survivor_count: u32 = env
+                .storage()
+                .instance()
+                .get(&SURVIVOR_COUNT_KEY)
+                .unwrap_or(0u32);
+            if survivor_count == 1 && storage(&env).has(&DataKey::Survivor(winner.clone())) {
+                storage(&env).set(&DataKey::Winner(winner.clone()), &());
+                bump(&env, &DataKey::Winner(winner.clone()));
+                env.storage().instance().set(&WINNER_SET_KEY, &true);
+            } else if survivor_count == 1 {
+                return Err(ArenaError::NotASurvivor);
+            } else {
+                return Err(ArenaError::WinnerNotSet);
+            }
         }
         if env
             .storage()

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -2227,6 +2227,51 @@ fn timeout_round_event_reflects_timed_out_state() {
     assert_eq!(timed_out.round_number, 1);
 }
 
+#[test]
+fn pause_unpause_emit_versioned_payloads() {
+    use soroban_sdk::testutils::Events as _;
+
+    let (env, _admin, client) = setup_with_admin();
+
+    client.pause();
+    let pause_event = env.events().all().last().unwrap();
+    let (_contract, pause_topics, pause_data) = pause_event;
+    let pause_topic: Symbol = pause_topics.get(0).unwrap().into_val(&env);
+    let pause_payload: (u32,) = pause_data.into_val(&env);
+    assert_eq!(pause_topic, symbol_short!("PAUSED"));
+    assert_eq!(pause_payload, (1u32,));
+
+    client.unpause();
+    let unpause_event = env.events().all().last().unwrap();
+    let (_contract, unpause_topics, unpause_data) = unpause_event;
+    let unpause_topic: Symbol = unpause_topics.get(0).unwrap().into_val(&env);
+    let unpause_payload: (u32,) = unpause_data.into_val(&env);
+    assert_eq!(unpause_topic, symbol_short!("UNPAUSED"));
+    assert_eq!(unpause_payload, (1u32,));
+}
+
+#[test]
+fn set_winner_event_includes_version_field() {
+    use soroban_sdk::testutils::Events as _;
+
+    let (env, admin, client) = setup_with_admin();
+    let (_asset, token_id) = setup_token(&env, &admin);
+    client.set_token(&token_id);
+    client.init(&5, &TEST_REQUIRED_STAKE);
+
+    let winner = Address::generate(&env);
+    client.set_winner(&winner, &100i128, &10i128);
+
+    let winner_event = env.events().all().last().unwrap();
+    let (_contract, topics, data) = winner_event;
+    let topic: Symbol = topics.get(0).unwrap().into_val(&env);
+    let payload: (Address, i128, i128, u32) = data.into_val(&env);
+
+    assert_eq!(topic, symbol_short!("WIN_SET"));
+    assert_eq!(payload.0, winner);
+    assert_eq!(payload.3, 1u32);
+}
+
 // ── Issue #358: claim() must verify caller is the designated winner ────────────
 
 #[test]

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -1895,17 +1895,27 @@ fn claim_rejects_before_game_is_finished() {
 }
 
 #[test]
-fn claim_second_set_winner_adds_to_prize_pool() {
-    let (env, _admin, client, token_id, winner) = setup_finished_game_with_winner(0i128);
-    // Pool starts with 300 (3 players × 100) + 0 (prize_amount) = 300.
-    // set_winner now adds to existing pool instead of overwriting.
-    let asset = StellarAssetClient::new(&env, &token_id);
-    asset.mint(&client.address, &700i128); // total contract balance = 300 + 700 = 1000
-    client.set_winner(&winner, &200i128, &100i128); // pool = 300 + 300 = 600
-    client.set_winner(&winner, &150i128, &50i128); // pool = 600 + 200 = 800
+fn claim_second_set_winner_overwrites_prize_pool() {
+    let (_env, _admin, client, _token_id, winner) = setup_finished_game_with_winner(0i128);
 
+    let err = client.try_set_winner(&winner, &200i128, &100i128);
+    assert_eq!(err, Err(Ok(ArenaError::WinnerAlreadySet)));
+
+    // Original pool remains claimable by the original winner.
     let claimed = client.claim(&winner);
-    assert_eq!(claimed, 800i128);
+    assert_eq!(claimed, 300i128);
+}
+
+#[test]
+fn set_winner_twice_returns_error() {
+    let (env, _admin, client, _token_id, winner) = setup_finished_game_with_winner(0i128);
+    let second = Address::generate(&env);
+
+    let err = client.try_set_winner(&second, &50i128, &25i128);
+    assert_eq!(err, Err(Ok(ArenaError::WinnerAlreadySet)));
+
+    let prize = client.claim(&winner);
+    assert_eq!(prize, 300i128);
 }
 
 #[test]

--- a/contract/arena/src/test.rs
+++ b/contract/arena/src/test.rs
@@ -2300,6 +2300,22 @@ fn claim_succeeds_only_for_designated_winner() {
 #[test]
 fn claim_fails_without_any_winner_set() {
     let (env, _admin, client, _token_id, players) = setup_game(5, 3);
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&GAME_FINISHED_KEY, &true);
+    });
+
+    // set_winner() never called and multiple survivors remain.
+    let result = client.try_claim(&players[0]);
+    assert_eq!(
+        result,
+        Err(Ok(ArenaError::WinnerNotSet)),
+        "claim must fail when no winner has been designated"
+    );
+}
+
+#[test]
+fn last_survivor_can_claim_after_resolve_round() {
+    let (env, _admin, client, _token_id, players) = setup_game(5, 3);
     set_ledger_sequence(&env, 1);
     client.start_round();
     client.submit_choice(&players[0], &1u32, &Choice::Heads);
@@ -2307,13 +2323,24 @@ fn claim_fails_without_any_winner_set() {
     client.submit_choice(&players[2], &1u32, &Choice::Tails);
     set_ledger_sequence(&env, 7);
     client.resolve_round();
-    // set_winner() never called — DataKey::Winner is absent for everyone.
+
+    // No explicit set_winner() call; sole survivor can still claim.
+    let prize = client.claim(&players[0]);
+    assert_eq!(prize, 300i128);
+
+    let user_state = client.get_user_state(&players[0]);
+    assert!(user_state.has_won);
+}
+
+#[test]
+fn claim_fails_gracefully_when_game_finished_but_winner_not_set() {
+    let (env, _admin, client, _token_id, players) = setup_game(5, 3);
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&GAME_FINISHED_KEY, &true);
+    });
+
     let result = client.try_claim(&players[0]);
-    assert_eq!(
-        result,
-        Err(Ok(ArenaError::NotASurvivor)),
-        "claim must fail when no winner has been designated"
-    );
+    assert_eq!(result, Err(Ok(ArenaError::WinnerNotSet)));
 }
 
 // ── Issue #227: minority-wins resolution algorithm unit tests ─────────────────

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -375,9 +375,6 @@ impl FactoryContract {
             capacity,
             stake_amount: stake,
         };
-        env.storage()
-            .persistent()
-            .set(&DataKey::Pool(pool_id), &metadata);
 
         // ── Deployment ──────────────────────────────────────────────────────────
 
@@ -443,6 +440,11 @@ impl FactoryContract {
             &soroban_sdk::Symbol::new(&env, "set_admin"),
             soroban_sdk::vec![&env, caller.into_val(&env)],
         );
+
+        // Persist metadata only after deployment and all init calls succeed.
+        env.storage()
+            .persistent()
+            .set(&DataKey::Pool(pool_id), &metadata);
 
         // Increment the pool counter.
         env.storage()

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -387,6 +387,20 @@ fn test_create_pool_two_pools_have_independent_state() {
     assert_eq!(arena2.admin(), admin);
 }
 
+#[test]
+fn create_pool_metadata_not_visible_before_full_init() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+
+    // round_speed = 0 makes arena.init fail; metadata must not become visible.
+    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &0u32, &8u32);
+    assert!(result.is_err());
+
+    assert!(client.get_arena(&0u32).is_none());
+    assert_eq!(client.get_arenas(&0u32, &10u32).len(), 0);
+}
+
 // ── propose_upgrade ───────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Fix arena winner assignment, event schema drift, lone-survivor claims, and factory metadata ordering

### Summary
Closes #416
Closes #417 
Closes #418 
Closes #421 
This PR fixes four contract issues across the arena and factory modules.

##### Arena winner overwrite bug
set_winner() now rejects a second winner assignment instead of allowing the prize configuration to be overwritten. This prevents multiple valid claimants from racing for a single pool and keeps stale winner state from persisting after a second call.

##### Arena event schema drift
Arena event emissions were aligned with the documented schema and versioning policy. PAUSED and UNPAUSED now emit versioned payloads, WIN_SET now includes the event version field, and EVENTS.md was updated to matchthe real arena event surface.

##### Lone-survivor claim fallback
If the game is marked finished with exactly one survivor remaining and no explicit winner has been set, that last survivor can now claim the prize. Calls from non-winners in a finished game without a winner assignment now fail with a  clearer WinnerNotSet error.

#### Factory partial-init metadata exposure
create_pool() now persists pool metadata only after deployment and all arena initialization calls succeed. This avoids exposing metadata for partially initialized pools and prevents pool-id reuse from silently overwriting metadata on retry.^C


