### PR TITLE
feat(payout): implement split payout for draw scenarios

### DIFF
--- a/contract/payout/src/lib.rs
+++ b/contract/payout/src/lib.rs
@@ -25,6 +25,8 @@ pub enum DataKey {
     CurrencyToken(Symbol),
     Payout(Symbol, u32, u32, Address),
     PrizePayout(u32),
+    SplitPayout(u32, Address),
+    SplitPayoutBatch(u32),
 }
 
 #[contracttype]
@@ -34,6 +36,15 @@ pub struct PayoutData {
     pub amount: i128,
     pub currency: Symbol,
     pub paid: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SplitPayoutReceipt {
+    pub arena_id: u32,
+    pub winner: Address,
+    pub amount: i128,
+    pub currency: Address,
 }
 
 #[contracterror]
@@ -273,6 +284,95 @@ impl PayoutContract {
 
     pub fn is_prize_distributed(env: Env, game_id: u32) -> bool {
         env.storage().instance().has(&DataKey::PrizePayout(game_id))
+    }
+
+    /// Splits and transfers `total_amount` across `winners`.
+    ///
+    /// Remainder dust from integer division is sent to the first winner so
+    /// no funds are left stranded in the contract.
+    pub fn distribute_split_payout(
+        env: Env,
+        arena_id: u32,
+        winners: Vec<Address>,
+        total_amount: i128,
+        currency: Address,
+    ) -> Result<(), PayoutError> {
+        let admin = Self::admin(env.clone());
+        admin.require_auth();
+
+        require_not_paused(&env)?;
+
+        if total_amount <= 0 {
+            return Err(PayoutError::InvalidAmount);
+        }
+        if winners.is_empty() {
+            return Err(PayoutError::NoWinners);
+        }
+
+        let batch_key = DataKey::SplitPayoutBatch(arena_id);
+        if env.storage().instance().has(&batch_key) {
+            return Err(PayoutError::AlreadyPaid);
+        }
+
+        let winners_count = winners.len() as i128;
+        let per_winner = total_amount / winners_count;
+        let remainder = total_amount % winners_count;
+        let first_winner = winners.get(0).ok_or(PayoutError::NoWinners)?;
+
+        // Idempotency guard first (effects before interactions)
+        env.storage().instance().set(&batch_key, &true);
+
+        let token_client = token::Client::new(&env, &currency);
+        let contract_address = env.current_contract_address();
+
+        for winner in winners.iter() {
+            let amount = if winner == first_winner {
+                per_winner
+                    .checked_add(remainder)
+                    .ok_or(PayoutError::InvalidAmount)?
+            } else {
+                per_winner
+            };
+
+            token_client.transfer(&contract_address, &winner, &amount);
+
+            let receipt = SplitPayoutReceipt {
+                arena_id,
+                winner: winner.clone(),
+                amount,
+                currency: currency.clone(),
+            };
+            let receipt_key = DataKey::SplitPayout(arena_id, winner.clone());
+            env.storage().persistent().set(&receipt_key, &receipt);
+            env.storage()
+                .persistent()
+                .extend_ttl(&receipt_key, PAYOUT_TTL_THRESHOLD, PAYOUT_TTL_EXTEND_TO);
+
+            env.events()
+                .publish((TOPIC_PAYOUT_EXECUTED,), (winner, amount, currency.clone()));
+        }
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+
+        Ok(())
+    }
+
+    pub fn is_split_payout_distributed(env: Env, arena_id: u32) -> bool {
+        env.storage()
+            .instance()
+            .has(&DataKey::SplitPayoutBatch(arena_id))
+    }
+
+    pub fn get_split_payout_receipt(
+        env: Env,
+        arena_id: u32,
+        winner: Address,
+    ) -> Option<SplitPayoutReceipt> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SplitPayout(arena_id, winner))
     }
 
     // ── Emergency pause ──────────────────────────────────────────────────────

