### PR TITLE
feat(arena): implement arena join deadline to auto-cancel unfilled games

### DIFF
--- a/contract/arena/src/commit_reveal_tests.rs
+++ b/contract/arena/src/commit_reveal_tests.rs
@@ -26,7 +26,7 @@ fn setup_test_env() -> (Env, ArenaContractClient<'static>, Address, Address) {
     let token_id = env.register_stellar_asset_contract(token_admin.clone());
     
     client.set_token(&token_id);
-    client.init(&10, &100); // 10 ledgers speed, 100 stake
+    client.init(&10, &100, &(env.ledger().timestamp() + 7200)); // 10 ledgers speed, 100 stake, 2h deadline
     
     (env, client, admin, token_id)
 }

--- a/contract/arena/src/expire_arena_tests.rs
+++ b/contract/arena/src/expire_arena_tests.rs
@@ -1,0 +1,113 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
+
+fn setup_arena_env() -> (Env, ArenaContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ArenaContract, ());
+    let client = ArenaContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin.clone());
+
+    client.set_token(&token_id);
+
+    // SAFETY: env lives for the duration of the test.
+    let env_static: &'static Env = unsafe { &*(&env as *const Env) };
+    let client = ArenaContractClient::new(env_static, &contract_id);
+
+    (env, client, admin, token_id)
+}
+
+#[test]
+fn test_expire_arena_before_deadline_fails() {
+    let (env, client, _admin, _token) = setup_arena_env();
+    let deadline = env.ledger().timestamp() + 7200; // 2 hours from now
+    client.init(&10, &100, &deadline);
+
+    // Try to expire immediately — deadline has not been reached yet
+    let result = client.try_expire_arena();
+    assert_eq!(result, Err(Ok(ArenaError::DeadlineNotReached)));
+}
+
+#[test]
+fn test_expire_arena_after_deadline_succeeds_and_refunds() {
+    let (env, client, _admin, token_id) = setup_arena_env();
+    let deadline = env.ledger().timestamp() + 7200; // 2 hours from now
+    client.init(&10, &100, &deadline);
+
+    // Mint tokens and have one player join
+    let player = Address::generate(&env);
+    let token_client = token::StellarAssetClient::new(&env, &token_id);
+    token_client.mint(&player, &200);
+
+    client.join(&player, &100);
+
+    // Advance time past the deadline
+    env.ledger().with_mut(|l| {
+        l.timestamp = deadline + 1;
+    });
+
+    // Expire arena — should succeed and refund the player
+    client.expire_arena();
+
+    // Verify arena is now cancelled
+    assert_eq!(client.state(), ArenaState::Cancelled);
+    assert!(client.is_cancelled());
+}
+
+#[test]
+#[should_panic]
+fn test_expire_arena_on_active_arena_panics() {
+    let (env, client, _admin, token_id) = setup_arena_env();
+    let deadline = env.ledger().timestamp() + 7200;
+    client.init(&10, &100, &deadline);
+
+    // Have two players join and start a round to activate the arena
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+    let token_client = token::StellarAssetClient::new(&env, &token_id);
+    token_client.mint(&player1, &200);
+    token_client.mint(&player2, &200);
+
+    client.join(&player1, &100);
+    client.join(&player2, &100);
+    client.start_round(); // transitions state to Active
+
+    // Advance time past deadline
+    env.ledger().with_mut(|l| {
+        l.timestamp = deadline + 1;
+    });
+
+    // expire_arena should panic because state is Active, not Pending
+    client.expire_arena();
+}
+
+#[test]
+fn test_deadline_too_soon_rejected() {
+    let (env, client, _admin, _token) = setup_arena_env();
+    let now = env.ledger().timestamp();
+    // 30 minutes — less than the required minimum of 1 hour (3600 seconds)
+    let deadline = now + 1800;
+    let result = client.try_init(&10, &100, &deadline);
+    assert_eq!(result, Err(Ok(ArenaError::DeadlineTooSoon)));
+}
+
+#[test]
+fn test_deadline_too_far_rejected() {
+    let (env, client, _admin, _token) = setup_arena_env();
+    let now = env.ledger().timestamp();
+    // 700000 seconds — exceeds the maximum of 604800 (1 week)
+    let deadline = now + 700_000;
+    let result = client.try_init(&10, &100, &deadline);
+    assert_eq!(result, Err(Ok(ArenaError::DeadlineTooFar)));
+}

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -38,6 +38,7 @@ const TOPIC_ROUND_RESOLVED: Symbol = symbol_short!("RSLVD");
 const TOPIC_PLAYER_ELIMINATED: Symbol = symbol_short!("P_ELIM");
 const TOPIC_WINNER_DECLARED: Symbol = symbol_short!("W_DECL");
 const TOPIC_ARENA_CANCELLED: Symbol = symbol_short!("A_CANC");
