### PR TITLE
Refactor upgrade flow and add factory coverage

### DIFF
--- a/contract/DATA_MODEL.md
+++ b/contract/DATA_MODEL.md
@@ -1,16 +1,17 @@
 # Soroban Contract Data Model
 
-This document describes the current on-chain data model for the Soroban workspace in `contract/`.
+This document describes the storage layout and TTL policy for the contracts in
+`contract/`.
 
-It is intended to make storage behavior explicit for:
-- contract debugging
-- off-chain indexer development
-- future schema migrations
-- contributor onboarding
+It is intended to answer two questions quickly:
+
+1. Which keys does each contract persist on-chain?
+2. How long do those keys stay durable without operator intervention?
 
 ## Scope
 
 Contracts in this workspace:
+
 - `arena`
 - `factory`
 - `payout`
@@ -18,231 +19,170 @@ Contracts in this workspace:
 
 ## Workspace Summary
 
-| Contract | Uses storage? | Storage key schema | TTL policy |
+| Contract | Storage model | Persistent TTL policy | Instance TTL policy |
 | --- | --- | --- | --- |
-| `arena` | Yes | `DataKey` enum (persistent) + symbol keys (instance) | Explicit bump on every write |
-| `factory` | Yes | Symbol keys (instance) | Instance-managed |
-| `payout` | No | None | None |
-| `staking` | No | None | None |
+| `arena` | Persistent `DataKey` entries plus symbol-based instance config | Explicitly bumped on every persistent write to a 31-day target | Host-managed instance TTL; no manual bump |
+| `factory` | Persistent `DataKey` records plus symbol-based instance config | No explicit bump; entries rely on Soroban's normal persistent TTL lifecycle | Host-managed instance TTL; no manual bump |
+| `payout` | Mixed persistent receipt data plus instance config and idempotency guards | `Payout(...)` and `SplitPayout(...)` are explicitly bumped; `PayoutHistory(...)` and `ArenaPayout(...)` are not | `execute_payout` and `distribute_split_payout` extend instance TTL to the same 31-day target |
+| `staking` | Persistent per-staker/per-host records plus symbol-based instance config | No explicit bump; entries rely on Soroban's normal persistent TTL lifecycle | Host-managed instance TTL; no manual bump |
 
-## Storage Key Inventory
+## Arena
 
-### Arena Contract
+Primary source: `contract/arena/src/lib.rs`
 
-File: `contract/arena/src/lib.rs`
+### Storage layout
 
-#### Persistent storage (`env.storage().persistent()`)
+Persistent keys:
 
-| `DataKey` variant | Value type | Description |
-| --- | --- | --- |
-| `DataKey::Config` | `ArenaConfig` | Round speed configuration; written once on `init` |
-| `DataKey::Round` | `RoundState` | Active round state (number, ledgers, submission count, flags) |
-| `DataKey::Submission(round_number, player)` | `Choice` | A player's Heads/Tails choice for a given round (bounded per round — see `contract/BOUNDS.md`) |
-| `DataKey::Survivor(player)` | `()` | Marker set when a player successfully joins; used to verify eligibility in `claim` |
-| `DataKey::Eliminated(player)` | `bool` | Marker set when a player is eliminated by `resolve_round`; used by `submit_choice` to return `PlayerEliminated` instead of `NotASurvivor` |
-| `DataKey::PrizeClaimed(winner)` | `i128` | Records the prize amount claimed by the winner; prevents double-claim |
+- `Config`: arena configuration, including round speed, stake amount, join deadline, and yield-share settings
+- `Round`: current round state
+- `Submission(round, player)`: player choice for a round
+- `Survivor(player)`: membership marker for joined players
+- `Eliminated(player)`: elimination marker
+- `PrizeClaimed(winner)`: prize-claim guard
+- `Metadata(arena_id)`, `Refunded(player)`, and other game-state entries in the same `DataKey` enum
 
-#### Instance storage (`env.storage().instance()`)
+Instance keys:
 
-| Symbol key | Value type | Description |
-| --- | --- | --- |
-| `ADMIN` | `Address` | Contract admin; set once via `initialize` |
-| `P_HASH` | `BytesN<32>` | WASM hash pending upgrade via 48-hour timelock |
-| `P_AFTER` | `u64` | Earliest timestamp at which `execute_upgrade` may be called |
-| `TOKEN` | `Address` | SAC token contract used for stake deposits and prize payouts; set via `set_token` |
-| `S_COUNT` | `u32` | Running count of survivors registered via `join`; incremented on each successful join |
-| `PRIZE` | `i128` | Accumulated prize pool; incremented by each player's stake on `join`, zeroed on `claim` |
-| `G_FIN` | `bool` | Permanently `true` after a successful `claim`; blocks any further claim attempts |
+- `ADMIN`, `TOKEN`, `CAPACITY`, `POOL`, `YIELD`, `WY_BPS`, `S_COUNT`
+- `P_HASH`, `P_AFTER` for upgrade timelock
+- `P_ADMIN`, `A_EXP` for admin transfer
+- `PAUSED`, `STATE`, `WINNER`, `FACTORY`, `CREATOR`, vault-related keys
 
-### Factory Contract
+### TTL policy
 
-File: `contract/factory/src/lib.rs`
-
-Instance storage only:
-
-| Symbol key | Value type | Description |
-| --- | --- | --- |
-| `ADMIN` | `Address` | Contract admin |
-| `P_HASH` | `BytesN<32>` | WASM hash pending upgrade |
-| `P_AFTER` | `u64` | Upgrade timelock timestamp |
-
-### Payout and Staking Contracts
-
-No custom Soroban storage keys are currently defined or used.
-
-## Access Pattern Matrix
-
-### Arena contract
-
-| Function | Keys read | Keys written | TTL bumped |
+| Storage class | Keys | Explicit bump? | Policy |
 | --- | --- | --- | --- |
