### PR TITLE
Fix: cap max_players to prevent Soroban budget exhaustion DoS (#495)

### DIFF
--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -20,6 +20,7 @@ const POOL_COUNT_KEY: Symbol = symbol_short!("P_CNT");
 const SCHEMA_VERSION_KEY: Symbol = symbol_short!("S_VER");
 const PAUSED_KEY: Symbol = symbol_short!("PAUSED");
 const TOKEN_COUNT_KEY: Symbol = symbol_short!("TOK_CNT");
+const MAX_PLAYERS_CAP_KEY: Symbol = symbol_short!("MAX_PLR");
 
 // ── Fee timelock storage keys ─────────────────────────────────────────────────
 const WIN_FEE_BPS_KEY: Symbol = symbol_short!("FEE_BPS");
@@ -71,6 +72,21 @@ pub struct ArenaRef {
 
 const MAX_POOL_CAPACITY: u32 = 256;
 const MAX_PAGE_SIZE: u32 = 50;
+
+// ── Player-cap (DoS hardening, see issue #495) ────────────────────────────────
+//
+// `resolve_round()` iterates over every registered player, so an unbounded
+// `max_players` lets a malicious host exhaust the Soroban CPU budget and
+// permanently lock entry fees. Enforce a protocol-wide hard cap in the factory
+// — the host's per-arena `capacity` is always validated against
+// `max_players_cap()` before deployment, regardless of what the host or
+// downstream arena contract permit.
+
+/// Default value of the configurable player cap (used when storage is unset).
+pub const MAX_PLAYERS_HARD_CAP: u32 = 64;
+/// Absolute upper bound for `set_max_players_cap` — the admin can never raise
+/// the cap above this, even via governance, so the DoS surface stays bounded.
+pub const MAX_PLAYERS_ABSOLUTE_CAP: u32 = 128;
 
 #[contracttype]
 #[derive(Clone)]
@@ -173,6 +189,10 @@ pub enum Error {
     EmptyTokenWhitelist = 23,
     /// Token address does not expose the expected SAC interface.
     InvalidTokenContract = 24,
+    /// Requested `capacity` exceeds the protocol-wide player cap. See issue #495.
+    ExceedsPlayerCap = 25,
+    /// `set_max_players_cap` called with a value outside `[2, MAX_PLAYERS_ABSOLUTE_CAP]`.
+    InvalidPlayerCap = 26,
 
 }
 
@@ -367,6 +387,39 @@ impl FactoryContract {
             .unwrap_or(DEFAULT_MIN_STAKE)
     }
 
+    // ── Player cap ────────────────────────────────────────────────────────────
+
+    /// Return the protocol-wide cap on `max_players` for new arenas.
+    /// Defaults to [`MAX_PLAYERS_HARD_CAP`] (64) until the admin overrides it.
+    pub fn max_players_cap(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&MAX_PLAYERS_CAP_KEY)
+            .unwrap_or(MAX_PLAYERS_HARD_CAP)
+    }
+
+    /// Update the protocol-wide cap on `max_players`. Admin-only.
+    ///
+    /// The new value must be in `[2, MAX_PLAYERS_ABSOLUTE_CAP]` so the cap can
+    /// never be raised beyond an absolute ceiling that keeps `resolve_round`
+    /// well within the Soroban CPU budget.
+    ///
+    /// # Errors
+    /// * [`Error::InvalidPlayerCap`] — `new_cap` is below 2 or above
+    ///   [`MAX_PLAYERS_ABSOLUTE_CAP`].
+    pub fn set_max_players_cap(env: Env, new_cap: u32) -> Result<(), Error> {
+        let admin = require_admin(&env)?;
+        require_not_paused(&env)?;
+        admin.require_auth();
+        if new_cap < 2 || new_cap > MAX_PLAYERS_ABSOLUTE_CAP {
+            return Err(Error::InvalidPlayerCap);
+        }
+        env.storage()
+            .instance()
+            .set(&MAX_PLAYERS_CAP_KEY, &new_cap);
+        Ok(())
+    }
+
     // ── Fee timelock ──────────────────────────────────────────────────────────
 
     /// Return the current effective platform win fee in basis points.
@@ -487,6 +540,7 @@ impl FactoryContract {
     /// * [`Error::UnsupportedToken`] — `currency` has not been added via `add_supported_token`.
     /// * [`Error::Unauthorized`] — `caller` is neither admin nor whitelisted.
     /// * [`Error::InvalidCapacity`] — `capacity` is < 2 or > `MAX_POOL_CAPACITY`.
+    /// * [`Error::ExceedsPlayerCap`] — `capacity` exceeds `max_players_cap()`.
     /// * [`Error::InvalidStakeAmount`] — `stake_amount` is zero or negative.
     /// * [`Error::StakeBelowMinimum`] — `stake_amount` is below the configured minimum.
     /// * [`Error::WasmHashNotSet`] — `set_arena_wasm_hash` has not been called yet.
@@ -524,6 +578,9 @@ impl FactoryContract {
 
         if capacity < 2 || capacity > MAX_POOL_CAPACITY {
             return Err(Error::InvalidCapacity);
+        }
+        if capacity > Self::max_players_cap(env.clone()) {
+            return Err(Error::ExceedsPlayerCap);
         }
 
         let min_stake = Self::get_min_stake(env.clone());

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -10,7 +10,8 @@ use soroban_sdk::{
 
 const TIMELOCK: u64 = 48 * 60 * 60; // 48 hours
 const MIN_STAKE: i128 = 10_000_000; // 10 XLM in stroops
-const MAX_CAPACITY: u32 = 256;
+// Default protocol-wide player cap (see issue #495). Mirrors `MAX_PLAYERS_HARD_CAP`.
+const MAX_CAPACITY: u32 = MAX_PLAYERS_HARD_CAP;
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -329,12 +330,136 @@ fn test_create_pool_with_zero_capacity_returns_invalid_capacity() {
 }
 
 #[test]
-fn test_create_pool_exceeding_max_capacity_returns_invalid_capacity() {
+fn test_create_pool_exceeding_max_capacity_returns_exceeds_player_cap() {
     let (env, admin, client) = setup();
     client.set_arena_wasm_hash(&dummy_hash(&env));
     let currency = supported_currency(&env, &client);
     let result = client.try_create_pool(&admin, &MIN_STAKE, &currency, &10u32, &(MAX_CAPACITY + 1), &(env.ledger().timestamp() + 7200));
+    assert_eq!(result, Err(Ok(Error::ExceedsPlayerCap)));
+}
+
+#[test]
+fn test_create_pool_above_structural_capacity_returns_invalid_capacity() {
+    // Even after the admin raises the player cap to its absolute max,
+    // capacity above the structural ceiling (`MAX_POOL_CAPACITY`, currently 256)
+    // must still fail with `InvalidCapacity`.
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+    client.set_max_players_cap(&MAX_PLAYERS_ABSOLUTE_CAP);
+    let result = client.try_create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &257u32,
+        &(env.ledger().timestamp() + 7200),
+    );
     assert_eq!(result, Err(Ok(Error::InvalidCapacity)));
+}
+
+// ── max_players_cap (issue #495) ──────────────────────────────────────────────
+
+#[test]
+fn test_default_max_players_cap_is_hard_cap() {
+    let (_env, _admin, client) = setup();
+    assert_eq!(client.max_players_cap(), MAX_PLAYERS_HARD_CAP);
+}
+
+#[test]
+fn test_create_pool_at_player_cap_succeeds() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+    client.create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &MAX_PLAYERS_HARD_CAP,
+        &(env.ledger().timestamp() + 7200),
+    );
+}
+
+#[test]
+fn test_create_pool_one_over_player_cap_returns_exceeds_player_cap() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+    let result = client.try_create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &(MAX_PLAYERS_HARD_CAP + 1),
+        &(env.ledger().timestamp() + 7200),
+    );
+    assert_eq!(result, Err(Ok(Error::ExceedsPlayerCap)));
+}
+
+#[test]
+fn test_admin_can_raise_player_cap_then_create_pool_succeeds() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+
+    // Capacity above the default cap is rejected.
+    let new_capacity = MAX_PLAYERS_HARD_CAP + 1;
+    let pre = client.try_create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &new_capacity,
+        &(env.ledger().timestamp() + 7200),
+    );
+    assert_eq!(pre, Err(Ok(Error::ExceedsPlayerCap)));
+
+    // Admin raises the cap; the same call now succeeds.
+    client.set_max_players_cap(&MAX_PLAYERS_ABSOLUTE_CAP);
+    assert_eq!(client.max_players_cap(), MAX_PLAYERS_ABSOLUTE_CAP);
+    client.create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &new_capacity,
+        &(env.ledger().timestamp() + 7200),
+    );
+}
+
+#[test]
+fn test_set_max_players_cap_above_absolute_cap_is_rejected() {
+    let (_env, _admin, client) = setup();
+    let result = client.try_set_max_players_cap(&(MAX_PLAYERS_ABSOLUTE_CAP + 1));
+    assert_eq!(result, Err(Ok(Error::InvalidPlayerCap)));
+}
+
+#[test]
+fn test_set_max_players_cap_below_minimum_is_rejected() {
+    let (_env, _admin, client) = setup();
+    let result = client.try_set_max_players_cap(&1u32);
+    assert_eq!(result, Err(Ok(Error::InvalidPlayerCap)));
+}
+
+#[test]
+fn test_set_max_players_cap_can_lower_below_default() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+
+    client.set_max_players_cap(&8u32);
+    assert_eq!(client.max_players_cap(), 8u32);
+
+    let result = client.try_create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &9u32,
+        &(env.ledger().timestamp() + 7200),
+    );
+    assert_eq!(result, Err(Ok(Error::ExceedsPlayerCap)));
 }
 
 // ── create_pool duplicate rejection ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Issue #495 reports that an unbounded `max_players` lets a malicious host spin up an arena with thousands of slots; once enough players join, `resolve_round()` exhausts the Soroban CPU budget and the round can never resolve, permanently locking entry fees.