+const TOPIC_ARENA_EXPIRED: Symbol = symbol_short!("A_EXP");
 
 const EVENT_VERSION: u32 = 1;
 
@@ -88,6 +89,9 @@ pub enum ArenaError {
     RevealDeadlinePassed = 39,
     CommitDeadlinePassed = 40,
     AlreadyCommitted = 41,
+    DeadlineTooSoon = 42,
+    DeadlineTooFar = 43,
+    DeadlineNotReached = 44,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -106,6 +110,7 @@ pub struct ArenaConfig {
     pub round_duration_seconds: u64,
     pub required_stake_amount: i128,
     pub max_rounds: u32,
+    pub join_deadline: u64,
 }
 
 #[contracttype]
@@ -218,6 +223,13 @@ pub struct ArenaCancelled {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArenaExpired {
+    pub arena_id: u64,
+    pub refunded_players: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ArenaSnapshot {
     pub arena_id: u64,
     pub state: ArenaState,
@@ -326,6 +338,7 @@ impl ArenaContract {
         env: Env,
         round_speed_in_ledgers: u32,
         required_stake_amount: i128,
+        join_deadline: u64,
     ) -> Result<(), ArenaError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
@@ -333,13 +346,22 @@ impl ArenaContract {
         if env.storage().instance().has(&DataKey::Config) {
             return Err(ArenaError::AlreadyInitialized);
         }
+
+        let now = env.ledger().timestamp();
+        if join_deadline < now + 3600 {
+            return Err(ArenaError::DeadlineTooSoon);
+        }
+        if join_deadline > now + 604800 {
+            return Err(ArenaError::DeadlineTooFar);
+        }
+
         if round_speed_in_ledgers == 0 || round_speed_in_ledgers > bounds::MAX_SPEED_LEDGERS {
             return Err(ArenaError::InvalidRoundSpeed);
         }
         if required_stake_amount < bounds::MIN_REQUIRED_STAKE {
             return Err(ArenaError::InvalidAmount);
         }
-        
+
         env.storage().instance().extend_ttl(GAME_TTL_THRESHOLD, GAME_TTL_EXTEND_TO);
         env.storage().instance().set(
             &DataKey::Config,
@@ -348,6 +370,7 @@ impl ArenaContract {
                 round_duration_seconds: 0,
                 required_stake_amount,
                 max_rounds: bounds::DEFAULT_MAX_ROUNDS,
+                join_deadline,
             },
         );
         env.storage().instance().set(
@@ -541,6 +564,61 @@ impl ArenaContract {
         env.events().publish((TOPIC_CANCELLED,), (EVENT_VERSION,));
 
         Ok(())
+    }
+
+    /// Expire an unfilled arena past its join deadline. Callable by anyone.
+    pub fn expire_arena(env: Env) -> Result<(), ArenaError> {
+        let current_state = get_state(&env);
+        assert_state!(current_state, ArenaState::Pending);
+
+        let config = get_config(&env)?;
+        if env.ledger().timestamp() <= config.join_deadline {
+            return Err(ArenaError::DeadlineNotReached);
+        }
+
+        let all_players: Vec<Address> = env.storage().persistent().get(&DataKey::AllPlayers).unwrap_or(Vec::new(&env));
+        let mut refunded_count: u32 = 0;
+        if !all_players.is_empty() {
+            let token: Address = env.storage().instance().get(&TOKEN_KEY).ok_or(ArenaError::TokenNotSet)?;
+            let refund_amount = config.required_stake_amount;
+            let token_client = token::Client::new(&env, &token);
+
+            for player in all_players.iter() {
+                if env.storage().persistent().has(&DataKey::Survivor(player.clone()))
+                    && !env.storage().persistent().has(&DataKey::Refunded(player.clone()))
+                {
+                    env.storage().persistent().set(&DataKey::Refunded(player.clone()), &());
+                    bump(&env, &DataKey::Refunded(player.clone()));
+                    token_client.transfer(&env.current_contract_address(), &player, &refund_amount);
+                    refunded_count += 1;
+                }
+            }
+            env.storage().instance().set(&PRIZE_POOL_KEY, &0i128);
+        }
+
+        env.storage().instance().set(&CANCELLED_KEY, &true);
+        env.storage().instance().set(&GAME_FINISHED_KEY, &true);
+        set_state(&env, ArenaState::Cancelled);
+
+        env.events().publish(
+            (TOPIC_ARENA_EXPIRED,),
+            ArenaExpired {
+                arena_id: 0,
+                refunded_players: refunded_count,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Return the join deadline timestamp stored in the config.
+    pub fn get_join_deadline(env: Env) -> u64 {
+        let config: ArenaConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("not initialized");
+        config.join_deadline
     }
 
     pub fn set_max_rounds(env: Env, max_rounds: u32) -> Result<(), ArenaError> {
@@ -1371,5 +1449,7 @@ mod abi_guard;
 // mod submit_choice_tests;
 #[cfg(test)]
 mod commit_reveal_tests;
+#[cfg(test)]
+mod expire_arena_tests;
 // #[cfg(test)]
 // mod test;

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -347,6 +347,7 @@ impl FactoryContract {
         currency: Address,
         round_speed: u32,
         capacity: u32,
+        join_deadline: u64,
     ) -> Result<Address, Error> {
         let admin = require_admin(&env)?;
         require_not_paused(&env)?;
@@ -442,7 +443,7 @@ impl FactoryContract {
         env.invoke_contract::<()>(
             &arena_address,
             &soroban_sdk::symbol_short!("init"),
-            soroban_sdk::vec![&env, round_speed.into_val(&env), stake.into_val(&env)],
+            soroban_sdk::vec![&env, round_speed.into_val(&env), stake.into_val(&env), join_deadline.into_val(&env)],
         );
 
         env.invoke_contract::<()>(

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -154,7 +154,7 @@ fn test_admin_can_create_pool() {
     client.set_arena_wasm_hash(&wasm_hash);
     let stake = MIN_STAKE + 1_000_000;
     let currency = supported_currency(&env, &client);
-    client.create_pool(&admin, &stake, &currency, &10u32, &8u32);
+    client.create_pool(&admin, &stake, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
 }
 
 #[test]
@@ -167,7 +167,7 @@ fn test_whitelisted_host_can_create_pool() {
     client.set_arena_wasm_hash(&wasm_hash);
     let stake = MIN_STAKE + 1_000_000;
     let currency = supported_currency(&env, &client);
-    client.create_pool(&host, &stake, &currency, &10u32, &8u32);
+    client.create_pool(&host, &stake, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn test_unauthorized_caller_returns_unauthorized() {
     let unauthorized = Address::generate(&env);
     let stake = MIN_STAKE + 1_000_000;
     let currency = Address::generate(&env);
-    let result = client.try_create_pool(&unauthorized, &stake, &currency, &10u32, &8u32);
+    let result = client.try_create_pool(&unauthorized, &stake, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
 
@@ -208,7 +208,7 @@ fn test_create_pool_allows_whitelisted_host_in_mock_auth_env() {
     let stake = MIN_STAKE + 1_000_000;
     let currency = Address::generate(&env);
     client.add_supported_token(&currency);
-    let result = client.try_create_pool(&host, &stake, &currency, &10u32, &8u32);
+    let result = client.try_create_pool(&host, &stake, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
 
     assert!(result.is_ok());
 }
@@ -221,7 +221,7 @@ fn test_create_pool_with_stake_equal_to_minimum_succeeds() {
     let wasm_hash = dummy_hash(&env);
     client.set_arena_wasm_hash(&wasm_hash);
     let currency = supported_currency(&env, &client);
-    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
+    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn test_create_pool_with_stake_below_minimum_returns_stake_below_minimum() {
     client.set_arena_wasm_hash(&wasm_hash);
     let stake = MIN_STAKE - 1;
     let currency = supported_currency(&env, &client);
-    let result = client.try_create_pool(&admin, &stake, &currency, &10u32, &8u32);
+    let result = client.try_create_pool(&admin, &stake, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::StakeBelowMinimum)));
 }
 
@@ -241,7 +241,7 @@ fn test_create_pool_with_zero_stake_returns_invalid_stake_amount() {
     let wasm_hash = dummy_hash(&env);
     client.set_arena_wasm_hash(&wasm_hash);
     let currency = supported_currency(&env, &client);
-    let result = client.try_create_pool(&admin, &0, &currency, &10u32, &8u32);
+    let result = client.try_create_pool(&admin, &0, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::InvalidStakeAmount)));
 }
 
@@ -251,7 +251,7 @@ fn test_create_pool_with_negative_stake_returns_invalid_stake_amount() {
     let wasm_hash = dummy_hash(&env);
     client.set_arena_wasm_hash(&wasm_hash);
     let currency = supported_currency(&env, &client);
-    let result = client.try_create_pool(&admin, &-1000, &currency, &10u32, &8u32);
+    let result = client.try_create_pool(&admin, &-1000, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::InvalidStakeAmount)));
 }
 
@@ -260,7 +260,7 @@ fn test_create_pool_without_wasm_hash_returns_wasm_hash_not_set() {
     let (env, admin, client) = setup();
     let stake = MIN_STAKE + 1_000_000;
     let currency = supported_currency(&env, &client);
-    let result = client.try_create_pool(&admin, &stake, &currency, &10u32, &8u32);
+    let result = client.try_create_pool(&admin, &stake, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::WasmHashNotSet)));
 }
 
@@ -271,7 +271,7 @@ fn test_create_pool_with_capacity_one_returns_invalid_capacity() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &1u32);
+    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &1u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::InvalidCapacity)));
 }
 
@@ -280,7 +280,7 @@ fn test_create_pool_with_capacity_two_succeeds() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &2u32);
+    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &2u32, &(env.ledger().timestamp() + 7200));
 }
 
 #[test]
@@ -288,7 +288,7 @@ fn test_create_pool_with_max_capacity_succeeds() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &MAX_CAPACITY);
+    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &MAX_CAPACITY, &(env.ledger().timestamp() + 7200));
 }
 
 #[test]
@@ -296,7 +296,7 @@ fn test_create_pool_with_zero_capacity_returns_invalid_capacity() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &0u32);
+    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &0u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::InvalidCapacity)));
 }
 
