### PR TITLE
feat(contracts): implement arena join/player state and factory create/list APIs

### DIFF
--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -240,6 +240,24 @@ pub struct PlayerJoined {
 }
 
 #[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PlayerStatus {
+    Active,
+    Elim,
+    Winner,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerSnapshot {
+    pub player: Address,
+    pub status: PlayerStatus,
+    pub eliminated_round: Option<u32>,
+    pub choice_this_round: Option<Choice>,
+    pub total_rounds_survived: u32,
+}
+
+#[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChoiceSubmitted {
     pub arena_id: u64,
@@ -399,6 +417,7 @@ enum DataKey {
     AllPlayers,
     Survivor(Address),
     Eliminated(Address),
+    ElimRound(Address),
     PrizeClaimed(Address),
     Claimable(Address),
     Winner(Address),
@@ -608,8 +627,11 @@ impl ArenaContract {
     pub fn join(env: Env, player: Address, amount: i128) -> Result<(), ArenaError> {
         player.require_auth();
         require_not_paused(&env)?;
-        if Self::is_cancelled(env.clone()) {
-            return Err(ArenaError::AlreadyCancelled);
+        match state(&env) {
+            ArenaState::Pending => {}
+            ArenaState::Active => return Err(ArenaError::RoundAlreadyActive),
+            ArenaState::Completed => return Err(ArenaError::GameAlreadyFinished),
+            ArenaState::Cancelled => return Err(ArenaError::AlreadyCancelled),
         }
         let config = get_config(&env)?;
         let arena_id: u64 = env.storage().instance().get(&DataKey::ArenaId).unwrap_or(0);
@@ -700,6 +722,19 @@ impl ArenaContract {
             );
         }
         Ok(())
+    }
+
+    pub fn player_join(env: Env, player: Address, arena_id: u64) -> Result<(), ArenaError> {
+        let stored_arena_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ArenaId)
+            .unwrap_or(arena_id);
+        if stored_arena_id != arena_id {
+            return Err(ArenaError::Unauthorized);
+        }
+        let config = get_config(&env)?;
+        Self::join(env, player, config.required_stake_amount)
     }
 
     /// Expire an unfilled arena past its join deadline. Callable by anyone.
@@ -999,6 +1034,9 @@ impl ArenaContract {
                 env.storage()
                     .persistent()
                     .set(&DataKey::Eliminated(player.clone()), &true);
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::ElimRound(player.clone()), &round.round_number);
                 eliminated_count += 1;
             }
         }
@@ -1150,6 +1188,9 @@ impl ArenaContract {
                 env.storage()
                     .persistent()
                     .set(&DataKey::Eliminated(player.clone()), &true);
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::ElimRound(player.clone()), &state.round_number);
                 eliminated_count += 1;
             }
         }
