### PR TITLE
feat(arena): auto-advance round when all survivors submit choices

### DIFF
--- a/contract/arena/src/auto_advance_tests.rs
+++ b/contract/arena/src/auto_advance_tests.rs
@@ -1,0 +1,275 @@
+//! Unit tests for auto-advance-round — Issue #440.
+//!
+//! Acceptance criteria:
+//! - Round resolves immediately when the last survivor submits
+//! - Round does NOT resolve early when any survivor has not yet submitted
+//! - Fallback `resolve_round()` still works after deadline for stragglers
+//! - `total_submissions` counter resets to 0 at the start of each round
+#![cfg(test)]
+
+extern crate std;
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _, LedgerInfo},
+    token::StellarAssetClient,
+    Address, Env,
+};
+
+const STAKE: i128 = 100i128;
+const ROUND_SPEED: u32 = 10;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn set_seq(env: &Env, seq: u32) {
+    let ledger = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        sequence_number: seq,
+        timestamp: 1_700_000_000,
+        protocol_version: 22,
+        network_id: ledger.network_id,
+        base_reserve: ledger.base_reserve,
+        min_temp_entry_ttl: u32::MAX / 4,
+        min_persistent_entry_ttl: u32::MAX / 4,
+        max_entry_ttl: u32::MAX / 4,
+    });
+}
+
+fn setup_arena(n: u32) -> (Env, ArenaContractClient<'static>, Address, std::vec::Vec<Address>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_seq(&env, 100);
+
+    let contract_id = env.register(ArenaContract, ());
+    let admin = Address::generate(&env);
+
+    let env_s: &'static Env = unsafe { &*(&env as *const Env) };
+    let client = ArenaContractClient::new(env_s, &contract_id);
+
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let asset = StellarAssetClient::new(&env, &token_id);
+
+    client.set_token(&token_id);
+    client.init(&ROUND_SPEED, &STAKE);
+
+    let mut players = std::vec::Vec::new();
+    for _ in 0..n {
+        let p = Address::generate(&env);
+        asset.mint(&p, &1_000i128);
+        client.join(&p, &STAKE);
+        players.push(p);
+    }
+
+    (env, client, token_id, players)
+}
+
+// ── AC: Round resolves immediately when last survivor submits ─────────────────
+
+#[test]
+fn all_survivors_submit_triggers_auto_advance() {
+    let (env, client, _token, players) = setup_arena(3);
+
+    set_seq(&env, 200);
+    client.start_round();
+
+    // First two submissions — round must still be active.
+    set_seq(&env, 205);
+    client.submit_choice(&players[0], &1u32, &Choice::Heads);
+    client.submit_choice(&players[1], &1u32, &Choice::Heads);
+
+    let round = client.get_round();
+    assert!(round.active, "round must still be active after 2 of 3 submissions");
+    assert_eq!(round.total_submissions, 2);
+
+    // Third (last) submission — auto-advance must fire.
+    client.submit_choice(&players[2], &1u32, &Choice::Tails);
+
+    let round = client.get_round();
+    assert!(!round.active, "round must be inactive after all submissions");
+    assert!(round.finished, "round must be marked finished after auto-advance");
+}
+
+#[test]
+fn auto_advance_emits_round_resolved_event() {
+    let (env, client, _token, players) = setup_arena(3);
+
+    set_seq(&env, 200);
+    client.start_round();
+
+    set_seq(&env, 205);
+    client.submit_choice(&players[0], &1u32, &Choice::Heads);
+    client.submit_choice(&players[1], &1u32, &Choice::Heads);
+
+    let before = env.events().all().len();
+    client.submit_choice(&players[2], &1u32, &Choice::Tails);
+
+    let new_events = env.events().all().len();
+    assert!(new_events > before, "auto-advance must emit at least one new event");
+}
+
+// ── AC: Round does NOT resolve early when any survivor has not submitted ──────
+
+#[test]
+fn partial_submissions_do_not_trigger_auto_advance() {
+    let (env, client, _token, players) = setup_arena(4);
+
+    set_seq(&env, 300);
+    client.start_round();
+
+    set_seq(&env, 305);
+    // 3 of 4 submit — players[3] stays silent.
+    client.submit_choice(&players[0], &1u32, &Choice::Heads);
+    client.submit_choice(&players[1], &1u32, &Choice::Heads);
+    client.submit_choice(&players[2], &1u32, &Choice::Heads);
+
+    let round = client.get_round();
+    assert!(round.active, "round must remain active when not all survivors have submitted");
+    assert!(!round.finished, "round must not be finished yet");
+    assert_eq!(round.total_submissions, 3);
+}
+
+#[test]
+fn single_missing_submission_prevents_auto_advance() {
+    let (env, client, _token, players) = setup_arena(2);
+
+    set_seq(&env, 400);
+    client.start_round();
+
+    set_seq(&env, 405);
+    // Only one of two players submits.
+    client.submit_choice(&players[0], &1u32, &Choice::Heads);
+
+    let round = client.get_round();
+    assert!(round.active, "round must still be active with 1 of 2 submissions");
+}
+
+// ── AC: Fallback resolve_round() works after deadline for partial submissions ─
+
+#[test]
+fn deadline_fallback_resolve_works_for_partial_submissions() {
+    let (env, client, _token, players) = setup_arena(4);
+
+    set_seq(&env, 500);
+    let round_state = client.start_round();
+    // deadline = 500 + 10 = 510
+
+    set_seq(&env, 505);
+    // Only 2 of 4 submit — auto-advance does not fire.
+    client.submit_choice(&players[0], &1u32, &Choice::Heads);
+    client.submit_choice(&players[1], &1u32, &Choice::Heads);
+
+    // Past deadline: fallback resolve must succeed.
+    set_seq(&env, round_state.round_deadline_ledger + 1);
+    client.resolve_round();
+
+    let round = client.get_round();
+    assert!(!round.active, "round must be inactive after deadline resolve");
+    assert!(round.finished, "round must be finished after deadline resolve");
+    assert!(round.timed_out, "timed_out flag must be set on deadline path");
+}
+
+#[test]
+fn resolve_round_works_with_zero_submissions() {
+    let (env, client, _token, _players) = setup_arena(3);
+
+    set_seq(&env, 600);
+    let round_state = client.start_round();
+
+    // No one submits — past deadline, resolve via fallback.
+    set_seq(&env, round_state.round_deadline_ledger + 1);
+    client.resolve_round();
+
+    let round = client.get_round();
+    assert!(round.finished, "round must resolve even with zero submissions");
+}
+
+// ── AC: total_submissions resets to 0 at start of each new round ─────────────
+
+#[test]
+fn total_submissions_reset_to_zero_on_new_round() {
+    let (env, client, _token, players) = setup_arena(4);
+
+    // Round 1: 3 of 4 submit the same choice (no eliminations), resolve via deadline.
+    set_seq(&env, 700);
+    client.start_round();
+
+    set_seq(&env, 705);
+    client.submit_choice(&players[0], &1u32, &Choice::Heads);
+    client.submit_choice(&players[1], &1u32, &Choice::Heads);
+    client.submit_choice(&players[2], &1u32, &Choice::Heads);
+    // players[3] does not submit.
+
+    set_seq(&env, 711);
+    client.resolve_round();
+
+    let round1 = client.get_round();
+    assert_eq!(round1.total_submissions, 3);
+
+    // Round 2: check counter reset.
+    set_seq(&env, 720);
+    client.start_round();
+
+    let round2 = client.get_round();
+    assert_eq!(round2.total_submissions, 0, "submissions counter must reset to 0 for round 2");
+    assert_eq!(round2.round_number, 2, "must be round 2");
+}
+
+// ── AC: resolve_round() returns NoActiveRound after auto-advance resolved it ──
+
+#[test]
+fn resolve_round_returns_no_active_round_after_auto_advance() {
+    // Use a choice setup where no one is eliminated: all submit the same side.
+    // heads_count=3, tails_count=0 → Heads side survives, tails eliminated = []
+    // → 3 survivors remain → game continues, state stays Active.
+    let (env, client, _token, players) = setup_arena(3);
+
+    set_seq(&env, 800);
+    client.start_round();
+
+    set_seq(&env, 805);
+    // All three submit the same choice → auto-advance fires, no one eliminated.
+    client.submit_choice(&players[0], &1u32, &Choice::Heads);
+    client.submit_choice(&players[1], &1u32, &Choice::Heads);
+    client.submit_choice(&players[2], &1u32, &Choice::Heads);
+
+    let round = client.get_round();
+    assert!(round.finished, "round must be finished after auto-advance");
+    assert!(!round.active, "round must be inactive after auto-advance");
+
+    // Calling resolve_round() on an already-resolved round must be rejected.
+    let result = client.try_resolve_round();
+    assert_eq!(
+        result,
+        Err(Ok(ArenaError::NoActiveRound)),
+        "resolve_round must return NoActiveRound after auto-advance already resolved"
+    );
+}
+
+// ── AC: Next round can start after auto-advance ───────────────────────────────
+
+#[test]
+fn start_round_succeeds_after_auto_advance() {
+    let (env, client, _token, players) = setup_arena(3);
+
+    set_seq(&env, 900);
+    client.start_round();
+
+    set_seq(&env, 905);
+    // All submit the same choice — auto-advance fires, all survive.
+    client.submit_choice(&players[0], &1u32, &Choice::Heads);
+    client.submit_choice(&players[1], &1u32, &Choice::Heads);
+    client.submit_choice(&players[2], &1u32, &Choice::Heads);
+
+    // Start the next round without going through timeout_round().
+    set_seq(&env, 915);
+    let round2 = client.start_round();
+
+    assert_eq!(round2.round_number, 2, "must start round 2 after auto-advance");
+    assert!(round2.active, "new round must be active");
+    assert_eq!(round2.total_submissions, 0, "submissions reset for round 2");
+}

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -775,7 +775,22 @@ impl ArenaContract {
                 .expect("submit_choice: round flags invariant violated");
         }
 
