### PR TITLE
Implement contract fixes for payout + host staking safeguards

### DIFF
--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -2,11 +2,7 @@
 
 use soroban_sdk::{
     Address, BytesN, Env, IntoVal, String, Symbol, Vec, contract, contracterror, contractimpl,
-<<<<<<< HEAD
-    contracttype, symbol_short, xdr::ToXdr, token,
-=======
     contracttype, symbol_short, token, xdr::ToXdr,
->>>>>>> 83c0ce16d2eca2bfab80651a454e22f3722b0af9
 };
 
 #[cfg(test)]
@@ -25,6 +21,8 @@ const SCHEMA_VERSION_KEY: Symbol = symbol_short!("S_VER");
 const PAUSED_KEY: Symbol = symbol_short!("PAUSED");
 const TOKEN_COUNT_KEY: Symbol = symbol_short!("TOK_CNT");
 const MAX_PLAYERS_CAP_KEY: Symbol = symbol_short!("MAX_PLR");
+const STAKING_CONTRACT_KEY: Symbol = symbol_short!("STAKING");
+const MIN_HOST_STAKE_KEY: Symbol = symbol_short!("HST_MIN");
 
 // ── Fee timelock storage keys ─────────────────────────────────────────────────
 const WIN_FEE_BPS_KEY: Symbol = symbol_short!("FEE_BPS");
@@ -135,12 +133,7 @@ const TOPIC_ARENA_WL_REM: Symbol = symbol_short!("AWL_REM");
 const TOPIC_FEE_QUEUED: Symbol = symbol_short!("FEE_Q");
 const TOPIC_FEE_EXECUTED: Symbol = symbol_short!("FEE_EX");
 const TOPIC_FEE_CANCELLED: Symbol = symbol_short!("FEE_CAN");
-<<<<<<< HEAD
 const TOPIC_FEE_CONFIG_UPDATED: Symbol = symbol_short!("CRF_UP");
-=======
-const TOPIC_ARENA_WL_ADD: Symbol = symbol_short!("AWL_ADD");
-const TOPIC_ARENA_WL_REM: Symbol = symbol_short!("AWL_REM");
->>>>>>> 83c0ce16d2eca2bfab80651a454e22f3722b0af9
 
 /// Event payload version. Include in every event data tuple so consumers
 /// can detect schema changes without re-deploying indexers.
