### PR TITLE
feat: implement staking reward flows and auto vault deposit on arena activation

### DIFF
--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -1,14 +1,8 @@
 #![no_std]
 
-<<<<<<< feat/close-473-479-484
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
-    Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec,
-=======
-use soroban_sdk::{IntoVal,
-    Address, Bytes, BytesN, Env, String, Symbol, Vec, contract, contracterror, contractimpl,
-    contracttype, panic_with_error, symbol_short, token,
->>>>>>> main
+    Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec, contract, contracterror,
+    contractimpl, contracttype, panic_with_error, symbol_short, token,
 };
 
 mod bounds;
@@ -65,19 +59,12 @@ const TOPIC_ARENA_STARTED: Symbol = symbol_short!("A_START");
 const TOPIC_UPGRADE_PROPOSED: Symbol = symbol_short!("UP_PROP");
 const TOPIC_UPGRADE_EXECUTED: Symbol = symbol_short!("UP_EXEC");
 const TOPIC_UPGRADE_CANCELLED: Symbol = symbol_short!("UP_CANC");
-
-<<<<<<< feat/close-473-479-484
-=======
 const TOPIC_YIELD_HARVESTED: Symbol = symbol_short!("Y_HARV");
 const TOPIC_VAULT_FALLBACK: Symbol = symbol_short!("V_FALL");
 const TOPIC_ADMIN_PROPOSED: Symbol = symbol_short!("AD_PROP");
 const TOPIC_ADMIN_ACCEPTED: Symbol = symbol_short!("AD_DONE");
 const TOPIC_ADMIN_CANCELLED: Symbol = symbol_short!("AD_CANC");
-
-
-
-
->>>>>>> main
+const TOPIC_FUNDS_DEPOSITED: Symbol = symbol_short!("F_DEP");
 const EVENT_VERSION: u32 = 1;
 
 // ── Error codes ───────────────────────────────────────────────────────────────
@@ -162,6 +149,7 @@ pub struct ArenaConfig {
     /// Payout uses this value rather than the current global fee so that
     /// fee changes cannot retroactively affect an in-progress game.
     pub win_fee_bps: u32,
+    pub reserve_ratio_bps: u32,
     pub is_private: bool,
 }
 
@@ -322,8 +310,6 @@ pub struct ArenaSnapshot {
     pub potential_payout: i128,
 }
 
