### PR TITLE
fix: avoid duplicate ArenaRef writes during factory arena creation

### DIFF
--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -1053,6 +1053,11 @@ impl FactoryContract {
     /// the arena's admin (typically the pool creator who was set as admin during
     /// `create_pool`).
     ///
+    /// The `ArenaRef` entry is written once by `create_pool`; this function only
+    /// forwards the display metadata to the arena contract and does not touch
+    /// the registry key, keeping the flow idempotent and avoiding redundant
+    /// storage writes.
+    ///
     /// # Arguments
     /// * `arena_address` — address of the deployed arena contract.
     /// * `arena_id`      — application-level identifier stored inside the metadata.
@@ -1078,18 +1083,7 @@ impl FactoryContract {
                 host.into_val(&env),
             ],
         );
-
-        // Store the ArenaRef tracking structure initialized to Pending status.
-        let arena_ref = ArenaRef {
-            contract: arena_address,
-            status: ArenaStatus::Pending,
-            host: host.clone(),
-        };
-        let ref_key = DataKey::ArenaRef(arena_id);
-        env.storage()
-            .persistent()
-            .set(&ref_key, &arena_ref);
-        env.storage().persistent().extend_ttl(&ref_key, REGISTRY_TTL_THRESHOLD, REGISTRY_TTL_EXTEND_TO);
+        // ArenaRef is written once in create_pool; no duplicate write here.
     }
 
     pub fn get_arena_ref(env: Env, arena_id: u64) -> Result<ArenaRef, Error> {


### PR DESCRIPTION
## Fix: Avoid duplicate `ArenaRef` writes during factory arena creation

### Problem

`create_pool()` writes an `ArenaRef` entry to persistent storage after successfully deploying and initialising the arena contract. `create_arena()` then calls `set_arena_metadata()`, which wrote the **same `DataKey::ArenaRef(arena_id)` key a second time** with identical data.

This meant every arena creation via `create_arena()` paid for two persistent storage writes to the same key — wasting Soroban budget and causing unnecessary storage churn.

### Fix

Removed the redundant `ArenaRef` write from `set_arena_metadata()`. `create_pool()` is now the single authoritative source for the `ArenaRef` registry entry. `set_arena_metadata()` only forwards display metadata (name, description) to the arena contract via `set_metadata`, which is its actual responsibility.

### Changes

- `contract/factory/src/lib.rs` — removed duplicate `ArenaRef` persistent set + TTL extension from `set_arena_metadata()`; updated doc comment to reflect the single-write contract


closes #575 