@@ -198,24 +191,24 @@ pub enum Error {
     NoPendingFeeUpdate = 20,
     /// Provided fee exceeds `MAX_WIN_FEE_BPS` (2000).
     FeeTooHigh = 21,
-<<<<<<< HEAD
     /// Creation fee amount is negative.
     InvalidCreationFee = 22,
     /// Host does not hold enough `fee_token` to pay the configured creation fee.
     InsufficientCreationFee = 23,
-=======
     /// Token is not currently on the allowed whitelist.
-    TokenNotAllowed = 22,
+    TokenNotAllowed = 24,
     /// Removing the token would leave whitelist empty.
-    EmptyTokenWhitelist = 23,
+    EmptyTokenWhitelist = 25,
     /// Token address does not expose the expected SAC interface.
-    InvalidTokenContract = 24,
+    InvalidTokenContract = 26,
     /// Requested `capacity` exceeds the protocol-wide player cap. See issue #495.
-    ExceedsPlayerCap = 25,
+    ExceedsPlayerCap = 27,
     /// `set_max_players_cap` called with a value outside `[2, MAX_PLAYERS_ABSOLUTE_CAP]`.
-    InvalidPlayerCap = 26,
-
->>>>>>> 83c0ce16d2eca2bfab80651a454e22f3722b0af9
+    InvalidPlayerCap = 28,
+    /// Staking contract not set.
+    StakingContractNotSet = 29,
+    /// Host staked balance below configured minimum host stake.
+    HostStakeInsufficient = 30,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -245,12 +238,13 @@ impl FactoryContract {
             .set(&MIN_STAKE_KEY, &DEFAULT_MIN_STAKE);
         env.storage()
             .instance()
+            .set(&MIN_HOST_STAKE_KEY, &DEFAULT_MIN_STAKE);
+        env.storage()
+            .instance()
             .set(&WIN_FEE_BPS_KEY, &DEFAULT_WIN_FEE_BPS);
         // Default creation fee is 0 (disabled) with a placeholder token address.
         // Admin should call `set_creation_fee` to configure the actual token.
-        env.storage()
-            .instance()
-            .set(&CREATION_FEE_KEY, &0i128);
+        env.storage().instance().set(&CREATION_FEE_KEY, &0i128);
         env.storage()
             .instance()
             .set(&CREATION_TOKEN_KEY, &env.current_contract_address());
@@ -340,8 +334,7 @@ impl FactoryContract {
     pub fn set_arena_wasm_hash(env: Env, wasm_hash: BytesN<32>) -> Result<(), Error> {
         let admin = require_admin(&env)?;
         admin.require_auth();
-        let previous_hash: Option<BytesN<32>> =
-            env.storage().instance().get(&ARENA_WASM_HASH_KEY);
+        let previous_hash: Option<BytesN<32>> = env.storage().instance().get(&ARENA_WASM_HASH_KEY);
         env.storage()
             .instance()
             .set(&ARENA_WASM_HASH_KEY, &wasm_hash);
@@ -420,6 +413,43 @@ impl FactoryContract {
             .unwrap_or(DEFAULT_MIN_STAKE)
     }
 
+    /// Admin-only: configure staking contract used for host stake checks.
+    pub fn set_staking_contract(env: Env, staking_contract: Address) -> Result<(), Error> {
+        let admin = require_admin(&env)?;
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&STAKING_CONTRACT_KEY, &staking_contract);
+        Ok(())
+    }
+
+    pub fn get_staking_contract(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&STAKING_CONTRACT_KEY)
+            .ok_or(Error::StakingContractNotSet)
+    }
+
+    /// Admin-only: set minimum host stake required to create arena.
+    pub fn set_min_host_stake(env: Env, min_host_stake: i128) -> Result<(), Error> {
+        let admin = require_admin(&env)?;
+        admin.require_auth();
+        if min_host_stake <= 0 {
+            return Err(Error::InvalidStakeAmount);
+        }
+        env.storage()
+            .instance()
+            .set(&MIN_HOST_STAKE_KEY, &min_host_stake);
+        Ok(())
+    }
+
+    pub fn get_min_host_stake(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&MIN_HOST_STAKE_KEY)
+            .unwrap_or(DEFAULT_MIN_STAKE)
+    }
+
     // ── Player cap ────────────────────────────────────────────────────────────
 
     /// Return the protocol-wide cap on `max_players` for new arenas.
@@ -447,9 +477,7 @@ impl FactoryContract {
         if new_cap < 2 || new_cap > MAX_PLAYERS_ABSOLUTE_CAP {
             return Err(Error::InvalidPlayerCap);
         }
-        env.storage()
-            .instance()
-            .set(&MAX_PLAYERS_CAP_KEY, &new_cap);
+        env.storage().instance().set(&MAX_PLAYERS_CAP_KEY, &new_cap);
         Ok(())
     }
 
@@ -575,7 +603,11 @@ impl FactoryContract {
             return Err(Error::InvalidCreationFee);
         }
 
-        let old_fee: i128 = env.storage().instance().get(&CREATION_FEE_KEY).unwrap_or(0i128);
+        let old_fee: i128 = env
+            .storage()
+            .instance()
+            .get(&CREATION_FEE_KEY)
+            .unwrap_or(0i128);
         env.storage().instance().set(&CREATION_FEE_KEY, &amount);
         env.storage().instance().set(&CREATION_TOKEN_KEY, &token);
 
@@ -588,7 +620,11 @@ impl FactoryContract {
 
     /// Public read: get the configured (creation_fee, fee_token).
     pub fn get_creation_fee(env: Env) -> (i128, Address) {
-        let fee: i128 = env.storage().instance().get(&CREATION_FEE_KEY).unwrap_or(0i128);
+        let fee: i128 = env
+            .storage()
+            .instance()
+            .get(&CREATION_FEE_KEY)
+            .unwrap_or(0i128);
         let tok: Address = env
             .storage()
             .instance()
@@ -660,6 +696,17 @@ impl FactoryContract {
             return Err(Error::StakeBelowMinimum);
         }
 
+        // Issue #449: host must have enough stake locked in staking contract.
+        let staking_contract = Self::get_staking_contract(env.clone())?;
+        let host_stake: i128 = env.invoke_contract(
+            &staking_contract,
+            &soroban_sdk::Symbol::new(&env, "get_host_stake"),
+            soroban_sdk::vec![&env, caller.clone().into_val(&env)],
+        );
+        if host_stake < Self::get_min_host_stake(env.clone()) {
+            return Err(Error::HostStakeInsufficient);
+        }
+
         // ── Arena creation fee (fee-then-deploy) ─────────────────────────────
         let (creation_fee, fee_token) = Self::get_creation_fee(env.clone());
         if creation_fee > 0 {
@@ -710,7 +757,8 @@ impl FactoryContract {
 
         // Deploy the contract.
         #[cfg(not(test))]
-        let arena_address = env.deployer()
+        let arena_address = env
+            .deployer()
             .with_current_contract(salt)
             .deploy_v2(wasm_hash, (env.current_contract_address(),));
 
@@ -725,15 +773,6 @@ impl FactoryContract {
             addr
         };
 
-<<<<<<< HEAD
-        #[cfg(not(test))]
-        let arena_address = env
-            .deployer()
-            .with_current_contract(salt)
-            .deploy_v2(wasm_hash, ());
-
-=======
->>>>>>> 83c0ce16d2eca2bfab80651a454e22f3722b0af9
         // ── Initialisation ──────────────────────────────────────────────────────
         // Note: __constructor runs at deploy time (deploy_v2/register_at), so
         // there is no separate initialize() call needed here.
@@ -795,11 +834,24 @@ impl FactoryContract {
             (
                 EVENT_VERSION,
                 pool_id,
-                caller,
+                caller.clone(),
                 capacity,
                 stake,
                 arena_address.clone(),
             ),
+        );
+
+        // Lock host stake against this arena id in staking contract.
+        let staking_contract = Self::get_staking_contract(env.clone())?;
+        env.invoke_contract::<()>(
+            &staking_contract,
+            &soroban_sdk::Symbol::new(&env, "lock_host_stake"),
+            soroban_sdk::vec![
+                &env,
+                caller.clone().into_val(&env),
+                (pool_id as u64).into_val(&env),
+                Self::get_min_host_stake(env.clone()).into_val(&env),
+            ],
         );
 
         Ok(arena_address)
@@ -843,7 +895,9 @@ impl FactoryContract {
             status: ArenaStatus::Pending,
             host: host.clone(),
         };
-        env.storage().persistent().set(&DataKey::ArenaRef(arena_id), &arena_ref);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ArenaRef(arena_id), &arena_ref);
     }
 
     /// Retrieve the ArenaRef for a given arena_id.
@@ -942,6 +996,21 @@ impl FactoryContract {
             .persistent()
             .set(&DataKey::ArenaRef(arena_id), &arena_ref);
 
+        // Release host stake when arena reaches terminal status.
+        if status == ArenaStatus::Completed || status == ArenaStatus::Cancelled {
+            if let Ok(staking_contract) = Self::get_staking_contract(env.clone()) {
+                env.invoke_contract::<()>(
+                    &staking_contract,
+                    &soroban_sdk::Symbol::new(&env, "release_host_stake"),
+                    soroban_sdk::vec![
+                        &env,
+                        arena_ref.host.into_val(&env),
+                        arena_id.into_val(&env),
+                    ],
+                );
+            }
+        }
+
         Ok(())
     }
 
@@ -960,9 +1029,7 @@ impl FactoryContract {
 
         let key = DataKey::SupportedToken(token.clone());
         let existed = env.storage().instance().has(&key);
-        env.storage()
-            .instance()
-            .set(&key, &true);
+        env.storage().instance().set(&key, &true);
         if !existed {
             let count: u32 = env.storage().instance().get(&TOKEN_COUNT_KEY).unwrap_or(0);
             env.storage().instance().set(&TOKEN_COUNT_KEY, &(count + 1));
@@ -992,9 +1059,7 @@ impl FactoryContract {
             }
             env.storage().instance().set(&TOKEN_COUNT_KEY, &(count - 1));
         }
-        env.storage()
-            .instance()
-            .remove(&key);
+        env.storage().instance().remove(&key);
         env.events()
             .publish((TOPIC_TOKEN_REMOVED,), (EVENT_VERSION, token));
         env.events()
@@ -1221,10 +1286,7 @@ impl FactoryContract {
 
     /// Return whether the contract is currently paused.
     pub fn is_paused(env: Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&PAUSED_KEY)
-            .unwrap_or(false)
+        env.storage().instance().get(&PAUSED_KEY).unwrap_or(false)
     }
 }
 
@@ -1240,12 +1302,7 @@ fn require_admin(env: &Env) -> Result<Address, Error> {
 
 /// Return `Error::Paused` if the contract is currently paused.
 fn require_not_paused(env: &Env) -> Result<(), Error> {
-    if env
-        .storage()
-        .instance()
-        .get(&PAUSED_KEY)
-        .unwrap_or(false)
-    {
+    if env.storage().instance().get(&PAUSED_KEY).unwrap_or(false) {
         return Err(Error::Paused);
     }
     Ok(())

--- a/contract/payout/src/lib.rs
+++ b/contract/payout/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    Address, BytesN, Env, IntoVal, Symbol, Vec, contract, contracterror, contractimpl, contracttype,
-    panic_with_error, symbol_short, token,
+    Address, BytesN, Env, IntoVal, Symbol, Vec, contract, contracterror, contractimpl,
+    contracttype, panic_with_error, symbol_short, token,
 };
 
 const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
@@ -13,6 +13,7 @@ const PENDING_HASH_KEY: Symbol = symbol_short!("P_HASH");
 const EXECUTE_AFTER_KEY: Symbol = symbol_short!("P_AFTER");
 const TOPIC_PAYOUT_EXECUTED: Symbol = symbol_short!("PAYOUT");
 const TOPIC_DUST_COLLECTED: Symbol = symbol_short!("DUST");
+const TOPIC_RECOVERY: Symbol = symbol_short!("RECOVER");
 const TOPIC_PAUSED: Symbol = symbol_short!("PAUSED");
 const TOPIC_UNPAUSED: Symbol = symbol_short!("UNPAUSED");
 const TOPIC_UPGRADE_PROPOSED: Symbol = symbol_short!("UP_PROP");
@@ -111,6 +112,7 @@ pub enum PayoutError {
     TimelockNotExpired = 8,
     UpgradeAlreadyPending = 9,
     HashMismatch = 10,
+    RecoveryAmountInvalid = 11,
 }
 
 #[contract]
@@ -248,7 +250,20 @@ impl PayoutContract {
             .instance()
             .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
 
-        // Transfer tokens to winner if a token address is registered for this currency.
+        let mut fee_amount: i128 = 0;
+        let mut winner_amount: i128 = amount;
+
+        let fee_bps: u32 = env.invoke_contract(
+            &factory,
+            &soroban_sdk::Symbol::new(&env, "current_fee_bps"),
+            soroban_sdk::vec![&env],
+        );
+        if fee_bps > 0 {
+            fee_amount = amount.saturating_mul(fee_bps as i128) / 10_000i128;
+            winner_amount = amount.saturating_sub(fee_amount);
+        }
+
+        // Transfer tokens to winner and fee treasury if token address exists.
         if let Some(token_address) = env
             .storage()
             .instance()
@@ -257,14 +272,31 @@ impl PayoutContract {
             token::Client::new(&env, &token_address).transfer(
                 &env.current_contract_address(),
                 &winner,
-                &amount,
+                &winner_amount,
             );
+            if fee_amount > 0 {
+                let treasury = Self::treasury(env.clone())?;
+                token::Client::new(&env, &token_address).transfer(
+                    &env.current_contract_address(),
+                    &treasury,
+                    &fee_amount,
+                );
+            }
         }
 
-        env.events()
-            .publish((TOPIC_PAYOUT_EXECUTED,), (winner, amount, currency));
+        env.events().publish(
+            (TOPIC_PAYOUT_EXECUTED,),
+            (winner, winner_amount, fee_amount, currency),
+        );
 
-        record_receipt(&env, pool_id as u64, payout_data.winner, amount, 0, None);
+        record_receipt(
+            &env,
+            pool_id as u64,
+            payout_data.winner,
+            winner_amount,
+            fee_amount,
+            None,
+        );
 
         Ok(())
     }
@@ -440,9 +472,11 @@ impl PayoutContract {
             };
             let receipt_key = DataKey::SplitPayout(arena_id, winner.clone());
             env.storage().persistent().set(&receipt_key, &receipt);
-            env.storage()
-                .persistent()
-                .extend_ttl(&receipt_key, PAYOUT_TTL_THRESHOLD, PAYOUT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &receipt_key,
+                PAYOUT_TTL_THRESHOLD,
+                PAYOUT_TTL_EXTEND_TO,
+            );
 
             env.events()
                 .publish((TOPIC_PAYOUT_EXECUTED,), (winner, amount, currency.clone()));
@@ -503,8 +537,12 @@ impl PayoutContract {
             return Err(PayoutError::UpgradeAlreadyPending);
         }
         let execute_after: u64 = env.ledger().timestamp() + TIMELOCK_PERIOD;
-        env.storage().instance().set(&PENDING_HASH_KEY, &new_wasm_hash);
-        env.storage().instance().set(&EXECUTE_AFTER_KEY, &execute_after);
+        env.storage()
+            .instance()
+            .set(&PENDING_HASH_KEY, &new_wasm_hash);
+        env.storage()
+            .instance()
+            .set(&EXECUTE_AFTER_KEY, &execute_after);
         env.events().publish(
             (TOPIC_UPGRADE_PROPOSED,),
             (EVENT_VERSION, new_wasm_hash, execute_after),
@@ -549,7 +587,8 @@ impl PayoutContract {
         }
         env.storage().instance().remove(&PENDING_HASH_KEY);
         env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events().publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
+        env.events()
+            .publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
         Ok(())
     }
 
@@ -560,6 +599,28 @@ impl PayoutContract {
             (Some(h), Some(a)) => Some((h, a)),
             _ => None,
         }
+    }
+
+    /// Admin-only recovery endpoint for stranded tokens.
+    pub fn emergency_recover_tokens(
+        env: Env,
+        token_address: Address,
+        recipient: Address,
+        amount: i128,
+    ) -> Result<(), PayoutError> {
+        let admin = Self::admin(env.clone());
+        admin.require_auth();
+        if amount <= 0 {
+            return Err(PayoutError::RecoveryAmountInvalid);
+        }
+        token::Client::new(&env, &token_address).transfer(
+            &env.current_contract_address(),
+            &recipient,
+            &amount,
+        );
+        env.events()
+            .publish((TOPIC_RECOVERY,), (recipient, amount, token_address));
+        Ok(())
     }
 }
 

--- a/contract/payout/src/test.rs
+++ b/contract/payout/src/test.rs
@@ -6,7 +6,6 @@ use soroban_sdk::{
     token::{StellarAssetClient, TokenClient},
 };
 
-
 #[contract]
 pub struct MockFactoryContract;
 #[contractimpl]
@@ -22,13 +21,20 @@ impl MockFactoryContract {
     pub fn get_arena_ref(env: Env, arena_id: u64) -> ArenaRef {
         env.storage().instance().get(&arena_id).unwrap()
     }
+    pub fn current_fee_bps(_env: Env) -> u32 {
+        0
+    }
 }
 
 const TIMELOCK: u64 = 48 * 60 * 60;
 
-
-
-fn setup() -> (Env, Address, PayoutContractClient<'static>, Address, MockFactoryContractClient<'static>) {
+fn setup() -> (
+    Env,
+    Address,
+    PayoutContractClient<'static>,
+    Address,
+    MockFactoryContractClient<'static>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -52,7 +58,7 @@ fn setup_with_token() -> (
     Address,
     Address,
     Address,
-    MockFactoryContractClient<'static>
+    MockFactoryContractClient<'static>,
 ) {
     let (env, admin, client, factory_id, factory_client) = setup();
 
@@ -66,7 +72,15 @@ fn setup_with_token() -> (
     let asset = StellarAssetClient::new(&env, &token_id);
     asset.mint(&client.address, &10_000i128);
 
-    (env, admin, client, token_id, treasury, factory_id, factory_client)
+    (
+        env,
+        admin,
+        client,
+        token_id,
+        treasury,
+        factory_id,
+        factory_client,
+    )
 }
 
 #[test]
@@ -99,7 +113,9 @@ fn test_admin_can_distribute_winnings() {
     {
         let caller = Address::generate(&env);
         factory_client.set_arena(&(pool_id as u64), &caller);
-        client.distribute_winnings(&caller, &ctx, &pool_id, &round_id, &winner, &amount, &currency)
+        client.distribute_winnings(
+            &caller, &ctx, &pool_id, &round_id, &winner, &amount, &currency,
+        )
     };
     assert!(client.is_payout_processed(&ctx, &pool_id, &round_id, &winner));
 
@@ -129,12 +145,13 @@ fn test_unauthorized_caller_cannot_distribute() {
     let result = {
         let caller = Address::generate(&env);
         // factory_client is not defined here, so we instantiate it
-        let factory_client = MockFactoryContractClient::new(&env, &env.register(MockFactoryContract, ()));
+        let factory_client =
+            MockFactoryContractClient::new(&env, &env.register(MockFactoryContract, ()));
         client.init_factory(&factory_client.address);
-        
+
         // Clear all mocked auths BEFORE trying to distribute, but AFTER init_factory which needs admin auth
         env.mock_auths(&[]);
-        
+
         factory_client.set_arena(&(1u32 as u64), &caller);
         client.try_distribute_winnings(&caller, &ctx, &1u32, &1u32, &winner, &1000i128, &currency)
     };
@@ -403,7 +420,9 @@ fn payout_record_survives_ttl_threshold() {
     {
         let caller = Address::generate(&env);
         factory_client.set_arena(&(pool_id as u64), &caller);
-        client.distribute_winnings(&caller, &ctx, &pool_id, &round_id, &winner, &amount, &currency)
+        client.distribute_winnings(
+            &caller, &ctx, &pool_id, &round_id, &winner, &amount, &currency,
+        )
     };
 
     // Advance ledger past PAYOUT_TTL_THRESHOLD (100_000) — record must still exist.
@@ -716,17 +735,16 @@ fn timelock_execute_with_wrong_hash_returns_hash_mismatch() {
     );
 }
 
-
 #[test]
 fn test_unauthorized_caller_attack_scenario() {
     let (env, _admin, client, _, factory_client) = setup();
     let attacker = Address::generate(&env);
     let ctx = symbol_short!("ATTACK");
     let pool_id = 1u32;
-    
+
     let valid_arena = Address::generate(&env);
     factory_client.set_arena(&(pool_id as u64), &valid_arena);
-    
+
     let result = client.try_distribute_winnings(
         &attacker,
         &ctx,
@@ -736,6 +754,6 @@ fn test_unauthorized_caller_attack_scenario() {
         &1000i128,
         &symbol_short!("XLM"),
     );
-    
+
     assert_eq!(result, Err(Ok(PayoutError::UnauthorizedCaller)));
 }

--- a/contract/staking/src/lib.rs
+++ b/contract/staking/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    Address, BytesN, Env, Symbol, contract, contracterror, contractimpl, contracttype, symbol_short,
-    token,
+    Address, BytesN, Env, Symbol, contract, contracterror, contractimpl, contracttype,
+    symbol_short, token,
 };
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -10,6 +10,7 @@ use soroban_sdk::{
 const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
 const PAUSED_KEY: Symbol = symbol_short!("PAUSED");
 const TOKEN_KEY: Symbol = symbol_short!("TOKEN");
+const FACTORY_KEY: Symbol = symbol_short!("FACTRY");
 pub const TOTAL_STAKED_KEY: Symbol = symbol_short!("TSTAKE");
 const TOTAL_SHARES_KEY: Symbol = symbol_short!("TSHARES");
 const PENDING_HASH_KEY: Symbol = symbol_short!("P_HASH");
@@ -45,6 +46,7 @@ pub enum StakingError {
     TimelockNotExpired = 8,
     UpgradeAlreadyPending = 9,
     HashMismatch = 10,
+    LockedStake = 11,
 }
 
 // ── Storage key schema ────────────────────────────────────────────────────────
@@ -53,6 +55,8 @@ pub enum StakingError {
 #[derive(Clone)]
 enum DataKey {
     Position(Address),
+    HostLock(Address, u64),
+    HostLockedTotal(Address),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -116,6 +120,17 @@ impl StakingContract {
             .instance()
             .get(&TOKEN_KEY)
             .expect("not initialized")
+    }
+
+    /// Admin-only: configure factory contract that can lock/release host stake.
+    pub fn set_factory(env: Env, factory: Address) {
+        let admin = Self::admin(env.clone());
+        admin.require_auth();
+        env.storage().instance().set(&FACTORY_KEY, &factory);
+    }
+
+    pub fn factory(env: Env) -> Option<Address> {
+        env.storage().instance().get(&FACTORY_KEY)
     }
 
     // ── Pause mechanism ──────────────────────────────────────────────────────
@@ -201,6 +216,66 @@ impl StakingContract {
             total_claimed_rewards: 0,
             stake_share_bps,
         }
+    }
+
+    /// Returns currently available host stake (staked minus locked amount).
+    pub fn get_host_stake(env: Env, host: Address) -> i128 {
+        let total = Self::staked_balance(env.clone(), host.clone());
+        let locked: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HostLockedTotal(host))
+            .unwrap_or(0);
+        total.saturating_sub(locked)
+    }
+
+    /// Lock host stake for an arena so host cannot withdraw below reserved amount.
+    pub fn lock_host_stake(
+        env: Env,
+        host: Address,
+        arena_id: u64,
+        amount: i128,
+    ) -> Result<(), StakingError> {
+        if amount <= 0 {
+            return Err(StakingError::InvalidAmount);
+        }
+        let available = Self::get_host_stake(env.clone(), host.clone());
+        if available < amount {
+            return Err(StakingError::InsufficientShares);
+        }
+        let lock_key = DataKey::HostLock(host.clone(), arena_id);
+        if env.storage().persistent().has(&lock_key) {
+            return Ok(());
+        }
+        env.storage().persistent().set(&lock_key, &amount);
+        let current_locked: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HostLockedTotal(host.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::HostLockedTotal(host), &(current_locked + amount));
+        Ok(())
+    }
+
+    /// Release previously locked host stake for an arena.
+    pub fn release_host_stake(env: Env, host: Address, arena_id: u64) -> Result<(), StakingError> {
+        let lock_key = DataKey::HostLock(host.clone(), arena_id);
+        let Some(locked_amount) = env.storage().persistent().get::<_, i128>(&lock_key) else {
+            return Ok(());
+        };
+        env.storage().persistent().remove(&lock_key);
+        let current_locked: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HostLockedTotal(host.clone()))
+            .unwrap_or(0);
+        let next_locked = current_locked.saturating_sub(locked_amount);
+        env.storage()
+            .persistent()
+            .set(&DataKey::HostLockedTotal(host), &next_locked);
+        Ok(())
     }
 
     // ── Staking ───────────────────────────────────────────────────────────────
@@ -318,6 +393,15 @@ impl StakingContract {
             .and_then(|v| v.checked_div(total_shares))
             .unwrap_or(shares);
 
+        let currently_locked: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HostLockedTotal(staker.clone()))
+            .unwrap_or(0);
+        if position.amount.saturating_sub(tokens_returned) < currently_locked {
+            return Err(StakingError::LockedStake);
+        }
+
         let token_contract = get_token_contract(&env)?;
 
         // CEI: update state before token transfer.
@@ -355,8 +439,12 @@ impl StakingContract {
             return Err(StakingError::UpgradeAlreadyPending);
         }
         let execute_after: u64 = env.ledger().timestamp() + TIMELOCK_PERIOD;
-        env.storage().instance().set(&PENDING_HASH_KEY, &new_wasm_hash);
-        env.storage().instance().set(&EXECUTE_AFTER_KEY, &execute_after);
+        env.storage()
+            .instance()
+            .set(&PENDING_HASH_KEY, &new_wasm_hash);
+        env.storage()
+            .instance()
+            .set(&EXECUTE_AFTER_KEY, &execute_after);
         env.events().publish(
             (TOPIC_UPGRADE_PROPOSED,),
             (EVENT_VERSION, new_wasm_hash, execute_after),
@@ -401,7 +489,8 @@ impl StakingContract {
         }
         env.storage().instance().remove(&PENDING_HASH_KEY);
         env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events().publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
+        env.events()
+            .publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- enforce host staking requirement for arena creation and lock/release host stake over arena lifecycle
- implement payout distribution authorization path with fee deduction and receipt persistence
- add admin emergency token recovery for stranded payout funds

Closes #451
Closes #452
Closes #449
Closes #454

## Test plan
- cargo test -p payout --tests
- cargo check -p factory

Made with [Cursor](https://cursor.com)