This PR adds a protocol-wide hard cap that the factory enforces in `create_pool` *before* any arena is deployed:

- New compile-time constants in `contract/factory/src/lib.rs`:
  - `MAX_PLAYERS_HARD_CAP = 64` — the default cap value applied immediately on every deploy.
  - `MAX_PLAYERS_ABSOLUTE_CAP = 128` — the admin can never raise the runtime cap above this.
- New admin entrypoint `set_max_players_cap(new_cap)` (validates `2 <= new_cap <= 128`) and view `max_players_cap()`.
- New errors `Error::ExceedsPlayerCap = 25` and `Error::InvalidPlayerCap = 26`.
- `create_pool` returns `ExceedsPlayerCap` when `capacity > max_players_cap()`.

The existing `MAX_POOL_CAPACITY = 256` structural ceiling is left in place as a defense-in-depth check; in practice the player cap is always tighter, so it only fires if the absolute cap is later raised — a regression test covers that path too.

Closes #495

## Changes

- [x] Add `MAX_PLAYERS_HARD_CAP` (default 64) and `MAX_PLAYERS_ABSOLUTE_CAP` (128) constants
- [x] Add storage-backed configurable cap with `MAX_PLAYERS_CAP_KEY`
- [x] Add admin entrypoint `set_max_players_cap` and view `max_players_cap`
- [x] Add `ExceedsPlayerCap` and `InvalidPlayerCap` error variants
- [x] Enforce the cap inside `FactoryContract::create_pool`
- [x] Update the existing `MAX_CAPACITY` test constant + corresponding tests to align with the new cap
- [x] Add 8 new tests covering the acceptance criteria

