### PR TITLE
fix: contract validation and testing improvements

### DIFF
--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -169,6 +169,22 @@ const REGISTRY_TTL_EXTEND_TO: u32 = 535_680;
 
 const DEFAULT_MIN_STAKE: i128 = 10_000_000;
 
+// ── Round speed bounds (mirrored from arena for fail-fast validation) ────────
+
+/// Minimum `round_speed_in_ledgers` — 10 ledgers ≈ 50 s at mainnet ~5 s/ledger.
+#[cfg(not(test))]
+const MIN_ROUND_SPEED_LEDGERS: u32 = 10;
+/// Minimum `round_speed_in_ledgers` — relaxed for tests.
+#[cfg(test)]
+const MIN_ROUND_SPEED_LEDGERS: u32 = 1;
+
+/// Maximum `round_speed_in_ledgers` — 17 280 ledgers ≈ 1 day at mainnet ~5 s/ledger.
+#[cfg(not(test))]
+const MAX_ROUND_SPEED_LEDGERS: u32 = 17_280;
+/// Maximum `round_speed_in_ledgers` — relaxed for tests.
+#[cfg(test)]
+const MAX_ROUND_SPEED_LEDGERS: u32 = 100_000;
+
 // ── Event topics ──────────────────────────────────────────────────────────────
 
 const TOPIC_UPGRADE_PROPOSED: Symbol = symbol_short!("UP_PROP");
