### PR TITLE
security: restrict lock_host_stake to factory/admin caller

### DIFF
--- a/contract/staking/src/lib.rs
+++ b/contract/staking/src/lib.rs
@@ -372,6 +372,10 @@ impl StakingContract {
     }
 
     /// Lock host stake for an arena so host cannot withdraw below reserved amount.
+    ///
+    /// # Authorization
+    /// `caller` must be either the contract admin or the configured factory address.
+    /// Any other caller is rejected with [`StakingError::Unauthorized`].
     pub fn lock_host_stake(
         env: Env,
         caller: Address,

--- a/contract/staking/src/test.rs
+++ b/contract/staking/src/test.rs
@@ -663,3 +663,48 @@ fn test_unauthorized_host_stake_methods() {
         Err(Ok(StakingError::Unauthorized))
     );
 }
+
+/// Verify that the configured factory address is authorized to call lock_host_stake.
+#[test]
+fn test_factory_caller_can_lock_host_stake() {
+    let (env, admin, staker, client, _token) = setup();
+    let factory = Address::generate(&env);
+
+    // Stake some tokens so there is balance to lock.
+    client.stake(&staker, &500i128);
+
+    // Register factory address.
+    client.set_factory(&factory);
+
+    // Factory should be able to lock host stake.
+    client.lock_host_stake(&factory, &staker, &1u64, &200i128);
+
+    // Available stake should be reduced by the locked amount.
+    assert_eq!(client.get_host_stake(&staker), 300i128);
+
+    // Factory should also be able to release the lock.
+    client.release_host_stake(&factory, &staker, &1u64);
+    assert_eq!(client.get_host_stake(&staker), 500i128);
+
+    // Sanity: admin can also lock/release.
+    client.lock_host_stake(&admin, &staker, &2u64, &100i128);
+    assert_eq!(client.get_host_stake(&staker), 400i128);
+    client.release_host_stake(&admin, &staker, &2u64);
+    assert_eq!(client.get_host_stake(&staker), 500i128);
+}
+
+/// Verify that an arbitrary caller cannot lock host stake even after a factory is set.
+#[test]
+fn test_non_factory_caller_rejected_after_factory_set() {
+    let (env, _admin, staker, client, _token) = setup();
+    let factory = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.stake(&staker, &500i128);
+    client.set_factory(&factory);
+
+    assert_eq!(
+        client.try_lock_host_stake(&attacker, &staker, &1u64, &100i128),
+        Err(Ok(StakingError::Unauthorized))
+    );
+}


### PR DESCRIPTION
## Summary

Restricts `lock_host_stake()` to trusted callers only (factory contract or admin), and documents the authorization requirement clearly.

## Problem

`lock_host_stake()` had an auth guard in the implementation but it was undocumented, leaving the security contract invisible to callers and reviewers. Test coverage only verified that a random attacker was rejected — there were no tests confirming the factory address is positively authorized.

## Changes

**`contract/staking/src/lib.rs`**
- Added `# Authorization` doc section to `lock_host_stake()` explicitly stating that only the admin or configured factory address may call it, and that all other callers receive `Unauthorized`

**`contract/staking/src/test.rs`**
- Added `test_factory_caller_can_lock_host_stake` — verifies the configured factory address can lock and release host stake, and that admin can do the same
- Added `test_non_factory_caller_rejected_after_factory_set` — verifies an arbitrary address is still rejected even after a factory is registered

## Security Impact

Any caller not matching the admin or factory address is rejected with `StakingError::Unauthorized` before any state is mutated. This prevents griefing attacks where an external caller could lock a host's stake and reduce their withdrawable balance.

## Testing

Existing unauthorized test retained. Two new targeted tests cover:
- Positive path: factory and admin are authorized
- Negative path: arbitrary caller is rejected when factory is set


closes #564 