@@ -305,7 +305,7 @@ fn test_create_pool_exceeding_max_capacity_returns_invalid_capacity() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &(MAX_CAPACITY + 1));
+    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &(MAX_CAPACITY + 1), &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::InvalidCapacity)));
 }
 
@@ -316,8 +316,8 @@ fn test_create_pool_increments_id() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    let pool1 = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
-    let pool2 = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
+    let pool1 = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
+    let pool2 = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_ne!(pool1, pool2);
 }
 
@@ -332,7 +332,7 @@ fn test_create_pool_deploys_interactive_arena() {
     let currency = supported_currency(&env, &client);
     let round_speed = 10u32;
 
-    let arena_addr = client.create_pool(&admin, &MIN_STAKE, &currency, &round_speed, &8u32);
+    let arena_addr = client.create_pool(&admin, &MIN_STAKE, &currency, &round_speed, &8u32, &(env.ledger().timestamp() + 7200));
 
     // Wrap the returned address in an ArenaContractClient and call it.
     let env_s: &'static Env = unsafe { &*(&env as *const Env) };
@@ -354,7 +354,7 @@ fn create_pool_arena_is_immediately_joinable() {
     let token = StellarAssetClient::new(&env, &currency);
     client.add_supported_token(&currency);
 
-    let arena_addr = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
+    let arena_addr = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
 
     let env_s: &'static Env = unsafe { &*(&env as *const Env) };
     let arena = ArenaContractClient::new(env_s, &arena_addr);
@@ -374,8 +374,8 @@ fn test_create_pool_two_pools_have_independent_state() {
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
 
-    let addr1 = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
-    let addr2 = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
+    let addr1 = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
+    let addr2 = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_ne!(addr1, addr2);
 
     let env_s: &'static Env = unsafe { &*(&env as *const Env) };
@@ -394,7 +394,7 @@ fn create_pool_metadata_not_visible_before_full_init() {
     let currency = supported_currency(&env, &client);
 
     // round_speed = 0 makes arena.init fail; metadata must not become visible.
-    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &0u32, &8u32);
+    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &0u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert!(result.is_err());
 
     assert!(client.get_arena(&0u32).is_none());
@@ -713,7 +713,7 @@ fn test_get_arena() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &10u32);
+    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &10u32, &(env.ledger().timestamp() + 7200));
 
     let arena = client.get_arena(&0u32).unwrap();
     assert_eq!(arena.pool_id, 0);
@@ -729,7 +729,7 @@ fn test_get_arenas_pagination() {
     let currency = supported_currency(&env, &client);
 
     for _ in 0..5 {
-        client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &10u32);
+        client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &10u32, &(env.ledger().timestamp() + 7200));
     }
 
     let all = client.get_arenas(&0u32, &10u32);