@@ -277,6 +293,8 @@ pub enum Error {
     HostStakeInsufficient = 32,
     /// Arithmetic overflow in fee calculation/accumulation.
     ArithmeticOverflow = 33,
+    /// `round_speed` is below `MIN_ROUND_SPEED_LEDGERS` or above `MAX_ROUND_SPEED_LEDGERS`.
+    InvalidRoundSpeed = 34,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -791,6 +809,7 @@ impl FactoryContract {
     /// The caller must provide a valid stake amount >= minimum stake and a
     /// capacity in range [2, MAX_POOL_CAPACITY]. `pool_id` must be unique.
     /// The `currency` must have been previously approved via `add_supported_token`.
+    /// The `round_speed` must be in range [MIN_ROUND_SPEED_LEDGERS, MAX_ROUND_SPEED_LEDGERS].
     /// Emits `PoolCreated(pool_id, creator, capacity, stake_amount)`.
     ///
     /// # Errors
@@ -801,6 +820,7 @@ impl FactoryContract {
     /// * [`Error::ExceedsPlayerCap`] — `capacity` exceeds `max_players_cap()`.
     /// * [`Error::InvalidStakeAmount`] — `stake_amount` is zero or negative.
     /// * [`Error::StakeBelowMinimum`] — `stake_amount` is below the configured minimum.
+    /// * [`Error::InvalidRoundSpeed`] — `round_speed` is outside the allowed range.
     /// * [`Error::WasmHashNotSet`] — `set_arena_wasm_hash` has not been called yet.
     pub fn create_pool(
         env: Env,
@@ -849,6 +869,10 @@ impl FactoryContract {
             return Err(Error::StakeBelowMinimum);
         }
 
+        if round_speed < MIN_ROUND_SPEED_LEDGERS || round_speed > MAX_ROUND_SPEED_LEDGERS {
+            return Err(Error::InvalidRoundSpeed);
+        }
+
         // Issue #449: host must have enough stake locked in staking contract.
         let staking_contract = Self::get_staking_contract(env.clone())?;
         let host_stake: i128 = env.invoke_contract(
@@ -859,6 +883,9 @@ impl FactoryContract {
         if host_stake < Self::get_min_host_stake(env.clone()) {
             return Err(Error::HostStakeInsufficient);
         }
+
+        // Cache staking contract for the lock_host_stake call below to avoid repeated reads.
+        let cached_staking_contract = staking_contract;
 
         // ── Arena creation fee (fee-then-deploy) ─────────────────────────────
         let (creation_fee, fee_token) = Self::get_creation_fee(env.clone());
@@ -1013,10 +1040,9 @@ impl FactoryContract {
             ),
         );
 
-        // Lock host stake against this arena id in staking contract.
-        let staking_contract = Self::get_staking_contract(env.clone())?;
+        // Lock host stake against this arena id in staking contract (using cached contract address).
         env.invoke_contract::<()>(
-            &staking_contract,
+            &cached_staking_contract,
             &soroban_sdk::Symbol::new(&env, "lock_host_stake"),
             soroban_sdk::vec![
                 &env,

--- a/contract/payout/src/test.rs
+++ b/contract/payout/src/test.rs
@@ -47,6 +47,7 @@ impl MockFactoryContract {
             win_fee_bps: fee,
         })
     }
+    pub fn record_win_fee(_env: Env, _amount: i128) {}
 }
 
 const TIMELOCK: u64 = 48 * 60 * 60;
@@ -864,4 +865,186 @@ fn win_fee_overflow_guard_returns_error() {
         &symbol_short!("XLM"),
     );
     assert_eq!(result, Err(Ok(PayoutError::ArithmeticOverflow)));
+}
+
+// ── Issue #581: Fee rounding and dust behavior ────────────────────────────────
+
+#[test]
+fn fee_rounding_with_tiny_payout_and_high_bps() {
+    let (env, _admin, client, token_id, _treasury, _factory_id, factory_client) =
+        setup_with_token();
+    let currency = symbol_short!("USDC");
+    client.set_currency_token(&currency, &token_id);
+    let token = TokenClient::new(&env, &token_id);
+
+    let winner = Address::generate(&env);
+    let caller = Address::generate(&env);
+    factory_client.set_arena(&(100u32 as u64), &caller);
+    factory_client.set_fee_bps(&9_999);
+
+    let amount = 1i128;
+    let before_winner = token.balance(&winner);
+    let before_factory = token.balance(&factory_client.address);
+
+    client.distribute_winnings(
+        &caller,
+        &symbol_short!("CTX"),
+        &100u32,
+        &1u32,
+        &winner,
+        &amount,
+        &currency,
+    );
+
+    let fee = amount * 9_999i128 / 10_000i128;
+    let winner_amount = amount - fee;
+    assert_eq!(token.balance(&winner), before_winner + winner_amount);
+    assert_eq!(token.balance(&factory_client.address), before_factory + fee);
+    assert_eq!(winner_amount, 1i128);
+    assert_eq!(fee, 0i128);
+}
+
+#[test]
+fn fee_rounding_with_small_payout_exact_division() {
+    let (env, _admin, client, token_id, _treasury, _factory_id, factory_client) =
+        setup_with_token();
+    let currency = symbol_short!("USDC");
+    client.set_currency_token(&currency, &token_id);
+    let token = TokenClient::new(&env, &token_id);
+
+    let winner = Address::generate(&env);
+    let caller = Address::generate(&env);
+    factory_client.set_arena(&(101u32 as u64), &caller);
+    factory_client.set_fee_bps(&5_000);
+
+    let amount = 10_000i128;
+    let before_winner = token.balance(&winner);
+    let before_factory = token.balance(&factory_client.address);
+
+    client.distribute_winnings(
+        &caller,
+        &symbol_short!("CTX"),
+        &101u32,
+        &1u32,
+        &winner,
+        &amount,
+        &currency,
+    );
+
+    let fee = amount * 5_000i128 / 10_000i128;
+    let winner_amount = amount - fee;
+    assert_eq!(token.balance(&winner), before_winner + winner_amount);
+    assert_eq!(token.balance(&factory_client.address), before_factory + fee);
+    assert_eq!(winner_amount, 5_000i128);
+    assert_eq!(fee, 5_000i128);
+}
+
+#[test]
+fn fee_rounding_with_remainder() {
+    let (env, _admin, client, token_id, _treasury, _factory_id, factory_client) =
+        setup_with_token();
+    let currency = symbol_short!("USDC");
+    client.set_currency_token(&currency, &token_id);
+    let token = TokenClient::new(&env, &token_id);
+
+    let winner = Address::generate(&env);
+    let caller = Address::generate(&env);
+    factory_client.set_arena(&(102u32 as u64), &caller);
+    factory_client.set_fee_bps(&333);
+
+    let amount = 1_000i128;
+    let before_winner = token.balance(&winner);
+    let before_factory = token.balance(&factory_client.address);
+
+    client.distribute_winnings(
+        &caller,
+        &symbol_short!("CTX"),
+        &102u32,
+        &1u32,
+        &winner,
+        &amount,
+        &currency,
+    );
+
+    let fee = amount * 333i128 / 10_000i128;
+    let winner_amount = amount - fee;
+    assert_eq!(token.balance(&winner), before_winner + winner_amount);
+    assert_eq!(token.balance(&factory_client.address), before_factory + fee);
+    assert_eq!(winner_amount, 967i128);
+    assert_eq!(fee, 33i128);
+}
+
+// ── Issue #582: Missing currency-token mapping path ──────────────────────────
+
+#[test]
+fn distribute_winnings_records_payout_without_token_mapping() {
+    let (env, _admin, client, _, factory_client) = setup();
+
+    let winner = Address::generate(&env);
+    let ctx = symbol_short!("NO_TOKEN");
+    let pool_id = 200u32;
+    let round_id = 1u32;
+    let amount = 5_000i128;
+    let currency = symbol_short!("UNKNOWN");
+
+    assert!(!client.is_payout_processed(&ctx, &pool_id, &round_id, &winner));
+
+    let caller = Address::generate(&env);
+    factory_client.set_arena(&(pool_id as u64), &caller);
+    client.distribute_winnings(
+        &caller, &ctx, &pool_id, &round_id, &winner, &amount, &currency,
+    );
+
+    assert!(client.is_payout_processed(&ctx, &pool_id, &round_id, &winner));
+    let payout = client
+        .get_payout(&ctx, &pool_id, &round_id, &winner)
+        .expect("payout must be recorded");
+    assert_eq!(payout.winner, winner);
+    assert_eq!(payout.amount, amount);
+    assert_eq!(payout.currency, currency);
+    assert!(payout.paid);
+}
+
+#[test]
+fn distribute_winnings_with_partial_token_mapping() {
+    let (env, _admin, client, token_id, _treasury, _, factory_client) = setup_with_token();
+
+    let currency1 = symbol_short!("USDC");
+    let currency2 = symbol_short!("EURC");
+    client.set_currency_token(&currency1, &token_id);
+
+    let winner = Address::generate(&env);
+    let caller = Address::generate(&env);
+    factory_client.set_arena(&(201u32 as u64), &caller);
+
+    client.distribute_winnings(
+        &caller,
+        &symbol_short!("CTX"),
+        &201u32,
+        &1u32,
+        &winner,
+        &1_000i128,
+        &currency1,
+    );
+
+    assert!(
+        client.is_payout_processed(&symbol_short!("CTX"), &201u32, &1u32, &winner),
+        "payout should be recorded for currency1"
+    );
+
+    let winner2 = Address::generate(&env);
+    client.distribute_winnings(
+        &caller,
+        &symbol_short!("CTX"),
+        &201u32,
+        &2u32,
+        &winner2,
+        &2_000i128,
+        &currency2,
+    );
+
+    assert!(
+        client.is_payout_processed(&symbol_short!("CTX"), &201u32, &2u32, &winner2),
+        "payout should be recorded for currency2 even without token mapping"
+    );
 }


### PR DESCRIPTION
## Summary

Adds pre-validation for round_speed bounds in factory contract, optimizes staking contract lookups, and adds comprehensive tests for payout fee rounding behavior.

## Changes

- Issue #579: Pre-validate round_speed bounds in factory for fail-fast validation
- Issue #580: Cache staking contract lookup in create_pool to reduce repeated reads  
- Issue #581: Add deterministic tests for payout fee rounding and dust behavior
- Issue #582: Add integration tests for missing currency-token mapping path

## Testing

All payout tests pass (49 passed). Factory and payout contracts build successfully with no errors.

Closes #579
Closes #580
Closes #581
Closes #582