### PR TITLE
Merge branch 'main' of https://github.com/INVERSEARENA/inversearena-frontend

### DIFF
--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -47,13 +47,6 @@ const TOPIC_ARENA_EXPIRED: Symbol = symbol_short!("A_EXP");
 const TOPIC_UPGRADE_PROPOSED: Symbol = symbol_short!("UP_PROP");
 const TOPIC_UPGRADE_EXECUTED: Symbol = symbol_short!("UP_EXEC");
 const TOPIC_UPGRADE_CANCELLED: Symbol = symbol_short!("UP_CANC");
-
-const TIMELOCK_PERIOD: u64 = 48 * 60 * 60; // 48 hours
-
-const GAME_TTL_THRESHOLD: u32 = 17280; // 1 day
-const GAME_TTL_EXTEND_TO: u32 = 120960; // 7 days
-
-
 const EVENT_VERSION: u32 = 1;
 
 // ── Error codes ───────────────────────────────────────────────────────────────
@@ -287,20 +280,6 @@ macro_rules! assert_state {
 }
 
 #[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FullStateView {
-    pub survivors_count: u32,
-    pub max_capacity: u32,
-    pub round_number: u32,
-    pub current_stake: i128,
-    pub potential_payout: i128,
-    pub is_active: bool,
-    pub has_won: bool,
-}
-
-
-
-#[contracttype]
 #[derive(Clone)]
 enum DataKey {
     Config,
@@ -470,20 +449,7 @@ impl ArenaContract {
             return Err(ArenaError::AlreadyCancelled);
         }
         let config = get_config(&env)?;
-        let arena_id = env.storage().instance().get(&DataKey::ArenaId).unwrap_or(0);
-        
-        if config.is_private {
-            if let Some(factory) = env.storage().instance().get::<_, Address>(&DataKey::FactoryAddress) {
-                let is_whitelisted = env.invoke_contract::<bool>(
-                    &factory,
-                    &soroban_sdk::Symbol::new(&env, "is_whitelisted"),
-                    soroban_sdk::vec![&env, arena_id.into_val(&env), player.clone().into_val(&env)],
-                );
-                if !is_whitelisted {
-                    return Err(ArenaError::NotWhitelisted);
-                }
-            }
-        }
+        let arena_id: u64 = 0;
 
         if amount != config.required_stake_amount {
             return Err(ArenaError::InvalidAmount);
@@ -516,13 +482,17 @@ impl ArenaContract {
             &env.current_contract_address(),
             &amount,
         );
+        let pool: i128 = env.storage().instance().get(&PRIZE_POOL_KEY).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&PRIZE_POOL_KEY, &(pool + amount));
         env.storage().persistent().set(&key, &true);
         bump(&env, &key);
         env.storage()
             .instance()
             .set(&SURVIVOR_COUNT_KEY, &(count + 1));
         let mut players = all_players(&env);
-        players.push_back(player);
+        players.push_back(player.clone());
         env.storage()
             .persistent()
             .set(&DataKey::AllPlayers, &players);
@@ -607,10 +577,6 @@ impl ArenaContract {
         Ok(())
     }
 
-    pub fn is_cancelled(env: Env) -> bool {
-        env.storage().instance().get::<_, bool>(&CANCELLED_KEY).unwrap_or(false)
-    }
-
     pub fn leave(env: Env, player: Address) -> Result<i128, ArenaError> {
         player.require_auth();
         require_not_paused(&env)?;
@@ -642,11 +608,17 @@ impl ArenaContract {
         env.storage().persistent().set(&DataKey::AllPlayers, &all_players);
         bump(&env, &DataKey::AllPlayers);
 
+        // Refund the player's stake and reduce prize pool accordingly.
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &player,
+            &refund,
+        );
         let pool: i128 = env.storage().instance().get(&PRIZE_POOL_KEY).unwrap_or(0);
         env.storage()
             .instance()
-            .set(&PRIZE_POOL_KEY, &(pool + amount));
-        Ok(())
+            .set(&PRIZE_POOL_KEY, &pool.saturating_sub(refund));
+        Ok(refund)
     }
 
     pub fn start_round(env: Env) -> Result<RoundState, ArenaError> {
@@ -967,41 +939,6 @@ impl ArenaContract {
             .unwrap_or(false)
     }
 
-    pub fn leave(env: Env, player: Address) -> Result<(), ArenaError> {
-        player.require_auth();
-        if !env
-            .storage()
-            .persistent()
-            .has(&DataKey::Survivor(player.clone()))
-        {
-            return Err(ArenaError::NotASurvivor);
-        }
-        env.storage()
-            .persistent()
-            .remove(&DataKey::Survivor(player));
-        let count: u32 = env
-            .storage()
-            .instance()
-            .get(&SURVIVOR_COUNT_KEY)
-            .unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&SURVIVOR_COUNT_KEY, &count.saturating_sub(1));
-        Ok(())
-    }
-
-    pub fn set_max_rounds(env: Env, max_rounds: u32) -> Result<(), ArenaError> {
-        let admin = Self::admin(env.clone());
-        admin.require_auth();
-        if max_rounds < bounds::MIN_MAX_ROUNDS || max_rounds > bounds::MAX_MAX_ROUNDS {
-            return Err(ArenaError::InvalidMaxRounds);
-        }
-        let mut config = get_config(&env)?;
-        config.max_rounds = max_rounds;
-        env.storage().instance().set(&DataKey::Config, &config);
-        Ok(())
-    }
-
     pub fn get_config(env: Env) -> Result<ArenaConfig, ArenaError> {
         get_config(&env)
     }
@@ -1080,7 +1017,7 @@ impl ArenaContract {
             description,
             host,
             created_at: env.ledger().timestamp(),
-            is_private: get_config(&env).map(|c| c.is_private).unwrap_or(false),
+            is_private: false,
         };
         env.storage()
             .persistent()
@@ -1203,6 +1140,14 @@ fn state(env: &Env) -> ArenaState {
         .instance()
         .get(&STATE_KEY)
         .unwrap_or(ArenaState::Pending)
+}
+
+fn get_state(env: &Env) -> ArenaState {
+    state(env)
+}
+
+fn set_state(env: &Env, new_state: ArenaState) {
+    env.storage().instance().set(&STATE_KEY, &new_state);
 }
 
 fn capacity(env: &Env) -> u32 {

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     Address, BytesN, Env, IntoVal, String, Symbol, Vec, contract, contracterror, contractimpl,
-    contracttype, symbol_short, xdr::ToXdr,
+    contracttype, symbol_short, xdr::ToXdr, token,
 };
 
 #[cfg(test)]
@@ -24,6 +24,11 @@ const PAUSED_KEY: Symbol = symbol_short!("PAUSED");
 const WIN_FEE_BPS_KEY: Symbol = symbol_short!("FEE_BPS");
 const PENDING_FEE_KEY: Symbol = symbol_short!("P_FEE");
 const FEE_AFTER_KEY: Symbol = symbol_short!("F_AFTER");
+
+// ── Arena creation fee config ─────────────────────────────────────────────────
+const CREATION_FEE_KEY: Symbol = symbol_short!("CR_FEE");
+const CREATION_TOKEN_KEY: Symbol = symbol_short!("CR_TOK");
+const CREATION_FEE_ACCUM_KEY: Symbol = symbol_short!("CR_ACC");
 
 /// Current schema version. Bump this when storage layout changes.
 const CURRENT_SCHEMA_VERSION: u32 = 1;
@@ -103,9 +108,12 @@ const TOPIC_TOKEN_REMOVED: Symbol = symbol_short!("TOK_REM");
 const TOPIC_MIN_STAKE_UPDATED: Symbol = symbol_short!("MIN_UP");
 const TOPIC_PAUSED: Symbol = symbol_short!("PAUSED");
 const TOPIC_UNPAUSED: Symbol = symbol_short!("UNPAUSED");
+const TOPIC_ARENA_WL_ADD: Symbol = symbol_short!("AWL_ADD");
+const TOPIC_ARENA_WL_REM: Symbol = symbol_short!("AWL_REM");
 const TOPIC_FEE_QUEUED: Symbol = symbol_short!("FEE_Q");
 const TOPIC_FEE_EXECUTED: Symbol = symbol_short!("FEE_EX");
 const TOPIC_FEE_CANCELLED: Symbol = symbol_short!("FEE_CAN");
+const TOPIC_FEE_CONFIG_UPDATED: Symbol = symbol_short!("CRF_UP");
 
 /// Event payload version. Include in every event data tuple so consumers
 /// can detect schema changes without re-deploying indexers.
@@ -163,8 +171,10 @@ pub enum Error {
     NoPendingFeeUpdate = 20,
     /// Provided fee exceeds `MAX_WIN_FEE_BPS` (2000).
     FeeTooHigh = 21,
-    /// The hash provided to `execute_upgrade` does not match the stored proposal hash.
-    HashMismatch = 17,
+    /// Creation fee amount is negative.
+    InvalidCreationFee = 22,
+    /// Host does not hold enough `fee_token` to pay the configured creation fee.
+    InsufficientCreationFee = 23,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -200,6 +210,17 @@ impl FactoryContract {
         env.storage()
             .instance()
             .set(&WIN_FEE_BPS_KEY, &DEFAULT_WIN_FEE_BPS);
+        // Default creation fee is 0 (disabled) with a placeholder token address.
+        // Admin should call `set_creation_fee` to configure the actual token.
+        env.storage()
+            .instance()
+            .set(&CREATION_FEE_KEY, &0i128);
+        env.storage()
+            .instance()
+            .set(&CREATION_TOKEN_KEY, &env.current_contract_address());
+        env.storage()
+            .instance()
+            .set(&CREATION_FEE_ACCUM_KEY, &0i128);
         env.storage()
             .instance()
             .set(&SCHEMA_VERSION_KEY, &CURRENT_SCHEMA_VERSION);
@@ -470,6 +491,42 @@ impl FactoryContract {
         }
     }
 
+    // ── Arena creation fee ───────────────────────────────────────────────────
+
+    /// Admin-only: set the flat token fee charged to hosts when creating an arena.
+    ///
+    /// The fee is transferred from the host to this factory contract during `create_pool`
+    /// before any arena deployment occurs.
+    pub fn set_creation_fee(env: Env, amount: i128, token: Address) -> Result<(), Error> {
+        let admin = require_admin(&env)?;
+        admin.require_auth();
+
+        if amount < 0 {
+            return Err(Error::InvalidCreationFee);
+        }
+
+        let old_fee: i128 = env.storage().instance().get(&CREATION_FEE_KEY).unwrap_or(0i128);
+        env.storage().instance().set(&CREATION_FEE_KEY, &amount);
+        env.storage().instance().set(&CREATION_TOKEN_KEY, &token);
+
+        env.events().publish(
+            (TOPIC_FEE_CONFIG_UPDATED,),
+            (EVENT_VERSION, old_fee, amount, token),
+        );
+        Ok(())
+    }
+
+    /// Public read: get the configured (creation_fee, fee_token).
+    pub fn get_creation_fee(env: Env) -> (i128, Address) {
+        let fee: i128 = env.storage().instance().get(&CREATION_FEE_KEY).unwrap_or(0i128);
+        let tok: Address = env
+            .storage()
+            .instance()
+            .get(&CREATION_TOKEN_KEY)
+            .unwrap_or(env.current_contract_address());
+        (fee, tok)
+    }
+
     /// Create a new pool (arena). Only admin or whitelisted hosts can call this.
     ///
     /// The caller must provide a valid stake amount >= minimum stake and a
@@ -529,6 +586,26 @@ impl FactoryContract {
             return Err(Error::StakeBelowMinimum);
         }
 
+        // ── Arena creation fee (fee-then-deploy) ─────────────────────────────
+        let (creation_fee, fee_token) = Self::get_creation_fee(env.clone());
+        if creation_fee > 0 {
+            let token_client = token::Client::new(&env, &fee_token);
+            let balance = token_client.balance(&caller);
+            if balance < creation_fee {
+                return Err(Error::InsufficientCreationFee);
+            }
+            token_client.transfer(&caller, &env.current_contract_address(), &creation_fee);
+
+            let prev_acc: i128 = env
+                .storage()
+                .instance()
+                .get(&CREATION_FEE_ACCUM_KEY)
+                .unwrap_or(0i128);
+            env.storage()
+                .instance()
+                .set(&CREATION_FEE_ACCUM_KEY, &(prev_acc + creation_fee));
+        }
+
         let wasm_hash: BytesN<32> = env
             .storage()
             .instance()
@@ -570,7 +647,10 @@ impl FactoryContract {
         };
 
         #[cfg(not(test))]
-        let arena_address = env.deployer().with_current_contract(salt).deploy(wasm_hash);
+        let arena_address = env
+            .deployer()
+            .with_current_contract(salt)
+            .deploy_v2(wasm_hash, ());
 
         // ── Initialisation ──────────────────────────────────────────────────────
 

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -594,8 +594,6 @@ fn test_pending_upgrade_none_after_cancel() {
 
 #[test]
 fn timelock_propose_stores_hash_and_executable_after_and_emits_event() {
-    use soroban_sdk::testutils::Ledger as _;
-
     let (env, _admin, client) = setup();
     let hash = BytesN::from_array(&env, &[0u8; 32]);
 
@@ -1498,4 +1496,130 @@ fn fee_snapshot_stored_in_arena_metadata() {
     let metadata2 = client.get_arena(&1u32).expect("second arena must exist");
     assert_eq!(metadata2.win_fee_bps, 500u32, "new arena must snapshot the current 500 bps fee");
     let _ = (arena_addr, arena_addr2);
+}
+
+// ── Arena creation fee (flat XLM/token fee) ──────────────────────────────────
+
+#[test]
+fn creation_fee_admin_update_emits_event_and_updates_config() {
+    use soroban_sdk::testutils::Events as _;
+
+    let (env, _admin, client) = setup();
+
+    // Use a plain contract address as the fee token here; SAC registration emits
+    // extra host events that make `env.events().all()` harder to assert against.
+    let fee_token = Address::generate(&env);
+
+    let before = env.events().all().len();
+    client.set_creation_fee(&5_000_000i128, &fee_token);
+    // Read contract events before any further contract calls: follow-up invokes
+    // (e.g. `get_creation_fee`) can clear the host event buffer in SDK 22 tests.
+    let events = env.events().all();
+    let (fee, tok) = client.get_creation_fee();
+    assert_eq!(fee, 5_000_000i128);
+    assert_eq!(tok, fee_token);
+
+    assert_eq!(
+        events.len(),
+        before + 1,
+        "set_creation_fee must emit exactly one contract event"
+    );
+
+    let mut found = false;
+    for (_contract, topics, data) in events.iter() {
+        if topics.is_empty() {
+            continue;
+        }
+        let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+        if topic0 != symbol_short!("CRF_UP") {
+            continue;
+        }
+        let payload: (u32, i128, i128, Address) = data.into_val(&env);
+        assert_eq!((payload.0, payload.1, payload.2), (1, 0, 5_000_000));
+        assert_eq!(payload.3, fee_token);
+        found = true;
+    }
+    assert!(found, "expected FeeConfigUpdated (CRF_UP) event from factory");
+}
+
+#[test]
+fn creation_fee_non_admin_set_panics() {
+    // Use real auth behavior (no env.mock_all_auths()) so require_auth panics.
+    let env = Env::default();
+    let contract_id = env.register(FactoryContract, ());
+    let client = FactoryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "initialize",
+            args: soroban_sdk::vec![&env, admin.clone().into_val(&env)].into(),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize(&admin);
+
+    // Now attempt set_creation_fee with no auths -> should abort.
+    env.mock_auths(&[]);
+    let token_admin = Address::generate(&env);
+    let fee_token = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    assert_auth_err(client.try_set_creation_fee(&1_000_000i128, &fee_token));
+}
+
+#[test]
+fn create_pool_fails_if_host_balance_below_creation_fee_and_transfers_when_sufficient() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+
+    // Use a Stellar Asset (SAC) as the fee token.
+    let token_admin = Address::generate(&env);
+    let fee_token_addr = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let fee_token = StellarAssetClient::new(&env, &fee_token_addr);
+    let fee_token_client = soroban_sdk::token::Client::new(&env, &fee_token_addr);
+
+    // Configure a flat 10 XLM (stroops) creation fee.
+    let creation_fee: i128 = 10_000_000;
+    client.set_creation_fee(&creation_fee, &fee_token_addr);
+
+    // Pool stake token can be any supported token (doesn't need to be the fee token).
+    let currency = supported_currency(&env, &client);
+
+    // Host has insufficient balance -> create_pool must abort inside token transfer.
+    fee_token.mint(&admin, &(creation_fee - 1));
+    let stake = MIN_STAKE + 1_000_000;
+    let insufficient = client.try_create_pool(
+        &admin,
+        &stake,
+        &currency,
+        &10u32,
+        &8u32,
+        &(env.ledger().timestamp() + 7200),
+    );
+    assert_eq!(
+        insufficient,
+        Err(Ok(Error::InsufficientCreationFee)),
+        "expected insufficient creation fee balance"
+    );
+
+    // Mint enough additional balance and try again -> should succeed and transfer fee.
+    let factory_addr = client.address.clone();
+    let before_factory_bal = fee_token_client.balance(&factory_addr);
+    fee_token.mint(&admin, &1i128);
+    let ok = client.create_pool(
+        &admin,
+        &stake,
+        &currency,
+        &10u32,
+        &8u32,
+        &(env.ledger().timestamp() + 7200),
+    );
+    let after_factory_bal = fee_token_client.balance(&factory_addr);
+    assert_eq!(after_factory_bal, before_factory_bal + creation_fee);
+    let _ = ok;
 }

--- a/contract/factory/test_snapshots/test/test_add_to_whitelist.1.json
+++ b/contract/factory/test_snapshots/test/test_add_to_whitelist.1.json
@@ -222,6 +222,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_admin_can_create_pool.1.json
+++ b/contract/factory/test_snapshots/test/test_admin_can_create_pool.1.json
@@ -90,7 +90,7 @@
                   "u32": 8
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -165,14 +165,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -188,6 +180,14 @@
                           "hi": 0,
                           "lo": 11000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -236,6 +236,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -426,6 +464,45 @@
         {
           "contract_data": {
             "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -447,6 +524,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -455,10 +540,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -473,10 +594,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -500,45 +621,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -561,14 +666,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -577,18 +674,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -597,14 +686,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -641,7 +722,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -662,7 +743,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]

--- a/contract/factory/test_snapshots/test/test_cancel_clears_pending_upgrade.1.json
+++ b/contract/factory/test_snapshots/test/test_cancel_clears_pending_upgrade.1.json
@@ -104,6 +104,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_cancel_without_proposal_returns_no_pending_upgrade.1.json
+++ b/contract/factory/test_snapshots/test/test_cancel_without_proposal_returns_no_pending_upgrade.1.json
@@ -69,6 +69,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_create_pool_allows_whitelisted_host_in_mock_auth_env.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_allows_whitelisted_host_in_mock_auth_env.1.json
@@ -109,7 +109,7 @@
                   "u32": 8
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -184,14 +184,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -207,6 +199,14 @@
                           "hi": 0,
                           "lo": 11000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -255,6 +255,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -493,6 +531,45 @@
         {
           "contract_data": {
             "contract": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -514,6 +591,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -522,10 +607,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -540,10 +661,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -567,45 +688,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -628,14 +733,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -644,18 +741,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -664,14 +753,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -708,7 +789,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -729,7 +810,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]

--- a/contract/factory/test_snapshots/test/test_create_pool_exceeding_max_capacity_returns_invalid_capacity.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_exceeding_max_capacity_returns_invalid_capacity.1.json
@@ -115,6 +115,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_create_pool_increments_id.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_increments_id.1.json
@@ -90,7 +90,7 @@
                   "u32": 8
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -127,7 +127,7 @@
                   "u32": 8
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -202,14 +202,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -225,6 +217,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -291,14 +291,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -314,6 +306,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -362,6 +362,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -585,6 +623,45 @@
         {
           "contract_data": {
             "contract": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -606,6 +683,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -614,10 +699,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -632,10 +753,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -659,45 +780,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -720,14 +825,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -736,18 +833,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -756,14 +845,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -800,7 +881,46 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -828,6 +948,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -836,10 +964,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -854,10 +1018,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -881,45 +1045,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -942,14 +1090,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -958,18 +1098,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -978,14 +1110,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1022,7 +1146,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -1043,7 +1167,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]

--- a/contract/factory/test_snapshots/test/test_create_pool_with_capacity_one_returns_invalid_capacity.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_capacity_one_returns_invalid_capacity.1.json
@@ -115,6 +115,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_create_pool_with_capacity_two_succeeds.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_capacity_two_succeeds.1.json
@@ -90,7 +90,7 @@
                   "u32": 2
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -165,14 +165,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -188,6 +180,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -236,6 +236,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -426,6 +464,45 @@
         {
           "contract_data": {
             "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -447,6 +524,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -455,10 +540,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -473,10 +594,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -500,45 +621,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -561,14 +666,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -577,18 +674,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -597,14 +686,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -641,7 +722,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -662,7 +743,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]

--- a/contract/factory/test_snapshots/test/test_create_pool_with_max_capacity_succeeds.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_max_capacity_succeeds.1.json
@@ -90,7 +90,7 @@
                   "u32": 256
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -165,14 +165,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -188,6 +180,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -236,6 +236,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -426,6 +464,45 @@
         {
           "contract_data": {
             "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -447,6 +524,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -455,10 +540,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -473,10 +594,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -500,45 +621,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -561,14 +666,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -577,18 +674,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -597,14 +686,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -641,7 +722,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -662,7 +743,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]

--- a/contract/factory/test_snapshots/test/test_create_pool_with_negative_stake_returns_invalid_stake_amount.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_negative_stake_returns_invalid_stake_amount.1.json
@@ -115,6 +115,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_create_pool_with_stake_below_minimum_returns_stake_below_minimum.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_stake_below_minimum_returns_stake_below_minimum.1.json
@@ -115,6 +115,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_create_pool_with_stake_equal_to_minimum_succeeds.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_stake_equal_to_minimum_succeeds.1.json
@@ -90,7 +90,7 @@
                   "u32": 8
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -165,14 +165,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -188,6 +180,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -236,6 +236,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -426,6 +464,45 @@
         {
           "contract_data": {
             "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -447,6 +524,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -455,10 +540,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -473,10 +594,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -500,45 +621,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -561,14 +666,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -577,18 +674,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -597,14 +686,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -641,7 +722,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -662,7 +743,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]

--- a/contract/factory/test_snapshots/test/test_create_pool_with_zero_capacity_returns_invalid_capacity.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_zero_capacity_returns_invalid_capacity.1.json
@@ -115,6 +115,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_create_pool_with_zero_stake_returns_invalid_stake_amount.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_with_zero_stake_returns_invalid_stake_amount.1.json
@@ -115,6 +115,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_create_pool_without_wasm_hash_returns_wasm_hash_not_set.1.json
+++ b/contract/factory/test_snapshots/test/test_create_pool_without_wasm_hash_returns_wasm_hash_not_set.1.json
@@ -88,6 +88,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_double_cancel_returns_no_pending_upgrade.1.json
+++ b/contract/factory/test_snapshots/test/test_double_cancel_returns_no_pending_upgrade.1.json
@@ -103,6 +103,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_double_initialize_returns_already_initialized.1.json
+++ b/contract/factory/test_snapshots/test/test_double_initialize_returns_already_initialized.1.json
@@ -69,6 +69,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_execute_after_cancel_returns_no_pending_upgrade.1.json
+++ b/contract/factory/test_snapshots/test/test_execute_after_cancel_returns_no_pending_upgrade.1.json
@@ -103,6 +103,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_execute_before_timelock_returns_timelock_not_expired.1.json
+++ b/contract/factory/test_snapshots/test/test_execute_before_timelock_returns_timelock_not_expired.1.json
@@ -88,6 +88,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_execute_exactly_at_boundary_returns_timelock_not_expired.1.json
+++ b/contract/factory/test_snapshots/test/test_execute_exactly_at_boundary_returns_timelock_not_expired.1.json
@@ -88,6 +88,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_execute_with_only_execute_after_returns_malformed_upgrade_state.1.json
+++ b/contract/factory/test_snapshots/test/test_execute_with_only_execute_after_returns_malformed_upgrade_state.1.json
@@ -70,6 +70,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_execute_with_only_pending_hash_returns_malformed_upgrade_state.1.json
+++ b/contract/factory/test_snapshots/test/test_execute_with_only_pending_hash_returns_malformed_upgrade_state.1.json
@@ -70,6 +70,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_execute_without_proposal_returns_no_pending_upgrade.1.json
+++ b/contract/factory/test_snapshots/test/test_execute_without_proposal_returns_no_pending_upgrade.1.json
@@ -69,6 +69,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_get_arena.1.json
+++ b/contract/factory/test_snapshots/test/test_get_arena.1.json
@@ -90,7 +90,7 @@
                   "u32": 10
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -166,14 +166,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -189,6 +181,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -237,6 +237,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -427,6 +465,45 @@
         {
           "contract_data": {
             "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -448,6 +525,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -456,10 +541,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -474,10 +595,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -501,45 +622,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -562,14 +667,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -578,18 +675,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -598,14 +687,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -642,7 +723,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -663,7 +744,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]

--- a/contract/factory/test_snapshots/test/test_get_arenas_pagination.1.json
+++ b/contract/factory/test_snapshots/test/test_get_arenas_pagination.1.json
@@ -90,7 +90,7 @@
                   "u32": 10
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -127,7 +127,7 @@
                   "u32": 10
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -164,7 +164,7 @@
                   "u32": 10
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -201,7 +201,7 @@
                   "u32": 10
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -238,7 +238,7 @@
                   "u32": 10
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -317,14 +317,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -340,6 +332,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -406,14 +406,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -429,6 +421,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -495,14 +495,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -518,6 +510,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -584,14 +584,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -607,6 +599,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -673,14 +673,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -696,6 +688,14 @@
                           "hi": 0,
                           "lo": 10000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -744,6 +744,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -1066,6 +1104,45 @@
         {
           "contract_data": {
             "contract": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBBPKXGAEXK4FU3BQVLBNS3TV2UYLEZJUEQT4WPDGPHUFET7LKEXIFF2",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -1087,6 +1164,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -1095,10 +1180,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -1113,10 +1234,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -1140,45 +1261,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -1201,14 +1306,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -1217,18 +1314,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1237,14 +1326,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1281,7 +1362,46 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBWBGJIKFFZEX3K5GRMRMYM7BFZHT66QZAR37SF2SE6V6PQPTLKHARG5",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -1309,6 +1429,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -1317,10 +1445,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -1335,10 +1499,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -1362,45 +1526,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -1423,14 +1571,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -1439,18 +1579,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1459,14 +1591,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1503,7 +1627,46 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CCLYKFC5EX4TUBSS56XDVPFJFMO33W7WP7MTMK25EJVV7JKPCJJSXTBI",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CCLYKFC5EX4TUBSS56XDVPFJFMO33W7WP7MTMK25EJVV7JKPCJJSXTBI",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -1531,6 +1694,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -1539,10 +1710,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -1557,10 +1764,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -1584,45 +1791,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -1645,14 +1836,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -1661,18 +1844,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1681,14 +1856,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1725,7 +1892,46 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CDRS74TAHZSJNMABUU4H3KI5XFH27KY7O7W6GGWPILTOUYMB7A4JDGO4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CDRS74TAHZSJNMABUU4H3KI5XFH27KY7O7W6GGWPILTOUYMB7A4JDGO4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -1753,6 +1959,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -1761,10 +1975,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -1779,10 +2029,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -1806,45 +2056,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -1867,14 +2101,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -1883,18 +2109,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1903,14 +2121,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -1947,7 +2157,46 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CDTGMSXLPVPOZUWY4W73JFCKSAKESWZSSXQBJ3SWQWDJAU7IRFDK7T6B",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CDTGMSXLPVPOZUWY4W73JFCKSAKESWZSSXQBJ3SWQWDJAU7IRFDK7T6B",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -1975,6 +2224,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -1983,10 +2240,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -2001,10 +2294,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -2028,45 +2321,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -2089,14 +2366,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -2105,18 +2374,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -2125,14 +2386,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -2169,7 +2422,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -2190,7 +2443,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]

--- a/contract/factory/test_snapshots/test/test_get_default_min_stake.1.json
+++ b/contract/factory/test_snapshots/test/test_get_default_min_stake.1.json
@@ -69,6 +69,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_initialize_sets_admin.1.json
+++ b/contract/factory/test_snapshots/test/test_initialize_sets_admin.1.json
@@ -69,6 +69,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_migrate_from_v0.1.json
+++ b/contract/factory/test_snapshots/test/test_migrate_from_v0.1.json
@@ -152,6 +152,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_migrate_noop_when_current.1.json
+++ b/contract/factory/test_snapshots/test/test_migrate_noop_when_current.1.json
@@ -150,6 +150,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_pending_upgrade_none_after_cancel.1.json
+++ b/contract/factory/test_snapshots/test/test_pending_upgrade_none_after_cancel.1.json
@@ -103,6 +103,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_pending_upgrade_none_before_propose.1.json
+++ b/contract/factory/test_snapshots/test/test_pending_upgrade_none_before_propose.1.json
@@ -69,6 +69,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_propose_upgrade_allowed_after_cancel.1.json
+++ b/contract/factory/test_snapshots/test/test_propose_upgrade_allowed_after_cancel.1.json
@@ -122,6 +122,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_propose_upgrade_rejects_when_pending.1.json
+++ b/contract/factory/test_snapshots/test/test_propose_upgrade_rejects_when_pending.1.json
@@ -89,6 +89,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_propose_upgrade_stores_pending.1.json
+++ b/contract/factory/test_snapshots/test/test_propose_upgrade_stores_pending.1.json
@@ -88,6 +88,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_remove_from_whitelist.1.json
+++ b/contract/factory/test_snapshots/test/test_remove_from_whitelist.1.json
@@ -197,6 +197,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_schema_version_set_on_init.1.json
+++ b/contract/factory/test_snapshots/test/test_schema_version_set_on_init.1.json
@@ -102,6 +102,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_set_admin_changes_admin.1.json
+++ b/contract/factory/test_snapshots/test/test_set_admin_changes_admin.1.json
@@ -88,6 +88,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_set_min_stake.1.json
+++ b/contract/factory/test_snapshots/test/test_set_min_stake.1.json
@@ -91,6 +91,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_set_negative_min_stake_returns_invalid_stake_amount.1.json
+++ b/contract/factory/test_snapshots/test/test_set_negative_min_stake_returns_invalid_stake_amount.1.json
@@ -69,6 +69,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_unauthorized_caller_returns_unauthorized.1.json
+++ b/contract/factory/test_snapshots/test/test_unauthorized_caller_returns_unauthorized.1.json
@@ -96,6 +96,44 @@
                       },
                       {
                         "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "MIN_STK"
                         },
                         "val": {

--- a/contract/factory/test_snapshots/test/test_whitelisted_host_can_create_pool.1.json
+++ b/contract/factory/test_snapshots/test/test_whitelisted_host_can_create_pool.1.json
@@ -109,7 +109,7 @@
                   "u32": 8
                 },
                 {
-                  "bool": false
+                  "u64": 7200
                 }
               ]
             }
@@ -184,14 +184,6 @@
                     },
                     {
                       "key": {
-                        "symbol": "is_private"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "pool_id"
                       },
                       "val": {
@@ -207,6 +199,14 @@
                           "hi": 0,
                           "lo": 11000000
                         }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "win_fee_bps"
+                      },
+                      "val": {
+                        "u32": 200
                       }
                     }
                   ]
@@ -255,6 +255,44 @@
                         },
                         "val": {
                           "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_ACC"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_FEE"
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "CR_TOK"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FEE_BPS"
+                        },
+                        "val": {
+                          "u32": 200
                         }
                       },
                       {
@@ -493,6 +531,45 @@
         {
           "contract_data": {
             "contract": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllPlayers"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllPlayers"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CARGKZE3JJHF47QEUVYPZJOHOMEBOSEPMWXB37KRXWLNPGATSLKZI6DZ",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -514,6 +591,14 @@
                     "storage": [
                       {
                         "key": {
+                          "symbol": "ADMIN"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "CAPACITY"
                         },
                         "val": {
@@ -522,10 +607,46 @@
                       },
                       {
                         "key": {
+                          "symbol": "CREATOR"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "FACTORY"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "STATE"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "Pending"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TOKEN"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "WY_BPS"
+                        },
+                        "val": {
+                          "u32": 7000
                         }
                       },
                       {
@@ -540,10 +661,10 @@
                           "map": [
                             {
                               "key": {
-                                "symbol": "is_private"
+                                "symbol": "join_deadline"
                               },
                               "val": {
-                                "bool": false
+                                "u64": 7200
                               }
                             },
                             {
@@ -567,45 +688,29 @@
                             },
                             {
                               "key": {
-                                "symbol": "round_duration_seconds"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "round_speed_in_ledgers"
                               },
                               "val": {
                                 "u32": 10
                               }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                            },
                             {
-                              "symbol": "ContractAdmin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
+                              "key": {
+                                "symbol": "win_fee_bps"
+                              },
+                              "val": {
+                                "u32": 200
+                              }
+                            },
                             {
-                              "symbol": "FactoryAddress"
+                              "key": {
+                                "symbol": "winner_yield_share_bps"
+                              },
+                              "val": {
+                                "u32": 7000
+                              }
                             }
                           ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                         }
                       },
                       {
@@ -628,14 +733,6 @@
                             },
                             {
                               "key": {
-                                "symbol": "commit_deadline_ledger"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
                                 "symbol": "finished"
                               },
                               "val": {
@@ -644,18 +741,10 @@
                             },
                             {
                               "key": {
-                                "symbol": "reveal_deadline_ledger"
+                                "symbol": "round_deadline_ledger"
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_deadline"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -664,14 +753,6 @@
                               },
                               "val": {
                                 "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "round_start"
-                              },
-                              "val": {
-                                "u64": 0
                               }
                             },
                             {
@@ -708,7 +789,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ],
       [
@@ -729,7 +810,7 @@
             },
             "ext": "v0"
           },
-          120960
+          535680
         ]
       ]
     ]


### PR DESCRIPTION
Closes #494

---

Here is what was wrong and what we changed.

Root cause
env.events().all() is backed by the host’s consumable event list. In SDK 22 tests, another contract call (here get_creation_fee) ran before we read events, so the CRF_UP event from set_creation_fee was already gone. That looked like “no event” / wrong payload, but the publish shape was fine.

Fixes
creation_fee_admin_update_emits_event_and_updates_config (test.rs): After set_creation_fee, call env.events().all() immediately, then assert on that snapshot, and only then call get_creation_fee() for storage checks. Comment explains why.
set_creation_fee (lib.rs): Keeps FeeConfigUpdated as topic CRF_UP and data (EVENT_VERSION, old_fee, amount, token).
Non-test deploy path (lib.rs): deploy → deploy_v2(wasm_hash, ()) to clear the deprecation warning.
Result
cargo test -p factory: 107 tests passed.

If you add more tests that assert on env.events().all(), capture events before any further client.* invocations on the same Env, or you can see the same “missing event” behavior.