-| `init` | — | `Config`, `Round` | `Config`, `Round` |
-| `start_round` | `Config`, `Round` | `Round` | `Round` |
-| `submit_choice` | `Round`, `Submission(n, player)` | `Submission(n, player)`, `Round` | `Submission(n, player)`, `Round` |
-| `timeout_round` | `Round` | `Round` | `Round` |
-| `resolve_round` | `Round`, `HeadsSubmitters(n)`, `TailsSubmitters(n)`, `Survivor(player)` | `Round`, remove `Survivor(player)`, write `Eliminated(player)`, update `S_COUNT` (instance) | `Round`, `Eliminated(player)` |
-| `get_config` | `Config` | — | — |
-| `get_round` | `Round` | — | — |
-| `get_choice` | `Submission(n, player)` | — | — |
-| `join` | `TOKEN`, `CAPACITY`, `S_COUNT`, `PRIZE` (instance), `Survivor(player)` | `Survivor(player)`, `S_COUNT`, `PRIZE` (instance) | `Survivor(player)` |
-| `set_token` ¹ | `ADMIN` (instance) | `TOKEN` (instance) | — |
-| `survivor_count` | `S_COUNT` (instance) | — | — |
-| `claim` | `G_FIN`, `S_COUNT`, `Survivor(winner)`, `PrizeClaimed(winner)`, `PRIZE`, `TOKEN` | `PrizeClaimed(winner)`, `PRIZE`, `G_FIN` (instance) | `PrizeClaimed(winner)` |
-| `initialize` | `ADMIN` (instance) | `ADMIN` (instance) | — |
-| `propose_upgrade` ¹ | `ADMIN` (instance) | `P_HASH`, `P_AFTER` (instance) | — |
-| `execute_upgrade` ¹ | `ADMIN`, `P_AFTER`, `P_HASH` (instance) | removes `P_HASH`, `P_AFTER` (instance) | — |
-| `cancel_upgrade` ¹ | `ADMIN`, `P_HASH` (instance) | removes `P_HASH`, `P_AFTER` (instance) | — |
-| `set_capacity` | `ADMIN` (instance) | `CAPACITY` (instance) | — |
-| `get_arena_state` | `S_COUNT`, `CAPACITY` (instance), `Round` | — | — |
-| `get_user_state` | `Survivor(player)`, `Winner(player)` | — | — |
-
-¹ Exempt from the global pause check — see [Emergency Pause Policy](#emergency-pause-policy) below.
-
-## View Functions
-
-These read-only functions expose aggregated contract state for frontend clients and indexers. They require no authorization and do not modify state.
-
-### `get_user_state(player: Address) → Result<UserStateView, ArenaError>`
-
-Returns a snapshot of a single player's participation status.
-
-**Return type: `UserStateView`**
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `is_survivor` | `bool` | `true` if the player has a `Survivor` entry (has joined the arena) |
-| `has_submitted` | `bool` | `true` if the player has submitted a choice for the current round |
-| `choice` | `Choice` | The player's `Heads`/`Tails` submission (only meaningful when `has_submitted` is `true`) |
-| `has_claimed` | `bool` | `true` if the player has already claimed their prize via `claim()` |
-
-**Errors**: `ArenaError::NotInitialized` if `init` has not been called.
-
-### `get_full_state() → Result<FullStateView, ArenaError>`
-
-Returns a combined snapshot of the entire contract state in a single call, reducing the number of RPC round-trips needed by the frontend.
-
-**Return type: `FullStateView`**
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `config` | `ArenaConfig` | Current round speed configuration (see `ArenaConfig`) |
-| `round` | `RoundState` | Current round state (see `RoundState`) |
-| `is_paused` | `bool` | Whether the contract is currently paused |
-
-**Errors**: `ArenaError::NotInitialized` if `init` has not been called.
-
-## TTL Policy Baseline
-
-All **persistent** storage entries in the arena contract are explicitly extended on
-every write. The policy constants are defined in `contract/arena/src/lib.rs`:
-
-| Constant | Value (ledgers) | Approximate wall-clock duration |
-| --- | --- | --- |
-| `GAME_TTL_THRESHOLD` | 100,000 | ~5.8 days (at 5 s/ledger) |
-| `GAME_TTL_EXTEND_TO` | 535,680 | ~31 days (at 5 s/ledger) |
-
-**Rule**: A `bump(env, key)` helper calls `storage().persistent().extend_ttl(key,
-GAME_TTL_THRESHOLD, GAME_TTL_EXTEND_TO)` immediately after every
-`storage().persistent().set()`. This ensures the TTL is extended to at least
-`GAME_TTL_EXTEND_TO` ledgers from the current ledger whenever it would fall below
-`GAME_TTL_THRESHOLD`, covering the maximum possible game duration.
-
-**Instance storage** (admin key, upgrade proposal keys) relies on the automatic
-instance TTL managed by the Soroban host and is not explicitly bumped by game logic.
-
-**Factory/payout/staking** contracts do not use persistent storage for game state.
-
-## ER-Style State Diagram
-
-```
-ArenaConfig (1)
-    │ round_speed_in_ledgers
-    │
-    └──────────────────────────────────────────────────┐
-                                                       │ governs deadline
-RoundState (1)                                         │
-    │ round_number                                     │
-    │ round_start_ledger ──────────────────────────────┘
-    │ round_deadline_ledger
-    │ active
-    │ timed_out
-    │ total_submissions
-    │
-    └─── has many ───► Submission(round_number, player_address)
-                           │ Choice { Heads | Tails }
-```
-
-Round lifecycle state machine:
-
-```
-[not initialised]
-    │ init()
-    ▼
-[Config set, Round { active: false }]
-    │ start_round()
-    ▼
-[Round { active: true }]
-    │ submit_choice()  (multiple callers, within deadline)
-    │ timeout_round()  (any caller, after deadline)
-    ▼
-[Round { active: false, timed_out: true }]
-    │ start_round()
-    ▼
-[Round { active: true, round_number + 1 }] ...
-```
-
-## Emergency Pause Policy
-
-### Overview
-
-The arena contract exposes a global pause mechanism (`pause` / `unpause`, admin-only).
-When paused, all state-mutating game functions reject calls with `ArenaError::Paused`.
-
-**However, governance/upgrade functions and admin-only recovery configuration are explicitly exempt from the pause check.**
-
-### Exempt functions
-
-| Function | Pause exempt? | Reason |
-| --- | --- | --- |
-| `propose_upgrade` | **Yes** | Admin must be able to queue a recovery upgrade at any time |
-| `execute_upgrade` | **Yes** | Admin must be able to deploy the recovery upgrade after the timelock |
-| `cancel_upgrade` | **Yes** | Admin must be able to retract an incorrect proposal before correcting it |
-| `set_token` | **Yes** | Admin must be able to rotate a compromised token address while gameplay is paused |
-| `pause` | **Yes** | Admin must always be able to pause |
-| `unpause` | **Yes** | Admin must always be able to unpause |
-
-### Non-exempt functions (blocked when paused)
-
-| Function | Blocked when paused? |
-| --- | --- |
-| `start_round` | Yes |
-| `submit_choice` | Yes |
-| `timeout_round` | Yes |
-| `join` | Yes |
-| `claim` | Yes |
+| Persistent | All arena `DataKey` entries written through the game flow | Yes | `bump(env, key)` calls `persistent().extend_ttl(key, 100_000, 535_680)` after every persistent write |
+| Instance | Admin/config/governance symbols | No | Relies on Soroban instance TTL management |
 
 ### Rationale
 
-A global pause is an emergency safety measure (e.g. to halt activity during a
-critical bug discovery). If the pause also blocked upgrade functions, a paused
-contract could become permanently locked with no recovery path. By keeping
-governance functions exempt, the admin retains full ability to:
+Arena state can remain live for days while rounds advance or while a winner delays
+claiming. The contract therefore actively extends persistent TTL on write so the
+game state stays durable without requiring an operator to manually restore it.
 
-1. Propose a corrective WASM upgrade while the contract is paused.
-2. Wait for the 48-hour timelock to elapse.
-3. Execute the upgrade and restore normal operation.
-4. Unpause.
+## Factory
 
-### Invariant
+Primary source: `contract/factory/src/lib.rs`
 
-> `propose_upgrade`, `execute_upgrade`, `cancel_upgrade`, and `set_token` MUST
-> NOT call `require_not_paused`. Any future addition of new governance or
-> admin-only recovery functions should follow the same exemption rule and update
-> this table.
+### Storage layout
 
-## Historical baseline note
+Persistent keys:
 
-Prior to the implementation of game state storage and TTL management, the accurate
-storage model for this workspace was:
+- `SupportedToken(address)`: allowed pool currencies
+- `Pool(pool_id)`: immutable arena metadata snapshot
+- `ArenaRef(arena_id)`: address, status, and host for cursor-based discovery
+- `ArenaWhitelist(arena_id, address)`: allowlist entries for private arenas
 
-> No custom Soroban storage keys are currently defined or used.
+Instance keys:
+
+- `ADMIN`, `P_ADMIN`, `A_EXP`
+- `P_HASH`, `P_AFTER` for upgrade timelock
+- `MIN_STK`, `AR_WASM`, `P_CNT`, `S_VER`, `PAUSED`
+- `TOK_CNT`, `MAX_PLR`, `STAKING`, `HST_MIN`
+- `FEE_BPS`, `P_FEE`, `F_AFTER`
+- `CR_FEE`, `CR_TOK`, `CR_ACC`, `WIN_ACC`
+
+### TTL policy
+
+| Storage class | Keys | Explicit bump? | Policy |
+| --- | --- | --- | --- |
+| Persistent | `SupportedToken`, `Pool`, `ArenaRef`, `ArenaWhitelist` | No | All entries rely on Soroban's default persistent TTL behavior |
+| Instance | Governance/config counters and fee settings | No | Relies on Soroban instance TTL management |
+
+### Rationale
+
+Factory state is mostly registry/config data rather than rapidly mutating
+round-by-round state. Operators should treat factory persistent entries as
+durable only while their Soroban TTL remains active, because the contract does
+not currently refresh those keys on writes or reads.
+
+## Payout
+
+Primary source: `contract/payout/src/lib.rs`
+
+### Storage layout
+
+Persistent keys:
+
+- `Payout(ctx, pool_id, round_id, winner)`: idempotent payout receipts
+- `SplitPayout(arena_id, winner)`: per-winner split payout receipts
+- `PayoutHistory(index)`: append-only payout history
+- `ArenaPayout(arena_id)`: latest payout receipt keyed by arena
+
+Instance keys:
+
+- `ADMIN`, `P_ADMIN`, `A_EXP`, `TREAS`, `FACTORY`, `PAUSED`
+- `P_HASH`, `P_AFTER` for upgrade timelock
+- `P_COUNT`: payout-history cursor
+- `CurrencyToken(symbol)`: symbol-to-token-address registry
+- `PrizePayout(game_id)`, `SplitPayoutBatch(arena_id)`: idempotency guards
+
+### TTL policy
+
+| Storage class | Keys | Explicit bump? | Policy |
+| --- | --- | --- | --- |
+| Persistent | `Payout(...)`, `SplitPayout(...)` | Yes | Extended with `persistent().extend_ttl(key, 100_000, 535_680)` when written |
+| Persistent | `PayoutHistory(...)`, `ArenaPayout(...)` | No | Written without a follow-up TTL extension |
+| Instance | Whole contract instance during payout execution paths | Yes, selectively | `execute_payout` and `distribute_split_payout` call `instance().extend_ttl(100_000, 535_680)` |
+| Instance | Governance/config/idempotency keys outside those flows | No direct per-key bump | Relies on the contract instance still being alive |
+
+### Rationale
+
+Payout keeps the receipt families that are queried most often alive explicitly,
+but its history index and arena lookup records are only as durable as their base
+persistent TTL. If long-term payout history matters operationally, index it
+off-chain instead of assuming the on-chain history keys will live forever.
+
+## Staking
+
+Primary source: `contract/staking/src/lib.rs`
+
+### Storage layout
+
+Persistent keys:
+
+- `Stake(address)` and `Position(address)`: staker balances and share positions
+- `HostLock(host, arena_id)` and `HostLockedTotal(host)`: host collateral locks
+- `RewardDebt(address)`, `PendingRewards(address)`, `StakedAt(address)`
+- `TotalClaimedRewards(address)`
+
+Instance keys:
+
+- `ADMIN`, `P_ADMIN`, `A_EXP`, `PAUSED`
+- `TOKEN`, `FACTRY`, `TSTAKE`, `TSHARES`
+- `P_HASH`, `P_AFTER` for upgrade timelock
+- `LOCK_SEC`, `MIN_STK`, `MAX_STK`
+- `RWD_EN`, `RWD_PSH`, `RWD_POOL`, `RWD_UNA`
+
+### TTL policy
+
+| Storage class | Keys | Explicit bump? | Policy |
+| --- | --- | --- | --- |
+| Persistent | All staking `DataKey` entries | No | Relies on Soroban's default persistent TTL behavior |
+| Instance | Config, totals, reward settings, governance state | No | Relies on Soroban instance TTL management |
+
+### Rationale
+
+Staking stores long-lived balances and reward accounting, but today it does not
+refresh TTL explicitly. Operators should plan around Soroban TTL restoration for
+staking state if positions are expected to remain untouched for long periods.
+
+## Shared Upgrade Timelock Flow
+
+The four contracts now share the same reusable helper module in
+`contract/shared/upgrade.rs`.
+
+Common flow:
+
+1. `propose_upgrade(new_hash)` stores `P_HASH` and `P_AFTER`, then emits
+   `UP_PROP`.
+2. `execute_upgrade(expected_hash)` checks the stored proposal, clears it,
+   emits `UP_EXEC`, and then upgrades the current contract WASM.
+3. `cancel_upgrade()` clears the pending proposal and emits `UP_CANC`.
+4. `pending_upgrade()` returns `(hash, execute_after)` only when both keys are
+   present.
+
+Factory keeps its additional malformed-state guard; arena keeps its stricter
+"strictly after" execution boundary to preserve existing behavior.

--- a/contract/README.md
+++ b/contract/README.md
@@ -1,5 +1,35 @@
 # Contract Workspace
 
+This directory contains the Soroban contract workspace for:
+
+- `arena`
+- `factory`
+- `payout`
+- `staking`
+
+## TTL Policy Overview
+
+Detailed storage and TTL documentation lives in `DATA_MODEL.md`. The short
+version is:
+
+| Contract | Persistent TTL approach | Instance TTL approach |
+| --- | --- | --- |
+| `arena` | Explicit bump on every persistent write | Host-managed |
+| `factory` | No explicit bump | Host-managed |
+| `payout` | Mixed: payout receipt families are bumped, history keys are not | Selective instance bump during payout execution paths |
+| `staking` | No explicit bump | Host-managed |
+
+Operationally, this means `arena` is the only contract that treats on-chain game
+state as actively refreshed by default. `factory`, `payout`, and `staking`
+should still be indexed and monitored with Soroban TTL limits in mind.
+
+## Shared Upgrade Timelock Helper
+
+The upgrade proposal / execute / cancel flow is centralized in
+`shared/upgrade.rs` and reused by all four contracts. Each contract still owns
+its own auth checks and error mapping, but event payloads and storage-key
+handling now follow one shared path.
+
 ## ABI Snapshots
 
 ABI snapshots live at:
@@ -16,6 +46,9 @@ cd contract
 ./scripts/generate_abi_snapshots.sh
 ```
 
-CI runs the same script with `--check` after building the WASM artifacts. If any snapshot differs from the committed version, the check fails and the ABI change must be reviewed and committed intentionally.
+CI runs the same script with `--check` after building the WASM artifacts. If any
+snapshot differs from the committed version, the check fails and the ABI change
+must be reviewed and committed intentionally.
 
-The script uses `stellar contract inspect --wasm ... --output xdr-base64-array` when `stellar` is installed, or falls back to `soroban contract inspect`.
+The script uses `stellar contract inspect --wasm ... --output xdr-base64-array`
+when `stellar` is installed, or falls back to `soroban contract inspect`.

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -4,6 +4,13 @@ use soroban_sdk::{IntoVal,
     Address, Bytes, BytesN, Env, String, Symbol, Vec, contract, contracterror, contractimpl,
     contracttype, panic_with_error, symbol_short, token,
 };
+#[path = "../../shared/upgrade.rs"]
+mod upgrade_utils;
+use upgrade_utils::{
+    ExecuteTimePolicy, UpgradeErrors, UpgradeKeys, UpgradeTopics, cancel_upgrade as cancel_upgrade_flow,
+    execute_upgrade as execute_upgrade_flow, pending_upgrade as pending_upgrade_flow,
+    propose_upgrade as propose_upgrade_flow,
+};
 
 mod bounds;
 #[cfg(test)]
@@ -1522,21 +1529,22 @@ impl ArenaContract {
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), ArenaError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
-        if env.storage().instance().has(&PENDING_HASH_KEY) {
-            return Err(ArenaError::UpgradeAlreadyPending);
-        }
-        let execute_after = env.ledger().timestamp() + TIMELOCK_PERIOD;
-        env.storage()
-            .instance()
-            .set(&PENDING_HASH_KEY, &new_wasm_hash);
-        env.storage()
-            .instance()
-            .set(&EXECUTE_AFTER_KEY, &execute_after);
-        env.events().publish(
-            (TOPIC_UPGRADE_PROPOSED,),
-            (EVENT_VERSION, new_wasm_hash.clone(), execute_after),
-        );
-        Ok(())
+        propose_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            TIMELOCK_PERIOD,
+            &new_wasm_hash,
+            ArenaError::UpgradeAlreadyPending,
+        )
     }
 
     pub fn execute_upgrade(env: Env, expected_hash: BytesN<32>) -> Result<(), ArenaError> {
@@ -1546,28 +1554,27 @@ impl ArenaContract {
             .get(&ADMIN_KEY)
             .ok_or(ArenaError::NotInitialized)?;
         admin.require_auth();
-        let execute_after: u64 = env
-            .storage()
-            .instance()
-            .get(&EXECUTE_AFTER_KEY)
-            .ok_or(ArenaError::NoPendingUpgrade)?;
-        if env.ledger().timestamp() <= execute_after {
-            return Err(ArenaError::TimelockNotExpired);
-        }
-        let stored_hash: BytesN<32> = env
-            .storage()
-            .instance()
-            .get(&PENDING_HASH_KEY)
-            .ok_or(ArenaError::NoPendingUpgrade)?;
-        if stored_hash != expected_hash {
-            return Err(ArenaError::HashMismatch);
-        }
-        env.storage().instance().remove(&PENDING_HASH_KEY);
-        env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events().publish(
-            (TOPIC_UPGRADE_EXECUTED,),
-            (EVENT_VERSION, stored_hash.clone()),
-        );
+        let stored_hash = execute_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            &expected_hash,
+            UpgradeErrors {
+                no_pending: ArenaError::NoPendingUpgrade,
+                timelock_not_expired: ArenaError::TimelockNotExpired,
+                hash_mismatch: ArenaError::HashMismatch,
+                malformed_state: None,
+            },
+            ExecuteTimePolicy::StrictlyAfter,
+        )?;
         env.deployer().update_current_contract_wasm(stored_hash);
         Ok(())
     }
@@ -1575,22 +1582,30 @@ impl ArenaContract {
     pub fn cancel_upgrade(env: Env) -> Result<(), ArenaError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
-        if !env.storage().instance().has(&PENDING_HASH_KEY) {
-            return Err(ArenaError::NoPendingUpgrade);
-        }
-        env.storage().instance().remove(&PENDING_HASH_KEY);
-        env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events().publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
-        Ok(())
+        cancel_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            ArenaError::NoPendingUpgrade,
+        )
     }
 
     pub fn pending_upgrade(env: Env) -> Option<(BytesN<32>, u64)> {
-        let hash: Option<BytesN<32>> = env.storage().instance().get(&PENDING_HASH_KEY);
-        let after: Option<u64> = env.storage().instance().get(&EXECUTE_AFTER_KEY);
-        match (hash, after) {
-            (Some(h), Some(a)) => Some((h, a)),
-            _ => None,
-        }
+        pending_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+        )
     }
 
     pub fn state(env: Env) -> ArenaState {

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -4,6 +4,13 @@ use soroban_sdk::{
     Address, BytesN, Env, IntoVal, String, Symbol, Vec, contract, contracterror, contractimpl,
     contracttype, symbol_short, token, xdr::ToXdr,
 };
+#[path = "../../shared/upgrade.rs"]
+mod upgrade_utils;
+use upgrade_utils::{
+    ExecuteTimePolicy, UpgradeErrors, UpgradeKeys, UpgradeTopics, cancel_upgrade as cancel_upgrade_flow,
+    execute_upgrade as execute_upgrade_flow, pending_upgrade as pending_upgrade_flow,
+    propose_upgrade as propose_upgrade_flow,
+};
 
 #[cfg(test)]
 use arena::ArenaContract; 
@@ -1289,24 +1296,22 @@ impl FactoryContract {
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
         let admin = require_admin(&env)?;
         admin.require_auth();
-
-        if env.storage().instance().has(&PENDING_HASH_KEY) {
-            return Err(Error::UpgradeAlreadyPending);
-        }
-
-        let execute_after: u64 = env.ledger().timestamp() + TIMELOCK_PERIOD;
-        env.storage()
-            .instance()
-            .set(&PENDING_HASH_KEY, &new_wasm_hash);
-        env.storage()
-            .instance()
-            .set(&EXECUTE_AFTER_KEY, &execute_after);
-
-        env.events().publish(
-            (TOPIC_UPGRADE_PROPOSED,),
-            (EVENT_VERSION, new_wasm_hash, execute_after),
-        );
-        Ok(())
+        propose_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            TIMELOCK_PERIOD,
+            &new_wasm_hash,
+            Error::UpgradeAlreadyPending,
+        )
     }
 
     /// Execute a previously proposed upgrade after the 48-hour timelock.
@@ -1327,44 +1332,27 @@ impl FactoryContract {
     pub fn execute_upgrade(env: Env, expected_hash: BytesN<32>) -> Result<(), Error> {
         let admin = require_admin(&env)?;
         admin.require_auth();
-
-        let has_pending_hash = env.storage().instance().has(&PENDING_HASH_KEY);
-        let has_execute_after = env.storage().instance().has(&EXECUTE_AFTER_KEY);
-        match (has_pending_hash, has_execute_after) {
-            (false, false) => return Err(Error::NoPendingUpgrade),
-            (true, false) | (false, true) => return Err(Error::MalformedUpgradeState),
-            (true, true) => {}
-        }
-
-        let execute_after: u64 = env
-            .storage()
-            .instance()
-            .get(&EXECUTE_AFTER_KEY)
-            .ok_or(Error::MalformedUpgradeState)?;
-
-        if env.ledger().timestamp() < execute_after {
-            return Err(Error::TimelockNotExpired);
-        }
-
-        let stored_hash: BytesN<32> = env
-            .storage()
-            .instance()
-            .get(&PENDING_HASH_KEY)
-            .ok_or(Error::MalformedUpgradeState)?;
-
-        if stored_hash != expected_hash {
-            return Err(Error::HashMismatch);
-        }
-
-        // Clear pending state before upgrading.
-        env.storage().instance().remove(&PENDING_HASH_KEY);
-        env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-
-        env.events().publish(
-            (TOPIC_UPGRADE_EXECUTED,),
-            (EVENT_VERSION, stored_hash.clone()),
-        );
-
+        let stored_hash = execute_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            &expected_hash,
+            UpgradeErrors {
+                no_pending: Error::NoPendingUpgrade,
+                timelock_not_expired: Error::TimelockNotExpired,
+                hash_mismatch: Error::HashMismatch,
+                malformed_state: Some(Error::MalformedUpgradeState),
+            },
+            ExecuteTimePolicy::AtOrAfter,
+        )?;
         env.deployer().update_current_contract_wasm(stored_hash);
         Ok(())
     }
@@ -1386,17 +1374,20 @@ impl FactoryContract {
     pub fn cancel_upgrade(env: Env) -> Result<(), Error> {
         let admin = require_admin(&env)?;
         admin.require_auth();
-
-        if !env.storage().instance().has(&PENDING_HASH_KEY) {
-            return Err(Error::NoPendingUpgrade);
-        }
-
-        env.storage().instance().remove(&PENDING_HASH_KEY);
-        env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-
-        env.events()
-            .publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
-        Ok(())
+        cancel_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            Error::NoPendingUpgrade,
+        )
     }
 
     /// Return the pending WASM hash and the earliest execution timestamp,
@@ -1405,12 +1396,13 @@ impl FactoryContract {
     /// # Authorization
     /// None — read-only, open to any caller.
     pub fn pending_upgrade(env: Env) -> Option<(BytesN<32>, u64)> {
-        let hash: Option<BytesN<32>> = env.storage().instance().get(&PENDING_HASH_KEY);
-        let after: Option<u64> = env.storage().instance().get(&EXECUTE_AFTER_KEY);
-        match (hash, after) {
-            (Some(h), Some(a)) => Some((h, a)),
-            _ => None,
-        }
+        pending_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+        )
     }
 
     /// Get metadata for a specific pool.

--- a/contract/factory/src/test.rs
+++ b/contract/factory/src/test.rs
@@ -72,16 +72,32 @@ fn test_double_initialize_returns_already_initialized() {
 
 /// Helper: inject an ArenaRef with a known host into factory storage.
 fn inject_arena_ref(env: &Env, contract_id: &Address, arena_id: u64, host: &Address) {
+    inject_arena_ref_with_status(env, contract_id, arena_id, host, ArenaStatus::Pending);
+}
+
+fn inject_arena_ref_with_status(
+    env: &Env,
+    contract_id: &Address,
+    arena_id: u64,
+    host: &Address,
+    status: ArenaStatus,
+) {
     let fake_contract = Address::generate(env);
     env.as_contract(contract_id, || {
         env.storage().persistent().set(
             &DataKey::ArenaRef(arena_id),
             &ArenaRef {
                 contract: fake_contract,
-                status: ArenaStatus::Pending,
+                status,
                 host: host.clone(),
             },
         );
+    });
+}
+
+fn set_pool_count(env: &Env, contract_id: &Address, pool_count: u32) {
+    env.as_contract(contract_id, || {
+        env.storage().instance().set(&POOL_COUNT_KEY, &pool_count);
     });
 }
 
@@ -552,6 +568,67 @@ fn create_pool_metadata_not_visible_before_full_init() {
 
     assert!(client.get_arena(&0u32).is_none());
     assert_eq!(client.get_arenas(&0u32, &10u32).len(), 0);
+}
+
+#[test]
+fn create_pool_rejects_past_join_deadline() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+
+    let result = client.try_create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &8u32,
+        &env.ledger().timestamp().saturating_sub(1),
+    );
+
+    assert!(result.is_err(), "past join deadlines must be rejected");
+    assert!(client.get_arena(&0u32).is_none());
+}
+
+#[test]
+fn create_pool_rejects_join_deadline_that_is_too_close() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+
+    let result = client.try_create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &8u32,
+        &(env.ledger().timestamp() + 3599),
+    );
+
+    assert!(result.is_err(), "join deadlines under one hour out must be rejected");
+    assert!(client.get_arena(&0u32).is_none());
+}
+
+#[test]
+fn create_pool_accepts_join_deadline_at_factory_boundary() {
+    let (env, admin, client) = setup();
+    client.set_arena_wasm_hash(&dummy_hash(&env));
+    let currency = supported_currency(&env, &client);
+    let join_deadline = env.ledger().timestamp() + 3600;
+
+    let arena_addr = client.create_pool(
+        &admin,
+        &MIN_STAKE,
+        &currency,
+        &10u32,
+        &8u32,
+        &join_deadline,
+    );
+
+    let metadata = client.get_arena(&0u32).expect("metadata must only exist after success");
+    assert_eq!(metadata.pool_id, 0);
+
+    let arena = ArenaContractClient::new(&env, &arena_addr);
+    assert_eq!(arena.get_join_deadline(), join_deadline);
 }
 
 // ── propose_upgrade ───────────────────────────────────────────────────────────
@@ -1067,6 +1144,46 @@ fn test_get_arenas_pagination() {
     let page3 = client.get_arenas(&4u32, &2u32);
     assert_eq!(page3.len(), 1);
     assert_eq!(page3.get(0).unwrap().pool_id, 4);
+}
+
+#[test]
+fn list_arenas_pagination_skips_sparse_entries_stably() {
+    let (env, _admin, client) = setup();
+    let host = Address::generate(&env);
+    set_pool_count(&env, &client.address, 6);
+    inject_arena_ref(&env, &client.address, 0, &host);
+    inject_arena_ref(&env, &client.address, 2, &host);
+    inject_arena_ref(&env, &client.address, 5, &host);
+
+    let page1 = client.list_arenas(&Option::<u64>::None, &2u32);
+    assert_eq!(page1.items.len(), 2);
+    assert_eq!(page1.items.get(0).unwrap().arena_id, 0);
+    assert_eq!(page1.items.get(1).unwrap().arena_id, 2);
+    assert_eq!(page1.next_cursor, Some(2));
+    assert!(page1.has_more);
+
+    let page2 = client.list_arenas(&Some(2u64), &2u32);
+    assert_eq!(page2.items.len(), 1);
+    assert_eq!(page2.items.get(0).unwrap().arena_id, 5);
+    assert_eq!(page2.next_cursor, None);
+    assert!(!page2.has_more);
+}
+
+#[test]
+fn list_arenas_cursor_can_resume_after_missing_id() {
+    let (env, _admin, client) = setup();
+    let host = Address::generate(&env);
+    set_pool_count(&env, &client.address, 8);
+    inject_arena_ref(&env, &client.address, 1, &host);
+    inject_arena_ref_with_status(&env, &client.address, 4, &host, ArenaStatus::Active);
+    inject_arena_ref(&env, &client.address, 7, &host);
+
+    let page = client.list_arenas(&Some(2u64), &2u32);
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.items.get(0).unwrap().arena_id, 4);
+    assert_eq!(page.items.get(1).unwrap().arena_id, 7);
+    assert_eq!(page.next_cursor, None);
+    assert!(!page.has_more);
 }
 
 // ── Schema versioning tests ──────────────────────────────────────────────────

--- a/contract/payout/src/lib.rs
+++ b/contract/payout/src/lib.rs
@@ -4,6 +4,13 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
     Address, BytesN, Env, IntoVal, Symbol, Vec,
 };
+#[path = "../../shared/upgrade.rs"]
+mod upgrade_utils;
+use upgrade_utils::{
+    ExecuteTimePolicy, UpgradeErrors, UpgradeKeys, UpgradeTopics, cancel_upgrade as cancel_upgrade_flow,
+    execute_upgrade as execute_upgrade_flow, pending_upgrade as pending_upgrade_flow,
+    propose_upgrade as propose_upgrade_flow,
+};
 
 const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
 const PENDING_ADMIN_KEY: Symbol = symbol_short!("P_ADMIN");
@@ -575,48 +582,48 @@ impl PayoutContract {
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), PayoutError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
-        if env.storage().instance().has(&PENDING_HASH_KEY) {
-            return Err(PayoutError::UpgradeAlreadyPending);
-        }
-        let execute_after: u64 = env.ledger().timestamp() + TIMELOCK_PERIOD;
-        env.storage()
-            .instance()
-            .set(&PENDING_HASH_KEY, &new_wasm_hash);
-        env.storage()
-            .instance()
-            .set(&EXECUTE_AFTER_KEY, &execute_after);
-        env.events().publish(
-            (TOPIC_UPGRADE_PROPOSED,),
-            (EVENT_VERSION, new_wasm_hash, execute_after),
-        );
-        Ok(())
+        propose_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            TIMELOCK_PERIOD,
+            &new_wasm_hash,
+            PayoutError::UpgradeAlreadyPending,
+        )
     }
 
     pub fn execute_upgrade(env: Env, expected_hash: BytesN<32>) -> Result<(), PayoutError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
-        let execute_after: u64 = env
-            .storage()
-            .instance()
-            .get(&EXECUTE_AFTER_KEY)
-            .ok_or(PayoutError::NoPendingUpgrade)?;
-        if env.ledger().timestamp() < execute_after {
-            return Err(PayoutError::TimelockNotExpired);
-        }
-        let stored_hash: BytesN<32> = env
-            .storage()
-            .instance()
-            .get(&PENDING_HASH_KEY)
-            .ok_or(PayoutError::NoPendingUpgrade)?;
-        if stored_hash != expected_hash {
-            return Err(PayoutError::HashMismatch);
-        }
-        env.storage().instance().remove(&PENDING_HASH_KEY);
-        env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events().publish(
-            (TOPIC_UPGRADE_EXECUTED,),
-            (EVENT_VERSION, stored_hash.clone()),
-        );
+        let stored_hash = execute_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            &expected_hash,
+            UpgradeErrors {
+                no_pending: PayoutError::NoPendingUpgrade,
+                timelock_not_expired: PayoutError::TimelockNotExpired,
+                hash_mismatch: PayoutError::HashMismatch,
+                malformed_state: None,
+            },
+            ExecuteTimePolicy::AtOrAfter,
+        )?;
         env.deployer().update_current_contract_wasm(stored_hash);
         Ok(())
     }
@@ -624,23 +631,30 @@ impl PayoutContract {
     pub fn cancel_upgrade(env: Env) -> Result<(), PayoutError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
-        if !env.storage().instance().has(&PENDING_HASH_KEY) {
-            return Err(PayoutError::NoPendingUpgrade);
-        }
-        env.storage().instance().remove(&PENDING_HASH_KEY);
-        env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events()
-            .publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
-        Ok(())
+        cancel_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            PayoutError::NoPendingUpgrade,
+        )
     }
 
     pub fn pending_upgrade(env: Env) -> Option<(BytesN<32>, u64)> {
-        let hash: Option<BytesN<32>> = env.storage().instance().get(&PENDING_HASH_KEY);
-        let after: Option<u64> = env.storage().instance().get(&EXECUTE_AFTER_KEY);
-        match (hash, after) {
-            (Some(h), Some(a)) => Some((h, a)),
-            _ => None,
-        }
+        pending_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+        )
     }
 
     /// Admin-only recovery endpoint for stranded tokens.

--- a/contract/shared/upgrade.rs
+++ b/contract/shared/upgrade.rs
@@ -1,0 +1,126 @@
+use soroban_sdk::{BytesN, Env, Symbol};
+
+#[derive(Clone, Copy)]
+pub enum ExecuteTimePolicy {
+    AtOrAfter,
+    StrictlyAfter,
+}
+
+#[derive(Clone, Copy)]
+pub struct UpgradeKeys<'a> {
+    pub pending_hash: &'a Symbol,
+    pub execute_after: &'a Symbol,
+}
+
+#[derive(Clone, Copy)]
+pub struct UpgradeTopics<'a> {
+    pub proposed: &'a Symbol,
+    pub executed: &'a Symbol,
+    pub cancelled: &'a Symbol,
+}
+
+#[derive(Clone, Copy)]
+pub struct UpgradeErrors<E> {
+    pub no_pending: E,
+    pub timelock_not_expired: E,
+    pub hash_mismatch: E,
+    pub malformed_state: Option<E>,
+}
+
+pub fn propose_upgrade<E: Copy>(
+    env: &Env,
+    keys: UpgradeKeys<'_>,
+    topics: UpgradeTopics<'_>,
+    event_version: u32,
+    timelock_period: u64,
+    new_wasm_hash: &BytesN<32>,
+    upgrade_already_pending: E,
+) -> Result<(), E> {
+    if env.storage().instance().has(keys.pending_hash) {
+        return Err(upgrade_already_pending);
+    }
+
+    let execute_after = env.ledger().timestamp() + timelock_period;
+    env.storage().instance().set(keys.pending_hash, new_wasm_hash);
+    env.storage().instance().set(keys.execute_after, &execute_after);
+    env.events().publish(
+        (topics.proposed.clone(),),
+        (event_version, new_wasm_hash.clone(), execute_after),
+    );
+    Ok(())
+}
+
+pub fn execute_upgrade<E: Copy>(
+    env: &Env,
+    keys: UpgradeKeys<'_>,
+    topics: UpgradeTopics<'_>,
+    event_version: u32,
+    expected_hash: &BytesN<32>,
+    errors: UpgradeErrors<E>,
+    time_policy: ExecuteTimePolicy,
+) -> Result<BytesN<32>, E> {
+    let has_pending_hash = env.storage().instance().has(keys.pending_hash);
+    let has_execute_after = env.storage().instance().has(keys.execute_after);
+    let missing_state_error = errors.malformed_state.unwrap_or(errors.no_pending);
+    match (has_pending_hash, has_execute_after) {
+        (false, false) => return Err(errors.no_pending),
+        (true, false) | (false, true) => return Err(missing_state_error),
+        (true, true) => {}
+    }
+
+    let execute_after: u64 = env
+        .storage()
+        .instance()
+        .get(keys.execute_after)
+        .ok_or(missing_state_error)?;
+
+    let timelock_not_expired = match time_policy {
+        ExecuteTimePolicy::AtOrAfter => env.ledger().timestamp() < execute_after,
+        ExecuteTimePolicy::StrictlyAfter => env.ledger().timestamp() <= execute_after,
+    };
+    if timelock_not_expired {
+        return Err(errors.timelock_not_expired);
+    }
+
+    let stored_hash: BytesN<32> = env
+        .storage()
+        .instance()
+        .get(keys.pending_hash)
+        .ok_or(missing_state_error)?;
+    if stored_hash != *expected_hash {
+        return Err(errors.hash_mismatch);
+    }
+
+    env.storage().instance().remove(keys.pending_hash);
+    env.storage().instance().remove(keys.execute_after);
+    env.events()
+        .publish((topics.executed.clone(),), (event_version, stored_hash.clone()));
+    Ok(stored_hash)
+}
+
+pub fn cancel_upgrade<E: Copy>(
+    env: &Env,
+    keys: UpgradeKeys<'_>,
+    topics: UpgradeTopics<'_>,
+    event_version: u32,
+    no_pending: E,
+) -> Result<(), E> {
+    if !env.storage().instance().has(keys.pending_hash) {
+        return Err(no_pending);
+    }
+
+    env.storage().instance().remove(keys.pending_hash);
+    env.storage().instance().remove(keys.execute_after);
+    env.events()
+        .publish((topics.cancelled.clone(),), (event_version,));
+    Ok(())
+}
+
+pub fn pending_upgrade(env: &Env, keys: UpgradeKeys<'_>) -> Option<(BytesN<32>, u64)> {
+    let hash: Option<BytesN<32>> = env.storage().instance().get(keys.pending_hash);
+    let after: Option<u64> = env.storage().instance().get(keys.execute_after);
+    match (hash, after) {
+        (Some(hash), Some(after)) => Some((hash, after)),
+        _ => None,
+    }
+}

--- a/contract/staking/src/lib.rs
+++ b/contract/staking/src/lib.rs
@@ -4,6 +4,13 @@ use soroban_sdk::{
     Address, BytesN, Env, Symbol, contract, contracterror, contractimpl, contracttype,
     panic_with_error, symbol_short, token,
 };
+#[path = "../../shared/upgrade.rs"]
+mod upgrade_utils;
+use upgrade_utils::{
+    ExecuteTimePolicy, UpgradeErrors, UpgradeKeys, UpgradeTopics, cancel_upgrade as cancel_upgrade_flow,
+    execute_upgrade as execute_upgrade_flow, pending_upgrade as pending_upgrade_flow,
+    propose_upgrade as propose_upgrade_flow,
+};
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
@@ -780,48 +787,48 @@ impl StakingContract {
     pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), StakingError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
-        if env.storage().instance().has(&PENDING_HASH_KEY) {
-            return Err(StakingError::UpgradeAlreadyPending);
-        }
-        let execute_after: u64 = env.ledger().timestamp() + TIMELOCK_PERIOD;
-        env.storage()
-            .instance()
-            .set(&PENDING_HASH_KEY, &new_wasm_hash);
-        env.storage()
-            .instance()
-            .set(&EXECUTE_AFTER_KEY, &execute_after);
-        env.events().publish(
-            (TOPIC_UPGRADE_PROPOSED,),
-            (EVENT_VERSION, new_wasm_hash, execute_after),
-        );
-        Ok(())
+        propose_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            TIMELOCK_PERIOD,
+            &new_wasm_hash,
+            StakingError::UpgradeAlreadyPending,
+        )
     }
 
     pub fn execute_upgrade(env: Env, expected_hash: BytesN<32>) -> Result<(), StakingError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
-        let execute_after: u64 = env
-            .storage()
-            .instance()
-            .get(&EXECUTE_AFTER_KEY)
-            .ok_or(StakingError::NoPendingUpgrade)?;
-        if env.ledger().timestamp() < execute_after {
-            return Err(StakingError::TimelockNotExpired);
-        }
-        let stored_hash: BytesN<32> = env
-            .storage()
-            .instance()
-            .get(&PENDING_HASH_KEY)
-            .ok_or(StakingError::NoPendingUpgrade)?;
-        if stored_hash != expected_hash {
-            return Err(StakingError::HashMismatch);
-        }
-        env.storage().instance().remove(&PENDING_HASH_KEY);
-        env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events().publish(
-            (TOPIC_UPGRADE_EXECUTED,),
-            (EVENT_VERSION, stored_hash.clone()),
-        );
+        let stored_hash = execute_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            &expected_hash,
+            UpgradeErrors {
+                no_pending: StakingError::NoPendingUpgrade,
+                timelock_not_expired: StakingError::TimelockNotExpired,
+                hash_mismatch: StakingError::HashMismatch,
+                malformed_state: None,
+            },
+            ExecuteTimePolicy::AtOrAfter,
+        )?;
         env.deployer().update_current_contract_wasm(stored_hash);
         Ok(())
     }
@@ -829,23 +836,30 @@ impl StakingContract {
     pub fn cancel_upgrade(env: Env) -> Result<(), StakingError> {
         let admin = Self::admin(env.clone());
         admin.require_auth();
-        if !env.storage().instance().has(&PENDING_HASH_KEY) {
-            return Err(StakingError::NoPendingUpgrade);
-        }
-        env.storage().instance().remove(&PENDING_HASH_KEY);
-        env.storage().instance().remove(&EXECUTE_AFTER_KEY);
-        env.events()
-            .publish((TOPIC_UPGRADE_CANCELLED,), (EVENT_VERSION,));
-        Ok(())
+        cancel_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+            UpgradeTopics {
+                proposed: &TOPIC_UPGRADE_PROPOSED,
+                executed: &TOPIC_UPGRADE_EXECUTED,
+                cancelled: &TOPIC_UPGRADE_CANCELLED,
+            },
+            EVENT_VERSION,
+            StakingError::NoPendingUpgrade,
+        )
     }
 
     pub fn pending_upgrade(env: Env) -> Option<(BytesN<32>, u64)> {
-        let hash: Option<BytesN<32>> = env.storage().instance().get(&PENDING_HASH_KEY);
-        let after: Option<u64> = env.storage().instance().get(&EXECUTE_AFTER_KEY);
-        match (hash, after) {
-            (Some(h), Some(a)) => Some((h, a)),
-            _ => None,
-        }
+        pending_upgrade_flow(
+            &env,
+            UpgradeKeys {
+                pending_hash: &PENDING_HASH_KEY,
+                execute_after: &EXECUTE_AFTER_KEY,
+            },
+        )
     }
 
     // ── Two-step admin transfer ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- document TTL policy for factory, payout, and staking contracts
- add factory tests for sparse `list_arenas` pagination
- add factory tests for invalid and boundary `create_pool` deadlines
- refactor duplicated upgrade timelock flow into one shared helper

Closes #597
Closes #589
Closes #588
Closes #587