## Tests

`cargo test -p factory` on `fix/issue-495-max-players-cap`:

```
test result: FAILED. 99 passed; 14 failed; 0 ignored; 0 measured
```

Compared to the same command on `main` (baseline):

```
test result: FAILED. 91 passed; 14 failed; 0 ignored; 0 measured
```

The same 14 tests fail on both branches — they are pre-existing failures (constructor invocation / SAC token issues) unrelated to this change. Net effect: **+8 new passing tests, 0 regressions**.

The 9 tests directly covering the fix all pass:

```
test test::test_default_max_players_cap_is_hard_cap ... ok
test test::test_create_pool_at_player_cap_succeeds ... ok
test test::test_create_pool_one_over_player_cap_returns_exceeds_player_cap ... ok
test test::test_admin_can_raise_player_cap_then_create_pool_succeeds ... ok
test test::test_set_max_players_cap_above_absolute_cap_is_rejected ... ok
test test::test_set_max_players_cap_below_minimum_is_rejected ... ok
test test::test_set_max_players_cap_can_lower_below_default ... ok
test test::test_create_pool_exceeding_max_capacity_returns_exceeds_player_cap ... ok
test test::test_create_pool_above_structural_capacity_returns_invalid_capacity ... ok

test result: ok. 9 passed; 0 failed
```

`cargo build --workspace` is clean (only pre-existing unused-constant warnings in `arena/src/bounds.rs`).

## Acceptance criteria

- [x] `create_pool()` with `capacity > 64` returns `Error::ExceedsPlayerCap`
- [x] Hard cap enforced in factory (not just arena contract)
- [x] Admin can update cap up to absolute maximum (128) via `set_max_players_cap()`
- [x] Unit tests for at-cap (64), one-over-cap (65), and admin update
- [x] Workspace builds cleanly

## Notes / follow-ups

- The 14 pre-existing factory test failures on `main` are not addressed here — they appear to be environment/SAC-token related and predate this change.
- A future PR could mirror the cap in `arena::set_capacity` for defense in depth (today the factory always calls `set_capacity(capacity)` after validating it, so the cap is enforced on every legitimate deploy path).