-<<<<<<< feat/close-473-479-484
-=======
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct YieldHarvested {
@@ -354,11 +340,23 @@ pub struct AdminTransferCompleted {
     pub new_admin: Address,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FundsDeposited {
+    pub arena_id: u64,
+    pub amount: i128,
+    pub shares: i128,
+    pub vault_address: Address,
+}
+
 macro_rules! assert_state {
     ($current:expr, $expected:pat) => {
         match $current {
-            $expected => {},
-            _ => panic!("Invalid state transition: current state {:?} is not allowed for this operation", $current),
+            $expected => {}
+            _ => panic!(
+                "Invalid state transition: current state {:?} is not allowed for this operation",
+                $current
+            ),
         }
     };
 }
@@ -378,17 +376,15 @@ macro_rules! assert_is_host {
 /// Returns `Err(ArenaError::Unauthorized)` if the check fails.
 macro_rules! assert_is_survivor {
     ($env:expr, $player:expr) => {
-        if !$env.storage().persistent().has(&DataKey::Survivor($player.clone())) {
+        if !$env
+            .storage()
+            .persistent()
+            .has(&DataKey::Survivor($player.clone()))
+        {
             return Err(ArenaError::Unauthorized);
         }
     };
 }
-
-
-
-
-
->>>>>>> main
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
@@ -534,6 +530,7 @@ impl ArenaContract {
                 grace_period_seconds: bounds::DEFAULT_GRACE_PERIOD_SECONDS,
                 join_deadline,
                 win_fee_bps,
+                reserve_ratio_bps: 1_000,
                 is_private: false,
             },
         );
@@ -593,6 +590,18 @@ impl ArenaContract {
         config.winner_yield_share_bps = bps;
         env.storage().instance().set(&DataKey::Config, &config);
         env.storage().instance().set(&WINNER_SHARE_KEY, &bps);
+        Ok(())
+    }
+
+    pub fn set_reserve_ratio_bps(env: Env, bps: u32) -> Result<(), ArenaError> {
+        let admin = Self::admin(env.clone());
+        admin.require_auth();
+        if bps > 10_000 {
+            return Err(ArenaError::InvalidAmount);
+        }
+        let mut config = get_config(&env)?;
+        config.reserve_ratio_bps = bps;
+        env.storage().instance().set(&DataKey::Config, &config);
         Ok(())
     }
 
@@ -676,6 +685,20 @@ impl ArenaContract {
                 entry_fee: amount,
             },
         );
+
+        let updated_count = count + 1;
+        if updated_count >= capacity && state(&env) == ArenaState::Pending {
+            activate_arena_internal(&env, arena_id, 1, config.round_speed_in_ledgers)?;
+            let prize_pool: i128 = env.storage().instance().get(&PRIZE_POOL_KEY).unwrap_or(0);
+            env.events().publish(
+                (TOPIC_ARENA_STARTED,),
+                ArenaStarted {
+                    arena_id,
+                    player_count: updated_count,
+                    prize_pool,
+                },
+            );
+        }
         Ok(())
     }
 
@@ -784,8 +807,10 @@ impl ArenaContract {
         if survivors < 2 {
             return Err(ArenaError::NotEnoughPlayers);
         }
+        let arena_id: u64 = env.storage().instance().get(&DataKey::ArenaId).unwrap_or(0);
         activate_arena_internal(
             &env,
+            arena_id,
             previous.round_number + 1,
             config.round_speed_in_ledgers,
         )
@@ -821,7 +846,7 @@ impl ArenaContract {
         }
 
         let config = get_config(&env)?;
-        let round = activate_arena_internal(&env, 1, config.round_speed_in_ledgers)?;
+        let round = activate_arena_internal(&env, arena_id, 1, config.round_speed_in_ledgers)?;
         let prize_pool: i128 = env.storage().instance().get(&PRIZE_POOL_KEY).unwrap_or(0);
         env.events().publish(
             (TOPIC_ARENA_STARTED,),
@@ -1474,11 +1499,7 @@ impl ArenaContract {
             .instance()
             .get(&TOKEN_KEY)
             .ok_or(ArenaError::TokenNotSet)?;
-        let prize_pool: i128 = env
-            .storage()
-            .instance()
-            .get(&PRIZE_POOL_KEY)
-            .unwrap_or(0);
+        let prize_pool: i128 = env.storage().instance().get(&PRIZE_POOL_KEY).unwrap_or(0);
         if prize_pool <= 0 {
             return Err(ArenaError::InvalidAmount);
         }
@@ -1493,7 +1514,9 @@ impl ArenaContract {
             soroban_sdk::vec![&env, token_addr.into_val(&env), prize_pool.into_val(&env)],
         );
         env.storage().instance().set(&VAULT_SHARES_KEY, &shares);
-        env.storage().instance().set(&VAULT_DEPOSITED_KEY, &prize_pool);
+        env.storage()
+            .instance()
+            .set(&VAULT_DEPOSITED_KEY, &prize_pool);
         Ok(shares)
     }
 
@@ -1533,11 +1556,7 @@ impl ArenaContract {
                 .instance()
                 .get(&VAULT_ADDR_KEY)
                 .ok_or(ArenaError::VaultNotSet)?;
-            let shares: i128 = env
-                .storage()
-                .instance()
-                .get(&VAULT_SHARES_KEY)
-                .unwrap_or(0);
+            let shares: i128 = env.storage().instance().get(&VAULT_SHARES_KEY).unwrap_or(0);
             // Vault interface: withdraw(shares: i128) -> i128 (tokens returned)
             let total_received: i128 = env.invoke_contract(
                 &vault_addr,
@@ -1547,11 +1566,7 @@ impl ArenaContract {
             let y = (total_received - deposited).max(0);
             (total_received - y, y)
         } else {
-            let prize_pool: i128 = env
-                .storage()
-                .instance()
-                .get(&PRIZE_POOL_KEY)
-                .unwrap_or(0);
+            let prize_pool: i128 = env.storage().instance().get(&PRIZE_POOL_KEY).unwrap_or(0);
             (prize_pool, 0)
         };
         let arena_id: u64 = env.storage().instance().get(&DataKey::ArenaId).unwrap_or(0);
@@ -1614,7 +1629,10 @@ impl ArenaContract {
         env.storage().instance().remove(&ADMIN_EXPIRY_KEY);
         env.events().publish(
             (TOPIC_ADMIN_ACCEPTED,),
-            AdminTransferCompleted { old_admin, new_admin },
+            AdminTransferCompleted {
+                old_admin,
+                new_admin,
+            },
         );
         Ok(())
     }
@@ -1681,14 +1699,18 @@ fn apply_winner_distribution(
         .persistent()
         .set(&DataKey::Winner(player.clone()), &true);
     env.storage().instance().set(&WINNER_ADDR_KEY, &player);
-    env.storage().instance().set(&PRIZE_POOL_KEY, &principal_pool);
+    env.storage()
+        .instance()
+        .set(&PRIZE_POOL_KEY, &principal_pool);
     env.storage().instance().set(&YIELD_KEY, &yield_earned);
     for eliminated_player in eliminated.iter() {
         env.storage()
             .persistent()
             .set(&DataKey::Claimable(eliminated_player), &per_eliminated);
     }
-    env.storage().instance().set(&STATE_KEY, &ArenaState::Completed);
+    env.storage()
+        .instance()
+        .set(&STATE_KEY, &ArenaState::Completed);
     let arena_id: u64 = env.storage().instance().get(&DataKey::ArenaId).unwrap_or(0);
     env.events().publish(
         (TOPIC_YIELD_DISTRIBUTED,),
@@ -1834,9 +1856,14 @@ fn set_state(env: &Env, new_state: ArenaState) {
 
 fn activate_arena_internal(
     env: &Env,
+    arena_id: u64,
     round_number: u32,
     round_speed_in_ledgers: u32,
 ) -> Result<RoundState, ArenaError> {
+    if state(env) == ArenaState::Pending {
+        auto_deposit_entry_fees(env, arena_id)?;
+    }
+
     let start = env.ledger().sequence();
     let deadline = start
         .checked_add(round_speed_in_ledgers)
@@ -1853,6 +1880,83 @@ fn activate_arena_internal(
     env.storage().instance().set(&DataKey::Round, &round);
     set_state(env, ArenaState::Active);
     Ok(round)
+}
+
+fn auto_deposit_entry_fees(env: &Env, arena_id: u64) -> Result<(), ArenaError> {
+    if env.storage().instance().has(&VAULT_SHARES_KEY) {
+        return Ok(());
+    }
+
+    let vault_active: bool = env
+        .storage()
+        .instance()
+        .get(&VAULT_ACTIVE_KEY)
+        .unwrap_or(false);
+    if !vault_active {
+        return Ok(());
+    }
+
+    let vault_addr: Address = env
+        .storage()
+        .instance()
+        .get(&VAULT_ADDR_KEY)
+        .ok_or(ArenaError::VaultNotSet)?;
+    let token_addr: Address = env
+        .storage()
+        .instance()
+        .get(&TOKEN_KEY)
+        .ok_or(ArenaError::TokenNotSet)?;
+    let config = get_config(env)?;
+    let player_count: i128 = env
+        .storage()
+        .instance()
+        .get::<_, u32>(&SURVIVOR_COUNT_KEY)
+        .unwrap_or(0) as i128;
+    if player_count <= 0 {
+        return Ok(());
+    }
+
+    let total_depositable = config
+        .required_stake_amount
+        .checked_mul(player_count)
+        .ok_or(ArenaError::InvalidAmount)?;
+    let reserve_amount = total_depositable
+        .checked_mul(config.reserve_ratio_bps as i128)
+        .and_then(|v| v.checked_div(BPS_DENOMINATOR))
+        .ok_or(ArenaError::InvalidAmount)?;
+    let deposit_amount = total_depositable.saturating_sub(reserve_amount);
+    if deposit_amount <= 0 {
+        return Ok(());
+    }
+
+    token::Client::new(env, &token_addr).transfer(
+        &env.current_contract_address(),
+        &vault_addr,
+        &deposit_amount,
+    );
+    let shares: i128 = env.invoke_contract(
+        &vault_addr,
+        &soroban_sdk::Symbol::new(env, "deposit"),
+        soroban_sdk::vec![env, token_addr.into_val(env), deposit_amount.into_val(env)],
+    );
+
+    env.storage().instance().set(&VAULT_SHARES_KEY, &shares);
+    env.storage()
+        .instance()
+        .set(&VAULT_DEPOSITED_KEY, &deposit_amount);
+    env.storage()
+        .instance()
+        .set(&PRIZE_POOL_KEY, &reserve_amount);
+    env.events().publish(
+        (TOPIC_FUNDS_DEPOSITED,),
+        FundsDeposited {
+            arena_id,
+            amount: deposit_amount,
+            shares,
+            vault_address: vault_addr,
+        },
+    );
+    Ok(())
 }
 
 fn capacity(env: &Env) -> u32 {
@@ -1966,7 +2070,7 @@ mod abi_guard;
 #[cfg(test)]
 mod yield_share_tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, IntoVal};
+    use soroban_sdk::{IntoVal, testutils::Address as _, token::StellarAssetClient};
 
     fn setup(bps: u32) -> (Env, ArenaContractClient<'static>, Address, Vec<Address>) {
         let env = Env::default();

--- a/contract/staking/src/lib.rs
+++ b/contract/staking/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
-    Address, BytesN, Env, Symbol,
+    Address, BytesN, Env, Symbol, contract, contracterror, contractimpl, contracttype,
+    panic_with_error, symbol_short, token,
 };
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -19,10 +19,16 @@ pub const TOTAL_STAKED_KEY: Symbol = symbol_short!("TSTAKE");
 const TOTAL_SHARES_KEY: Symbol = symbol_short!("TSHARES");
 const PENDING_HASH_KEY: Symbol = symbol_short!("P_HASH");
 const EXECUTE_AFTER_KEY: Symbol = symbol_short!("P_AFTER");
+const LOCK_PERIOD_KEY: Symbol = symbol_short!("LOCK_SEC");
+const MIN_STAKE_KEY: Symbol = symbol_short!("MIN_STK");
+const REWARD_PER_SHARE_KEY: Symbol = symbol_short!("RWD_PSH");
+const REWARD_POOL_KEY: Symbol = symbol_short!("RWD_POOL");
+const UNALLOCATED_REWARDS_KEY: Symbol = symbol_short!("RWD_UNA");
 
 // ── Timelock: 48 hours in seconds ─────────────────────────────────────────────
 const TIMELOCK_PERIOD: u64 = 48 * 60 * 60;
 const EVENT_VERSION: u32 = 1;
+const PRECISION: i128 = 1_000_000_000_000_000_000;
 
 // ── Event topics ──────────────────────────────────────────────────────────────
 
@@ -36,6 +42,9 @@ const TOPIC_UPGRADE_CANCELLED: Symbol = symbol_short!("UP_CANC");
 const TOPIC_ADMIN_PROPOSED: Symbol = symbol_short!("AD_PROP");
 const TOPIC_ADMIN_ACCEPTED: Symbol = symbol_short!("AD_DONE");
 const TOPIC_ADMIN_CANCELLED: Symbol = symbol_short!("AD_CANC");
+const TOPIC_REWARDS_DEPOSITED: Symbol = symbol_short!("RWD_DEP");
+const TOPIC_REWARDS_CLAIMED: Symbol = symbol_short!("RWD_CLM");
+const TOPIC_COMPOUNDED: Symbol = symbol_short!("CMPND");
 
 // ── Error codes ───────────────────────────────────────────────────────────────
 
@@ -57,6 +66,9 @@ pub enum StakingError {
     AdminTransferExpired = 12,
     Unauthorized = 13,
     LockedStake = 14,
+    StillLocked = 15,
+    InsufficientBalance = 16,
+    NothingToCompound = 17,
 }
 
 // ── Storage key schema ────────────────────────────────────────────────────────
@@ -67,6 +79,10 @@ enum DataKey {
     Position(Address),
     HostLock(Address, u64),
     HostLockedTotal(Address),
+    RewardDebt(Address),
+    PendingRewards(Address),
+    StakedAt(Address),
+    TotalClaimedRewards(Address),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -114,6 +130,13 @@ impl StakingContract {
         admin.require_auth();
         env.storage().instance().set(&ADMIN_KEY, &admin);
         env.storage().instance().set(&TOKEN_KEY, &token);
+        env.storage().instance().set(&LOCK_PERIOD_KEY, &0u64);
+        env.storage().instance().set(&MIN_STAKE_KEY, &1i128);
+        env.storage().instance().set(&REWARD_PER_SHARE_KEY, &0i128);
+        env.storage().instance().set(&REWARD_POOL_KEY, &0i128);
+        env.storage()
+            .instance()
+            .set(&UNALLOCATED_REWARDS_KEY, &0i128);
     }
 
     /// Return the current admin address.
@@ -141,6 +164,30 @@ impl StakingContract {
 
     pub fn factory(env: Env) -> Option<Address> {
         env.storage().instance().get(&FACTORY_KEY)
+    }
+
+    pub fn set_lock_period_seconds(env: Env, seconds: u64) {
+        let admin = Self::admin(env.clone());
+        admin.require_auth();
+        env.storage().instance().set(&LOCK_PERIOD_KEY, &seconds);
+    }
+
+    pub fn lock_period_seconds(env: Env) -> u64 {
+        env.storage().instance().get(&LOCK_PERIOD_KEY).unwrap_or(0)
+    }
+
+    pub fn set_min_stake(env: Env, min_stake: i128) -> Result<(), StakingError> {
+        let admin = Self::admin(env.clone());
+        admin.require_auth();
+        if min_stake <= 0 {
+            return Err(StakingError::InvalidAmount);
+        }
+        env.storage().instance().set(&MIN_STAKE_KEY, &min_stake);
+        Ok(())
+    }
+
+    pub fn min_stake(env: Env) -> i128 {
+        env.storage().instance().get(&MIN_STAKE_KEY).unwrap_or(1)
     }
 
     // ── Pause mechanism ──────────────────────────────────────────────────────
@@ -207,8 +254,20 @@ impl StakingContract {
     }
 
     pub fn get_staker_stats(env: Env, staker: Address) -> StakerStats {
-        let position = Self::get_position(env.clone(), staker);
+        let position = Self::get_position(env.clone(), staker.clone());
         let total_staked = Self::total_staked(env.clone());
+        let pending_rewards = pending_rewards_of(&env, &staker, &position);
+        let staked_at: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StakedAt(staker.clone()))
+            .unwrap_or(0);
+        let unlock_at = staked_at.saturating_add(Self::lock_period_seconds(env.clone()));
+        let total_claimed_rewards: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalClaimedRewards(staker.clone()))
+            .unwrap_or(0);
         let stake_share_bps = if total_staked <= 0 || position.amount <= 0 {
             0
         } else {
@@ -221,9 +280,9 @@ impl StakingContract {
 
         StakerStats {
             staked_amount: position.amount,
-            pending_rewards: 0,
-            unlock_at: 0,
-            total_claimed_rewards: 0,
+            pending_rewards,
+            unlock_at,
+            total_claimed_rewards,
             stake_share_bps,
         }
     }
@@ -312,6 +371,16 @@ impl StakingContract {
 
         let token_contract = get_token_contract(&env)?;
 
+        let mut position: StakePosition = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Position(staker.clone()))
+            .unwrap_or(StakePosition {
+                amount: 0,
+                shares: 0,
+            });
+        accrue_rewards(&env, &staker, &position)?;
+
         let total_staked: i128 = env.storage().instance().get(&TOTAL_STAKED_KEY).unwrap_or(0);
         let total_shares: i128 = env.storage().instance().get(&TOTAL_SHARES_KEY).unwrap_or(0);
 
@@ -331,20 +400,17 @@ impl StakingContract {
         env.storage()
             .instance()
             .set(&TOTAL_SHARES_KEY, &(total_shares + shares_minted));
-
-        let mut position: StakePosition = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Position(staker.clone()))
-            .unwrap_or(StakePosition {
-                amount: 0,
-                shares: 0,
-            });
         position.amount += amount;
         position.shares += shares_minted;
         env.storage()
             .persistent()
             .set(&DataKey::Position(staker.clone()), &position);
+        env.storage().persistent().set(
+            &DataKey::StakedAt(staker.clone()),
+            &env.ledger().timestamp(),
+        );
+        sync_reward_debt(&env, &staker)?;
+        distribute_unallocated_rewards(&env)?;
 
         // Interaction: transfer tokens into the contract.
         token::Client::new(&env, &token_contract).transfer(
@@ -372,14 +438,14 @@ impl StakingContract {
     ///
     /// # Authorization
     /// Requires `staker.require_auth()`.
-    pub fn unstake(env: Env, staker: Address, shares: i128) -> Result<i128, StakingError> {
+    pub fn unstake(env: Env, staker: Address, amount: i128) -> Result<i128, StakingError> {
         require_not_paused(&env)?;
         staker.require_auth();
 
-        if shares == 0 {
+        if amount == 0 {
             return Err(StakingError::ZeroShares);
         }
-        if shares < 0 {
+        if amount < 0 {
             return Err(StakingError::InvalidAmount);
         }
 
@@ -391,53 +457,231 @@ impl StakingContract {
                 amount: 0,
                 shares: 0,
             });
-        if position.shares < shares {
-            return Err(StakingError::InsufficientShares);
+        if position.amount < amount {
+            return Err(StakingError::InsufficientBalance);
         }
+
+        let staked_at: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StakedAt(staker.clone()))
+            .unwrap_or(0);
+        let unlock_at = staked_at.saturating_add(Self::lock_period_seconds(env.clone()));
+        if env.ledger().timestamp() < unlock_at {
+            return Err(StakingError::StillLocked);
+        }
+
+        accrue_rewards(&env, &staker, &position)?;
 
         let total_staked: i128 = env.storage().instance().get(&TOTAL_STAKED_KEY).unwrap_or(0);
         let total_shares: i128 = env.storage().instance().get(&TOTAL_SHARES_KEY).unwrap_or(0);
 
-        let tokens_returned = shares
-            .checked_mul(total_staked)
-            .and_then(|v| v.checked_div(total_shares))
-            .unwrap_or(shares);
+        let shares_to_burn = if amount == position.amount {
+            position.shares
+        } else {
+            amount
+                .checked_mul(total_shares)
+                .and_then(|v| v.checked_div(total_staked))
+                .unwrap_or(0)
+                .max(1)
+                .min(position.shares)
+        };
 
         let currently_locked: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::HostLockedTotal(staker.clone()))
             .unwrap_or(0);
-        if position.amount.saturating_sub(tokens_returned) < currently_locked {
+        if position.amount.saturating_sub(amount) < currently_locked {
             return Err(StakingError::LockedStake);
         }
 
         let token_contract = get_token_contract(&env)?;
 
         // CEI: update state before token transfer.
-        position.shares -= shares;
-        position.amount = position.amount.saturating_sub(tokens_returned);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Position(staker.clone()), &position);
+        position.shares = position.shares.saturating_sub(shares_to_burn);
+        position.amount = position.amount.saturating_sub(amount);
+        if position.shares == 0 || position.amount == 0 {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Position(staker.clone()));
+            env.storage()
+                .persistent()
+                .remove(&DataKey::RewardDebt(staker.clone()));
+            env.storage()
+                .persistent()
+                .remove(&DataKey::StakedAt(staker.clone()));
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Position(staker.clone()), &position);
+            sync_reward_debt(&env, &staker)?;
+        }
         env.storage()
             .instance()
-            .set(&TOTAL_STAKED_KEY, &(total_staked - tokens_returned));
+            .set(&TOTAL_STAKED_KEY, &(total_staked - amount));
         env.storage()
             .instance()
-            .set(&TOTAL_SHARES_KEY, &(total_shares - shares));
+            .set(&TOTAL_SHARES_KEY, &(total_shares - shares_to_burn));
 
         // Interaction: transfer tokens back to staker.
         token::Client::new(&env, &token_contract).transfer(
             &env.current_contract_address(),
             &staker,
-            &tokens_returned,
+            &amount,
         );
 
         env.events()
-            .publish((TOPIC_UNSTAKE,), (staker, tokens_returned, shares));
+            .publish((TOPIC_UNSTAKE,), (staker, amount, position.amount));
 
-        Ok(tokens_returned)
+        Ok(amount)
+    }
+
+    pub fn deposit_rewards(env: Env, from: Address, amount: i128) -> Result<(), StakingError> {
+        require_not_paused(&env)?;
+        from.require_auth();
+        if amount <= 0 {
+            return Err(StakingError::InvalidAmount);
+        }
+
+        let admin = Self::admin(env.clone());
+        let factory = Self::factory(env.clone());
+        let is_authorized = from == admin || factory.as_ref().is_some_and(|f| *f == from);
+        if !is_authorized {
+            return Err(StakingError::Unauthorized);
+        }
+
+        let token_contract = get_token_contract(&env)?;
+        token::Client::new(&env, &token_contract).transfer(
+            &from,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let reward_pool: i128 = env.storage().instance().get(&REWARD_POOL_KEY).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&REWARD_POOL_KEY, &(reward_pool + amount));
+
+        let total_shares = Self::total_shares(env.clone());
+        if total_shares > 0 {
+            let reward_per_share = env
+                .storage()
+                .instance()
+                .get(&REWARD_PER_SHARE_KEY)
+                .unwrap_or(0i128);
+            let delta = amount
+                .checked_mul(PRECISION)
+                .and_then(|v| v.checked_div(total_shares))
+                .unwrap_or(0);
+            env.storage()
+                .instance()
+                .set(&REWARD_PER_SHARE_KEY, &(reward_per_share + delta));
+        } else {
+            let unallocated: i128 = env
+                .storage()
+                .instance()
+                .get(&UNALLOCATED_REWARDS_KEY)
+                .unwrap_or(0);
+            env.storage()
+                .instance()
+                .set(&UNALLOCATED_REWARDS_KEY, &(unallocated + amount));
+        }
+
+        env.events()
+            .publish((TOPIC_REWARDS_DEPOSITED,), (from, amount));
+        Ok(())
+    }
+
+    pub fn claim_rewards(env: Env, staker: Address) -> Result<i128, StakingError> {
+        require_not_paused(&env)?;
+        staker.require_auth();
+
+        let position = Self::get_position(env.clone(), staker.clone());
+        accrue_rewards(&env, &staker, &position)?;
+
+        let claim_key = DataKey::PendingRewards(staker.clone());
+        let claimable: i128 = env.storage().persistent().get(&claim_key).unwrap_or(0);
+        if claimable <= 0 {
+            return Ok(0);
+        }
+
+        let token_contract = get_token_contract(&env)?;
+        let pool: i128 = env.storage().instance().get(&REWARD_POOL_KEY).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&REWARD_POOL_KEY, &pool.saturating_sub(claimable));
+        env.storage().persistent().set(&claim_key, &0i128);
+
+        let total_claimed_key = DataKey::TotalClaimedRewards(staker.clone());
+        let total_claimed: i128 = env
+            .storage()
+            .persistent()
+            .get(&total_claimed_key)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&total_claimed_key, &(total_claimed + claimable));
+
+        token::Client::new(&env, &token_contract).transfer(
+            &env.current_contract_address(),
+            &staker,
+            &claimable,
+        );
+        env.events()
+            .publish((TOPIC_REWARDS_CLAIMED,), (staker, claimable));
+        Ok(claimable)
+    }
+
+    pub fn compound(env: Env, staker: Address) -> Result<i128, StakingError> {
+        require_not_paused(&env)?;
+        staker.require_auth();
+
+        let mut position = Self::get_position(env.clone(), staker.clone());
+        accrue_rewards(&env, &staker, &position)?;
+
+        let pending_key = DataKey::PendingRewards(staker.clone());
+        let pending: i128 = env.storage().persistent().get(&pending_key).unwrap_or(0);
+        if pending <= 0 {
+            return Err(StakingError::NothingToCompound);
+        }
+        if pending < Self::min_stake(env.clone()) && position.amount <= 0 {
+            return Err(StakingError::InvalidAmount);
+        }
+
+        let total_staked = Self::total_staked(env.clone());
+        let total_shares = Self::total_shares(env.clone());
+        let shares_minted = if total_staked == 0 || total_shares == 0 {
+            pending
+        } else {
+            pending
+                .checked_mul(total_shares)
+                .and_then(|v| v.checked_div(total_staked))
+                .unwrap_or(pending)
+        };
+
+        position.amount += pending;
+        position.shares += shares_minted;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Position(staker.clone()), &position);
+        env.storage().persistent().set(&pending_key, &0i128);
+
+        let reward_pool: i128 = env.storage().instance().get(&REWARD_POOL_KEY).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&REWARD_POOL_KEY, &reward_pool.saturating_sub(pending));
+        env.storage()
+            .instance()
+            .set(&TOTAL_STAKED_KEY, &(total_staked + pending));
+        env.storage()
+            .instance()
+            .set(&TOTAL_SHARES_KEY, &(total_shares + shares_minted));
+        sync_reward_debt(&env, &staker)?;
+
+        env.events()
+            .publish((TOPIC_COMPOUNDED,), (staker, pending, position.amount));
+        Ok(pending)
     }
 
     // ── Upgrade timelock ─────────────────────────────────────────────────────
@@ -571,7 +815,8 @@ impl StakingContract {
         }
         env.storage().instance().remove(&PENDING_ADMIN_KEY);
         env.storage().instance().remove(&ADMIN_EXPIRY_KEY);
-        env.events().publish((TOPIC_ADMIN_CANCELLED,), (EVENT_VERSION,));
+        env.events()
+            .publish((TOPIC_ADMIN_CANCELLED,), (EVENT_VERSION,));
         Ok(())
     }
 
@@ -599,6 +844,109 @@ fn require_not_paused(env: &Env) -> Result<(), StakingError> {
     if env.storage().instance().get(&PAUSED_KEY).unwrap_or(false) {
         return Err(StakingError::Paused);
     }
+    Ok(())
+}
+
+fn pending_rewards_of(env: &Env, staker: &Address, position: &StakePosition) -> i128 {
+    let pending: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::PendingRewards(staker.clone()))
+        .unwrap_or(0);
+    if position.shares <= 0 {
+        return pending;
+    }
+
+    let reward_per_share: i128 = env
+        .storage()
+        .instance()
+        .get(&REWARD_PER_SHARE_KEY)
+        .unwrap_or(0);
+    let reward_debt: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RewardDebt(staker.clone()))
+        .unwrap_or(0);
+    let delta = reward_per_share.saturating_sub(reward_debt);
+    if delta <= 0 {
+        return pending;
+    }
+    let accrued = position
+        .shares
+        .checked_mul(delta)
+        .and_then(|v| v.checked_div(PRECISION))
+        .unwrap_or(0);
+    pending.saturating_add(accrued)
+}
+
+fn accrue_rewards(
+    env: &Env,
+    staker: &Address,
+    position: &StakePosition,
+) -> Result<(), StakingError> {
+    distribute_unallocated_rewards(env)?;
+    let pending = pending_rewards_of(env, staker, position);
+    env.storage()
+        .persistent()
+        .set(&DataKey::PendingRewards(staker.clone()), &pending);
+    sync_reward_debt(env, staker)?;
+    Ok(())
+}
+
+fn sync_reward_debt(env: &Env, staker: &Address) -> Result<(), StakingError> {
+    let position: StakePosition = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Position(staker.clone()))
+        .unwrap_or(StakePosition {
+            amount: 0,
+            shares: 0,
+        });
+    if position.shares <= 0 {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RewardDebt(staker.clone()));
+        return Ok(());
+    }
+    let reward_per_share: i128 = env
+        .storage()
+        .instance()
+        .get(&REWARD_PER_SHARE_KEY)
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DataKey::RewardDebt(staker.clone()), &reward_per_share);
+    Ok(())
+}
+
+fn distribute_unallocated_rewards(env: &Env) -> Result<(), StakingError> {
+    let unallocated: i128 = env
+        .storage()
+        .instance()
+        .get(&UNALLOCATED_REWARDS_KEY)
+        .unwrap_or(0);
+    if unallocated <= 0 {
+        return Ok(());
+    }
+    let total_shares: i128 = env.storage().instance().get(&TOTAL_SHARES_KEY).unwrap_or(0);
+    if total_shares <= 0 {
+        return Ok(());
+    }
+    let reward_per_share: i128 = env
+        .storage()
+        .instance()
+        .get(&REWARD_PER_SHARE_KEY)
+        .unwrap_or(0);
+    let delta = unallocated
+        .checked_mul(PRECISION)
+        .and_then(|v| v.checked_div(total_shares))
+        .ok_or(StakingError::InvalidAmount)?;
+    env.storage()
+        .instance()
+        .set(&REWARD_PER_SHARE_KEY, &(reward_per_share + delta));
+    env.storage()
+        .instance()
+        .set(&UNALLOCATED_REWARDS_KEY, &0i128);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- implement lock-aware unstake flow and balance validation in staking
- add reward accumulator flows: deposit_rewards, claim_rewards, and compound
- add reserve ratio config and auto vault deposit on Pending to Active arena transition
- trigger activation automatically when arena reaches max capacity

## Validation
- cargo check -p staking --manifest-path contract/Cargo.toml
- cargo check -p arena --manifest-path contract/Cargo.toml (fails due to existing #[contracterror] enum-length macro panic in arena crate baseline)

Closes #456
Closes #457
Closes #459
Closes #461