@@ -1292,6 +1333,56 @@ impl ArenaContract {
 
     pub fn get_user_state(env: Env, player: Address) -> UserStateView {
         PlayerCache::load(&env, &player).user_state_view()
+    }
+
+    pub fn get_player_state(env: Env, player: Address) -> PlayerSnapshot {
+        let persistent = env.storage().persistent();
+        let is_survivor = persistent.has(&DataKey::Survivor(player.clone()));
+        let is_winner = persistent.has(&DataKey::Winner(player.clone()));
+        let is_eliminated = persistent.has(&DataKey::Eliminated(player.clone()));
+        if !is_survivor && !is_winner && !is_eliminated {
+            panic_with_error!(&env, ArenaError::Unauthorized);
+        }
+
+        let status = if is_winner {
+            PlayerStatus::Winner
+        } else if is_survivor {
+            PlayerStatus::Active
+        } else {
+            PlayerStatus::Elim
+        };
+
+        let round =
+            get_round(&env).unwrap_or_else(|_| panic_with_error!(&env, ArenaError::NotInitialized));
+        let eliminated_round: Option<u32> = persistent.get(&DataKey::ElimRound(player.clone()));
+        let reveal_choice = !round.active || env.ledger().sequence() > round.round_deadline_ledger;
+        let choice_this_round = if reveal_choice && round.round_number > 0 {
+            persistent.get(&DataKey::Choices(0, round.round_number, player.clone()))
+        } else {
+            None
+        };
+
+        let total_rounds_survived = match status {
+            PlayerStatus::Winner => round.round_number,
+            PlayerStatus::Elim => eliminated_round.unwrap_or(round.round_number).saturating_sub(1),
+            PlayerStatus::Active => {
+                if round.round_number == 0 {
+                    0
+                } else if round.active {
+                    round.round_number - 1
+                } else {
+                    round.round_number
+                }
+            }
+        };
+
+        PlayerSnapshot {
+            player,
+            status,
+            eliminated_round,
+            choice_this_round,
+            total_rounds_survived,
+        }
     }
 
     pub fn get_full_state(env: Env, player: Address) -> Result<FullStateView, ArenaError> {

--- a/contract/arena/src/rwa.rs
+++ b/contract/arena/src/rwa.rs
@@ -25,6 +25,8 @@
 /// - `withdraw(shares: i128) -> i128`                 — burns shares, returns tokens.
 pub struct RwaVaultAdapter;
 
+use soroban_sdk::IntoVal;
+
 impl RwaVaultAdapter {
     /// Call `vault.deposit(token, amount)` and return the shares minted.
     ///
@@ -44,11 +46,7 @@ impl RwaVaultAdapter {
     }
 
     /// Call `vault.withdraw(shares)` and return the tokens received.
-    pub fn withdraw(
-        env: &soroban_sdk::Env,
-        vault: &soroban_sdk::Address,
-        shares: i128,
-    ) -> i128 {
+    pub fn withdraw(env: &soroban_sdk::Env, vault: &soroban_sdk::Address, shares: i128) -> i128 {
         env.invoke_contract(
             vault,
             &soroban_sdk::Symbol::new(env, "withdraw"),

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -79,10 +79,38 @@ pub struct ArenaRef {
     pub host: Address,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreateArenaConfig {
+    pub stake_amount: i128,
+    pub currency: Address,
+    pub round_speed: u32,
+    pub capacity: u32,
+    pub join_deadline: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArenaSummary {
+    pub arena_id: u64,
+    pub contract: Address,
+    pub status: ArenaStatus,
+    pub host: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArenaPage {
+    pub items: Vec<ArenaSummary>,
+    pub next_cursor: Option<u64>,
+    pub has_more: bool,
+}
+
 // ── Capacity limits ───────────────────────────────────────────────────────────
 
 const MAX_POOL_CAPACITY: u32 = 256;
 const MAX_PAGE_SIZE: u32 = 50;
+const MAX_CURSOR_PAGE_SIZE: u32 = 100;
 
 // ── Player-cap (DoS hardening, see issue #495) ────────────────────────────────
 //
@@ -141,6 +169,7 @@ const TOPIC_FEE_QUEUED: Symbol = symbol_short!("FEE_Q");
 const TOPIC_FEE_EXECUTED: Symbol = symbol_short!("FEE_EX");
 const TOPIC_FEE_CANCELLED: Symbol = symbol_short!("FEE_CAN");
 const TOPIC_FEE_CONFIG_UPDATED: Symbol = symbol_short!("CRF_UP");
+const TOPIC_ARENA_CREATED: Symbol = symbol_short!("ARNA_CRE");
 
 /// Event payload version. Include in every event data tuple so consumers
 /// can detect schema changes without re-deploying indexers.
@@ -834,6 +863,14 @@ impl FactoryContract {
         env.storage()
             .persistent()
             .set(&DataKey::Pool(pool_id), &metadata);
+        env.storage().persistent().set(
+            &DataKey::ArenaRef(pool_id as u64),
+            &ArenaRef {
+                contract: arena_address.clone(),
+                status: ArenaStatus::Pending,
+                host: caller.clone(),
+            },
+        );
 
         // Increment the pool counter.
         env.storage()
@@ -866,6 +903,47 @@ impl FactoryContract {
         );
 
         Ok(arena_address)
+    }
+
+    pub fn create_arena(
+        env: Env,
+        host: Address,
+        config: CreateArenaConfig,
+        name: String,
+        description: Option<String>,
+    ) -> Result<(u64, Address), Error> {
+        let arena_address = Self::create_pool(
+            env.clone(),
+            host.clone(),
+            config.stake_amount,
+            config.currency.clone(),
+            config.round_speed,
+            config.capacity,
+            config.join_deadline,
+        )?;
+
+        let arena_id = env
+            .storage()
+            .instance()
+            .get::<_, u32>(&POOL_COUNT_KEY)
+            .unwrap_or(0u32)
+            .saturating_sub(1) as u64;
+
+        Self::set_arena_metadata(
+            env.clone(),
+            arena_address.clone(),
+            arena_id,
+            name,
+            description,
+            host.clone(),
+        );
+
+        env.events().publish(
+            (TOPIC_ARENA_CREATED,),
+            (EVENT_VERSION, arena_id, host, arena_address.clone(), config),
+        );
+
+        Ok((arena_id, arena_address))
     }
 
     /// Set human-readable metadata on a deployed arena contract.
@@ -1275,6 +1353,23 @@ impl FactoryContract {
         results
     }
 
+    pub fn list_arenas(env: Env, cursor: Option<u64>, limit: u32) -> ArenaPage {
+        list_arenas_filtered(&env, cursor, limit, false, None)
+    }
+
+    pub fn list_active_arenas(env: Env, cursor: Option<u64>, limit: u32) -> ArenaPage {
+        list_arenas_filtered(&env, cursor, limit, true, None)
+    }
+
+    pub fn list_arenas_by_host(
+        env: Env,
+        host: Address,
+        cursor: Option<u64>,
+        limit: u32,
+    ) -> ArenaPage {
+        list_arenas_filtered(&env, cursor, limit, false, Some(host))
+    }
+
     // ── Emergency pause ──────────────────────────────────────────────────────
 
     /// Pause the contract, disabling all write operations. Admin-only.
@@ -1359,7 +1454,8 @@ impl FactoryContract {
         }
         env.storage().instance().remove(&PENDING_ADMIN_KEY);
         env.storage().instance().remove(&ADMIN_EXPIRY_KEY);
-        env.events().publish((TOPIC_ADMIN_CANCELLED,), (EVENT_VERSION,));
+        env.events()
+            .publish((TOPIC_ADMIN_CANCELLED,), (EVENT_VERSION,));
         Ok(())
     }
 
@@ -1390,6 +1486,82 @@ fn require_not_paused(env: &Env) -> Result<(), Error> {
         return Err(Error::Paused);
     }
     Ok(())
+}
+
+fn list_arenas_filtered(
+    env: &Env,
+    cursor: Option<u64>,
+    limit: u32,
+    only_active: bool,
+    host_filter: Option<Address>,
+) -> ArenaPage {
+    let start_id = cursor.map(|id| id.saturating_add(1)).unwrap_or(0u64);
+    let limit = limit.min(MAX_CURSOR_PAGE_SIZE);
+    let pool_count = env
+        .storage()
+        .instance()
+        .get(&POOL_COUNT_KEY)
+        .unwrap_or(0u32) as u64;
+
+    let mut items = Vec::new(env);
+    let mut scanned = start_id;
+    let mut last_included: Option<u64> = None;
+
+    while scanned < pool_count && items.len() < limit {
+        if let Some(summary) = load_arena_summary(env, scanned) {
+            if matches_arena_filter(&summary, only_active, host_filter.as_ref()) {
+                items.push_back(summary);
+                last_included = Some(scanned);
+            }
+        }
+        scanned = scanned.saturating_add(1);
+    }
+
+    let mut has_more = false;
+    let mut probe = last_included
+        .map(|id| id.saturating_add(1))
+        .unwrap_or(start_id);
+    while probe < pool_count {
+        if let Some(summary) = load_arena_summary(env, probe) {
+            if matches_arena_filter(&summary, only_active, host_filter.as_ref()) {
+                has_more = true;
+                break;
+            }
+        }
+        probe = probe.saturating_add(1);
+    }
+
+    ArenaPage {
+        items,
+        next_cursor: if has_more { last_included } else { None },
+        has_more,
+    }
+}
+
+fn load_arena_summary(env: &Env, arena_id: u64) -> Option<ArenaSummary> {
+    let arena_ref: Option<ArenaRef> = env.storage().persistent().get(&DataKey::ArenaRef(arena_id));
+    arena_ref.map(|entry| ArenaSummary {
+        arena_id,
+        contract: entry.contract,
+        status: entry.status,
+        host: entry.host,
+    })
+}
+
+fn matches_arena_filter(
+    summary: &ArenaSummary,
+    only_active: bool,
+    host_filter: Option<&Address>,
+) -> bool {
+    if only_active && summary.status != ArenaStatus::Active {
+        return false;
+    }
+    if let Some(host) = host_filter {
+        if summary.host != *host {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add `player_join` entrypoint and enforce pending-state join flow with SAC transfer-backed join path
- add `PlayerSnapshot`/`get_player_state` for per-player status queries and round-choice privacy after close
- add factory `create_arena` wrapper, registry persistence, and cursor-based listing APIs (`list_arenas`, `list_active_arenas`, `list_arenas_by_host`)

## Notes
- `cargo check -p factory` passes.
- `cargo check -p arena` currently fails on this codebase due a pre-existing `#[contracterror]` macro `LengthExceedsMax` issue on `upstream/main`.

Closes #430
Closes #438
Closes #445
Closes #446