--- a/contract/payout/src/test.rs
+++ b/contract/payout/src/test.rs
@@ -268,6 +268,78 @@ fn test_distribute_prize_invalid_amount_returns_error() {
     assert_eq!(result, Err(Ok(PayoutError::InvalidAmount)));
 }
 
+#[test]
+fn test_distribute_split_payout_two_winners_equal_split() {
+    let (env, _admin, client, token_id, _treasury) = setup_with_token();
+    let winner1 = Address::generate(&env);
+    let winner2 = Address::generate(&env);
+    let mut winners = Vec::new(&env);
+    winners.push_back(winner1.clone());
+    winners.push_back(winner2.clone());
+
+    client.distribute_split_payout(&77u32, &winners, &1000i128, &token_id);
+
+    let token = TokenClient::new(&env, &token_id);
+    assert_eq!(token.balance(&winner1), 500i128);
+    assert_eq!(token.balance(&winner2), 500i128);
+    assert!(client.is_split_payout_distributed(&77u32));
+
+    let receipt1 = client
+        .get_split_payout_receipt(&77u32, &winner1)
+        .expect("receipt for winner1 must exist");
+    let receipt2 = client
+        .get_split_payout_receipt(&77u32, &winner2)
+        .expect("receipt for winner2 must exist");
+    assert_eq!(receipt1.amount, 500i128);
+    assert_eq!(receipt2.amount, 500i128);
+}
+
+#[test]
+fn test_distribute_split_payout_three_winners_remainder_to_first() {
+    let (env, _admin, client, token_id, _treasury) = setup_with_token();
+    let winner1 = Address::generate(&env);
+    let winner2 = Address::generate(&env);
+    let winner3 = Address::generate(&env);
+    let mut winners = Vec::new(&env);
+    winners.push_back(winner1.clone());
+    winners.push_back(winner2.clone());
+    winners.push_back(winner3.clone());
+
+    client.distribute_split_payout(&78u32, &winners, &1000i128, &token_id);
+
+    let token = TokenClient::new(&env, &token_id);
+    assert_eq!(token.balance(&winner1), 334i128);
+    assert_eq!(token.balance(&winner2), 333i128);
+    assert_eq!(token.balance(&winner3), 333i128);
+}
+
+#[test]
+fn test_distribute_split_payout_no_winners_returns_error() {
+    let (env, _admin, client, token_id, _treasury) = setup_with_token();
+    let empty: Vec<Address> = Vec::new(&env);
+
+    let result = client.try_distribute_split_payout(&79u32, &empty, &1000i128, &token_id);
+    assert_eq!(result, Err(Ok(PayoutError::NoWinners)));
+}
+
+#[test]
+fn test_distribute_split_payout_single_winner_gets_full_amount() {
+    let (env, _admin, client, token_id, _treasury) = setup_with_token();
+    let winner = Address::generate(&env);
+    let mut winners = Vec::new(&env);
+    winners.push_back(winner.clone());
+
+    client.distribute_split_payout(&80u32, &winners, &750i128, &token_id);
+
+    let token = TokenClient::new(&env, &token_id);
+    assert_eq!(token.balance(&winner), 750i128);
+
+    let receipt = client
+        .get_split_payout_receipt(&80u32, &winner)
+        .expect("single-winner receipt must exist");
+    assert_eq!(receipt.amount, 750i128);
+}
+
 // ── persistent storage TTL ────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Fixes #453

## What changed
- added distribute_split_payout(arena_id, winners, total_amount, currency) to split prize amounts across winners
- sends integer-division remainder (dust) to the first winner so no funds are stranded
- added per-winner receipts via SplitPayoutReceipt and persistent keys
- added read helpers: is_split_payout_distributed and get_split_payout_receipt
- added payout tests for 2-way split, 3-way split with remainder, empty winners, and single-winner behavior

## Why
- complete-tie rounds need deterministic split payout handling to avoid locked funds
- receipts provide auditable per-winner distribution records

## How to test
- cd contract && cargo test -q -p payout