@@ -868,7 +868,7 @@ fn test_create_pool_rejects_unsupported_token() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = Address::generate(&env); // not added via add_supported_token
-    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
+    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::UnsupportedToken)));
 }
 
@@ -877,7 +877,7 @@ fn test_create_pool_succeeds_after_token_added() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
-    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
+    client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
 }
 
 #[test]
@@ -887,7 +887,7 @@ fn test_create_pool_fails_after_token_removed() {
     let currency = Address::generate(&env);
     client.add_supported_token(&currency);
     client.remove_supported_token(&currency);
-    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32);
+    let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &8u32, &(env.ledger().timestamp() + 7200));
     assert_eq!(result, Err(Ok(Error::UnsupportedToken)));
 }
 
@@ -1056,8 +1056,8 @@ fn test_update_arena_status_success_and_auth() {
     let currency = supported_currency(&env, &client);
     
     // Create pool will internally call set_arena_metadata, setting status to Pending
-    let arena_addr = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &10u32);
-    
+    let arena_addr = client.create_pool(&admin, &MIN_STAKE, &currency, &10u32, &10u32, &(env.ledger().timestamp() + 7200));
+
     // We must call set_arena_metadata to initialize the ArenaRef mapping
     env.mock_all_auths_allowing_non_root_auth();
     client.set_arena_metadata(


### PR DESCRIPTION
## Summary

- Adds `join_deadline: u64` to `ArenaConfig` struct with validation (minimum 1 hour, maximum 1 week from now)
- Adds three new `ArenaError` variants: `DeadlineTooSoon = 42`, `DeadlineTooFar = 43`, `DeadlineNotReached = 44`
- Adds `expire_arena()` public function callable by anyone — refunds all players and sets state to Cancelled when deadline has passed
- Adds `get_join_deadline()` read function
- Updates `factory::create_pool()` to accept and forward `join_deadline` to the arena `init()` call
- Adds `expire_arena_tests.rs` with 5 tests covering all deadline enforcement scenarios

## Test plan

- [ ] `test_expire_arena_before_deadline_fails` — calling expire_arena before deadline returns `DeadlineNotReached`
- [ ] `test_expire_arena_after_deadline_succeeds_and_refunds` — after deadline, expire_arena refunds the joined player and sets state to Cancelled
- [ ] `test_expire_arena_on_active_arena_panics` — expire_arena panics when arena is Active (not Pending)
- [ ] `test_deadline_too_soon_rejected` — `init()` with deadline 30 min away returns `DeadlineTooSoon`
- [ ] `test_deadline_too_far_rejected` — `init()` with deadline 700000s away returns `DeadlineTooFar`
- [ ] All existing factory tests updated to pass `join_deadline` parameter

Closes #498