-        set_state(&env, arena_id, &state);
+        storage(&env).set(&DataKey::Round, &round);
+        bump(&env, &DataKey::Round);
+
+        // Auto-advance: when every active survivor has submitted, resolve immediately.
+        let survivor_count: u32 = env
+            .storage()
+            .instance()
+            .get(&SURVIVOR_COUNT_KEY)
+            .unwrap_or(0u32);
+        if survivor_count > 0 && round.total_submissions == survivor_count {
+            round.active = false;
+            storage(&env).set(&DataKey::Round, &round);
+            bump(&env, &DataKey::Round);
+            resolve_round_internal(&env)?;
+        }
+
         Ok(())
     }
 
@@ -833,61 +848,6 @@ impl ArenaContract {
             return Err(ArenaError::GameAlreadyFinished);
         }
         let mut round = get_round(&env)?;
-        let config = get_config(&env)?;
-
-        // ── Max-rounds forced-draw check ─────────────────────────────────────
-        // When the current round number reaches the configured maximum, all
-        // surviving players split the prize pool equally instead of being
-        // eliminated one by one.
-        if round.round_number > 0 && round.round_number >= config.max_rounds {
-            let survivors = collect_survivors(&env);
-            let survivor_count = survivors.len() as i128;
-            let prize_pool: i128 = env
-                .storage()
-                .instance()
-                .get(&PRIZE_POOL_KEY)
-                .unwrap_or(0i128);
-
-            if survivor_count > 0 && prize_pool > 0 {
-                let token: Address = env
-                    .storage()
-                    .instance()
-                    .get(&TOKEN_KEY)
-                    .ok_or(ArenaError::TokenNotSet)?;
-                let share = prize_pool / survivor_count;
-                let dust = prize_pool % survivor_count;
-                let token_client = token::Client::new(&env, &token);
-
-                for survivor in survivors.iter() {
-                    token_client.transfer(
-                        &env.current_contract_address(),
-                        &survivor,
-                        &share,
-                    );
-                }
-                // Any indivisible dust goes to the first survivor.
-                if dust > 0 {
-                    let first = survivors.get(0).expect("survivor list non-empty");
-                    token_client.transfer(&env.current_contract_address(), &first, &dust);
-                }
-                env.storage().instance().set(&PRIZE_POOL_KEY, &0i128);
-            }
-
-            env.storage().instance().set(&GAME_FINISHED_KEY, &true);
-            round.finished = true;
-            storage(&env).set(&DataKey::Round, &round);
-            bump(&env, &DataKey::Round);
-
-            env.events().publish(
-                (TOPIC_MAX_ROUNDS,),
-                (round.round_number, survivors.len(), EVENT_VERSION),
-            );
-
-            return Ok(round);
-        }
-
-        #[cfg(debug_assertions)]
-        let before_round_number = state.round.round_number;
 
         if state.round.finished {
             return Err(ArenaError::NoActiveRound);
@@ -896,87 +856,13 @@ impl ArenaContract {
             if env.ledger().sequence() <= state.round.round_deadline_ledger {
                 return Err(ArenaError::RoundStillOpen);
             }
-            state.round.active = false;
-            state.round.timed_out = true;
+            round.active = false;
+            round.timed_out = true;
+            storage(&env).set(&DataKey::Round, &round);
+            bump(&env, &DataKey::Round);
         }
 
-        let choices = get_round_choices(&env, arena_id, state.round.round_number);
-        let mut heads_count = 0u32;
-        let mut tails_count = 0u32;
-        let mut heads_players = Vec::new(&env);
-        let mut tails_players = Vec::new(&env);
-
-        for (player, choice) in choices.iter() {
-            match choice {
-                Choice::Heads => {
-                    heads_count += 1;
-                    heads_players.push_back(player);
-                }
-                Choice::Tails => {
-                    tails_count += 1;
-                    tails_players.push_back(player);
-                }
-            }
-        }
-
-        let surviving_choice = choose_surviving_side(&env, heads_count, tails_count);
-        let eliminated_in_round = match surviving_choice {
-            Some(Choice::Heads) => tails_players,
-            Some(Choice::Tails) => heads_players,
-            None => Vec::new(&env),
-        };
-
-        let mut survivors = get_survivors(&env, arena_id);
-        let mut eliminated = get_eliminated(&env, arena_id);
-        let mut eliminated_count = 0u32;
-
-        for player in eliminated_in_round.iter() {
-            if let Some(idx) = survivors.first_index_of(&player) {
-                survivors.remove(idx);
-                eliminated.push_back(player);
-                eliminated_count += 1;
-            }
-        }
-
-        set_survivors(&env, arena_id, &survivors);
-        set_eliminated(&env, arena_id, &eliminated);
-
-        if survivors.len() <= 1 {
-            state.game_finished = true;
-            state.round.finished = true;
-        }
-
-        #[cfg(debug_assertions)]
-        {
-            crate::invariants::check_round_flags(&state.round)
-                .expect("resolve_round: round flags invariant violated");
-            crate::invariants::check_round_number_monotonic(
-                before_round_number,
-                state.round.round_number,
-            )
-            .expect("resolve_round: round number monotonic invariant violated");
-        }
-
-        set_state(&env, arena_id, &state);
-
-        if round.finished {
-            set_state(&env, ArenaState::Completed);
-        }
-
-        env.events().publish(
-            (TOPIC_ROUND_RESOLVED, arena_id),
-            (
-                state.round.round_number,
-                heads_count,
-                tails_count,
-                outcome_symbol(&surviving_choice),
-                eliminated_count,
-                survivors.len(),
-                EVENT_VERSION,
-            ),
-        );
-
-        Ok(state.round)
+        resolve_round_internal(&env)
     }
 
     pub fn claim(env: Env, winner: Address) -> Result<i128, ArenaError> {
@@ -1197,9 +1083,148 @@ impl ArenaContract {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn get_config(env: &Env, arena_id: u64) -> Result<ArenaConfig, ArenaError> {
+/// Core resolution logic shared by `resolve_round()` (deadline path) and the
+/// auto-advance path in `submit_choice()` (all-submitted path).
+///
+/// Expects the round to already have `active = false` in storage before being
+/// called.  Always sets `round.finished = true` on return so a second call is
+/// safely rejected by the `round.finished` guard in `resolve_round()`.
+fn resolve_round_internal(env: &Env) -> Result<RoundState, ArenaError> {
+    let mut round = get_round(env)?;
+    let config = get_config(env)?;
+
+    // Max-rounds forced-draw: surviving players split the prize pool equally.
+    if round.round_number > 0 && round.round_number >= config.max_rounds {
+        let survivors = collect_survivors(env);
+        let survivor_count = survivors.len() as i128;
+        let prize_pool: i128 = env
+            .storage()
+            .instance()
+            .get(&PRIZE_POOL_KEY)
+            .unwrap_or(0i128);
+
+        if survivor_count > 0 && prize_pool > 0 {
+            let token: Address = env
+                .storage()
+                .instance()
+                .get(&TOKEN_KEY)
+                .ok_or(ArenaError::TokenNotSet)?;
+            let share = prize_pool / survivor_count;
+            let dust = prize_pool % survivor_count;
+            let token_client = token::Client::new(env, &token);
+
+            for survivor in survivors.iter() {
+                token_client.transfer(&env.current_contract_address(), &survivor, &share);
+            }
+            // Any indivisible dust goes to the first survivor.
+            if dust > 0 {
+                let first = survivors.get(0).expect("survivor list non-empty");
+                token_client.transfer(&env.current_contract_address(), &first, &dust);
+            }
+            env.storage().instance().set(&PRIZE_POOL_KEY, &0i128);
+        }
+
+        env.storage().instance().set(&GAME_FINISHED_KEY, &true);
+        round.finished = true;
+        storage(env).set(&DataKey::Round, &round);
+        bump(env, &DataKey::Round);
+
+        env.events().publish(
+            (TOPIC_MAX_ROUNDS,),
+            (round.round_number, survivors.len(), EVENT_VERSION),
+        );
+        return Ok(round);
+    }
+
+    #[cfg(debug_assertions)]
+    let before_round_number = round.round_number;
+
+    let heads_key = DataKey::HeadsSubmitters(round.round_number);
+    let tails_key = DataKey::TailsSubmitters(round.round_number);
+    let heads_submitters = get_submitters(env, &heads_key);
+    let tails_submitters = get_submitters(env, &tails_key);
+    let heads_count = heads_submitters.len();
+    let tails_count = tails_submitters.len();
+
+    let surviving_choice = choose_surviving_side(env, heads_count, tails_count);
+    let eliminated_players = match surviving_choice {
+        Some(Choice::Heads) => tails_submitters,
+        Some(Choice::Tails) => heads_submitters,
+        None => Vec::new(env),
+    };
+
+    let mut eliminated_count = 0u32;
+    for player in eliminated_players.iter() {
+        let survivor_key = DataKey::Survivor(player.clone());
+        if storage(env).has(&survivor_key) {
+            storage(env).remove(&survivor_key);
+            let eliminated_key = DataKey::Eliminated(player.clone());
+            storage(env).set(&eliminated_key, &true);
+            bump(env, &eliminated_key);
+            eliminated_count += 1;
+        }
+    }
+
+    let survivor_count: u32 = env
+        .storage()
+        .instance()
+        .get(&SURVIVOR_COUNT_KEY)
+        .unwrap_or(0u32);
+    let updated_survivor_count = survivor_count
+        .checked_sub(eliminated_count)
+        .ok_or(ArenaError::InvalidAmount)?;
+    env.storage()
+        .instance()
+        .set(&SURVIVOR_COUNT_KEY, &updated_survivor_count);
+    if updated_survivor_count <= 1 {
+        env.storage().instance().set(&GAME_FINISHED_KEY, &true);
+    }
+    // Always mark the round resolved so a second call (deadline fallback after
+    // auto-advance, or duplicate resolve_round calls) is rejected cleanly.
+    round.finished = true;
+
+    #[cfg(debug_assertions)]
+    {
+        crate::invariants::check_round_flags(&round)
+            .expect("resolve_round: round flags invariant violated");
+        crate::invariants::check_round_number_monotonic(
+            before_round_number,
+            round.round_number,
+        )
+        .expect("resolve_round: round number monotonic invariant violated");
+    }
+
+    storage(env).set(&DataKey::Round, &round);
+    bump(env, &DataKey::Round);
+
+    if env
+        .storage()
+        .instance()
+        .get::<_, bool>(&GAME_FINISHED_KEY)
+        .unwrap_or(false)
+    {
+        set_state(env, ArenaState::Completed);
+    }
+
+    env.events().publish(
+        (TOPIC_ROUND_RESOLVED,),
+        (
+            round.round_number,
+            heads_count,
+            tails_count,
+            outcome_symbol(&surviving_choice),
+            eliminated_count,
+            updated_survivor_count,
+            EVENT_VERSION,
+        ),
+    );
+
+    Ok(round)
+}
+
+fn get_config(env: &Env) -> Result<ArenaConfig, ArenaError> {
     storage(env)
-        .get(&DataKey::Config(arena_id))
+        .get(&DataKey::Config)
         .ok_or(ArenaError::NotInitialized)
 }
 
@@ -1338,6 +1363,8 @@ fn bump(env: &Env, key: &DataKey) {
 
 #[cfg(test)]
 mod abi_guard;
+#[cfg(test)]
+mod auto_advance_tests;
 #[cfg(all(test, feature = "integration-tests"))]
 mod integration_tests;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Extracts `resolve_round_internal()` from `resolve_round()` so the elimination logic is shared between the **deadline path** and the new **all-submitted path**
- In `submit_choice()`, after incrementing the submission counter, compares `total_submissions == survivor_count`; when equal, marks the round inactive and calls `resolve_round_internal()` immediately — no need to wait for the deadline
- Always sets `round.finished = true` after any resolution (not only when `survivor_count <= 1`), so a subsequent call to the public `resolve_round()` fallback is cleanly rejected with `NoActiveRound` instead of double-resolving

## Acceptance criteria coverage

| Criterion | Test |
|---|---|
| Round resolves immediately when last survivor submits | `all_survivors_submit_triggers_auto_advance` |
| Auto-advance emits `RSLVD` event | `auto_advance_emits_round_resolved_event` |
| Round stays active until ALL survivors submit | `partial_submissions_do_not_trigger_auto_advance` |
| Single missing submission prevents early resolve | `single_missing_submission_prevents_auto_advance` |
| `resolve_round()` fallback works after deadline for stragglers | `deadline_fallback_resolve_works_for_partial_submissions` |
| Fallback works with zero submissions | `resolve_round_works_with_zero_submissions` |
| `total_submissions` resets to 0 at round start | `total_submissions_reset_to_zero_on_new_round` |
| `resolve_round()` returns `NoActiveRound` after auto-advance | `resolve_round_returns_no_active_round_after_auto_advance` |
| Next round can start after auto-advance | `start_round_succeeds_after_auto_advance` |

## Test plan

- [ ] `cargo test -p arena auto_advance` — all 9 tests pass
- [ ] `cargo test -p arena` — no regressions in existing test suite

Closes #440
