### PR TITLE
test: add cross-contract financial invariant coverage (#478)

### DIFF
--- a/contract/arena/src/integration_tests.rs
+++ b/contract/arena/src/integration_tests.rs
@@ -13,7 +13,7 @@ use std::vec;
 use factory::{FactoryContract, FactoryContractClient};
 use payout::{PayoutContract, PayoutContractClient};
 use soroban_sdk::{
-    Address, BytesN, Env,
+    Address, BytesN, Env, Symbol,
     testutils::{Address as _, Ledger, LedgerInfo},
     token::{StellarAssetClient, TokenClient},
 };
@@ -89,6 +89,56 @@ fn join_players(
         token.mint(player, &(stake * 10));
         arena.join(player, &stake);
     }
+}
+
+fn read_instance_i128(env: &Env, arena: &ArenaContractClient<'_>, key: &Symbol) -> i128 {
+    env.as_contract(&arena.address, || env.storage().instance().get(key).unwrap_or(0i128))
+}
+
+fn assert_arena_balance_invariant(
+    env: &Env,
+    arena: &ArenaContractClient<'_>,
+    token: &TokenClient<'_>,
+    sum_entry_fees: i128,
+    platform_fees_paid: i128,
+    operation: &str,
+) {
+    let contract_token_balance = token.balance(&arena.address);
+    let vault_shares_value = env.as_contract(&arena.address, || {
+        if env.storage().instance().has(&VAULT_SHARES_KEY) {
+            // In tests without a vault price feed, deposited principal is the
+            // best available proxy for current share value.
+            env.storage()
+                .instance()
+                .get(&VAULT_DEPOSITED_KEY)
+                .unwrap_or(0i128)
+        } else {
+            0i128
+        }
+    });
+    let yield_earned = read_instance_i128(env, arena, &YIELD_KEY);
+    let expected = sum_entry_fees + yield_earned - platform_fees_paid;
+
+    assert_eq!(
+        contract_token_balance + vault_shares_value,
+        expected,
+        "balance invariant failed after {operation}: contract_balance({contract_token_balance}) + vault_value({vault_shares_value}) != sum_entry_fees({sum_entry_fees}) + yield_earned({yield_earned}) - platform_fees_paid({platform_fees_paid})"
+    );
+}
+
+fn assert_player_count_invariant(
+    env: &Env,
+    arena: &ArenaContractClient<'_>,
+    initial_player_count: u32,
+    operation: &str,
+) {
+    let survivors = arena.get_arena_state().survivors_count;
+    let eliminated = get_eliminated(env).len();
+    assert_eq!(
+        survivors + eliminated,
+        initial_player_count,
+        "player-count invariant failed after {operation}: eliminated_count({eliminated}) + survivors_count({survivors}) != initial_player_count({initial_player_count})"
+    );
 }
 
 // ── AC: Full lifecycle runs without error ─────────────────────────────────────
@@ -238,6 +288,98 @@ fn lifecycle_full_game_resolve_round_to_claim() {
     assert_eq!(
         token_reader.balance(&winner),
         winner_balance_before_bonus + bonus_prize
+    );
+}
+
+#[test]
+fn issue_478_invariants_hold_after_join_resolve_and_payout_setup() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_seq(&env, 3_000);
+
+    let admin = Address::generate(&env);
+    let (_factory, _payout) = deploy_all(&env, &admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token = StellarAssetClient::new(&env, &token_id);
+    let token_reader = TokenClient::new(&env, &token_id);
+
+    let stake = 10_000_000i128;
+    let arena = deploy_arena(&env, &admin, 5, stake, &token_id);
+    let players: std::vec::Vec<Address> = (0..6).map(|_| Address::generate(&env)).collect();
+    let initial_player_count = players.len() as u32;
+
+    let mut sum_entry_fees = 0i128;
+    for (idx, player) in players.iter().enumerate() {
+        token.mint(player, &(stake * 10));
+        arena.join(player, &stake);
+        sum_entry_fees += stake;
+        assert_arena_balance_invariant(
+            &env,
+            &arena,
+            &token_reader,
+            sum_entry_fees,
+            0,
+            &format!("join[{idx}]"),
+        );
+    }
+
+    set_seq(&env, 3_010);
+    let round_one = arena.start_round();
+    assert_eq!(round_one.round_number, 1);
+
+    for player in &players[0..4] {
+        arena.submit_choice(player, &1, &Choice::Heads);
+    }
+    for player in &players[4..6] {
+        arena.submit_choice(player, &1, &Choice::Tails);
+    }
+    set_seq(&env, 3_016);
+    arena.resolve_round();
+    assert_player_count_invariant(&env, &arena, initial_player_count, "resolve_round[1]");
+    assert_arena_balance_invariant(
+        &env,
+        &arena,
+        &token_reader,
+        sum_entry_fees,
+        0,
+        "resolve_round[1]",
+    );
+
+    set_seq(&env, 3_020);
+    let round_two = arena.start_round();
+    assert_eq!(round_two.round_number, 2);
+    let survivors = get_survivors(&env);
+    assert_eq!(survivors.len(), 2);
+    arena.submit_choice(&survivors.get(0).unwrap(), &2, &Choice::Heads);
+    arena.submit_choice(&survivors.get(1).unwrap(), &2, &Choice::Tails);
+    set_seq(&env, 3_026);
+    arena.resolve_round();
+    assert_player_count_invariant(&env, &arena, initial_player_count, "resolve_round[2]");
+    assert_arena_balance_invariant(
+        &env,
+        &arena,
+        &token_reader,
+        sum_entry_fees,
+        0,
+        "resolve_round[2]",
+    );
+
+    // Simulate harvested yield arriving before payout settlement.
+    let yield_earned = 1_500i128;
+    token.mint(&arena.address, &yield_earned);
+    let winner = get_survivors(&env).get(0).unwrap();
+    arena.set_winner(&winner, &sum_entry_fees, &yield_earned);
+    assert_arena_balance_invariant(
+        &env,
+        &arena,
+        &token_reader,
+        sum_entry_fees,
+        0,
+        "payout_setup",
     );
 }
 

--- a/contract/payout/src/test.rs
+++ b/contract/payout/src/test.rs
@@ -982,6 +982,62 @@ fn win_fee_bps_cases_0_200_1000() {
     run_case(12, 1_000, 1_000);
 }
 
+fn assert_payout_conservation(
+    client: &PayoutContractClient<'_>,
+    arena_id: u64,
+    total_prize_pool: i128,
+    operation: &str,
+) {
+    let receipt = client
+        .get_payout_by_arena(&arena_id)
+        .expect("payout receipt must exist for invariant check");
+    assert_eq!(
+        receipt.amount + receipt.fee,
+        total_prize_pool,
+        "payout invariant failed after {operation}: payout_amount({}) + platform_fee({}) != total_prize_pool({total_prize_pool})",
+        receipt.amount,
+        receipt.fee
+    );
+}
+
+#[test]
+fn issue_478_payout_amount_plus_fee_equals_total_prize_pool() {
+    let (env, _admin, client, token_id, _treasury, _factory_id, factory_client) = setup_with_token();
+    let currency = symbol_short!("USDC");
+    client.set_currency_token(&currency, &token_id);
+    let token = TokenClient::new(&env, &token_id);
+
+    let pool_id = 478u32;
+    let round_id = 1u32;
+    let amount = 12_345i128;
+    let fee_bps = 275u32;
+    let winner = Address::generate(&env);
+    let caller = Address::generate(&env);
+    factory_client.set_arena(&(pool_id as u64), &caller);
+    factory_client.set_fee_bps(&fee_bps);
+
+    let before_winner = token.balance(&winner);
+    let before_factory = token.balance(&factory_client.address);
+    client.distribute_winnings(
+        &caller,
+        &symbol_short!("INV478"),
+        &pool_id,
+        &round_id,
+        &winner,
+        &amount,
+        &currency,
+    );
+
+    let expected_fee = amount * (fee_bps as i128) / 10_000;
+    let expected_winner_amount = amount - expected_fee;
+    assert_eq!(token.balance(&winner), before_winner + expected_winner_amount);
+    assert_eq!(
+        token.balance(&factory_client.address),
+        before_factory + expected_fee
+    );
+    assert_payout_conservation(&client, pool_id as u64, amount, "distribute_winnings");
+}
+
 #[test]
 fn win_fee_overflow_guard_returns_error() {
     let (env, _admin, client, _token_id, _treasury, _factory_id, factory_client) =

--- a/contract/staking/src/test.rs
+++ b/contract/staking/src/test.rs
@@ -344,6 +344,23 @@ fn invariants_hold_across_stake_unstake_claim_and_compound() {
     assert_pool_invariants(&client, &[staker1]);
 }
 
+#[test]
+fn issue_478_total_staked_equals_sum_of_staker_balances() {
+    let (env, _admin, staker1, client, _token_client) = setup();
+    let staker2 = Address::generate(&env);
+    let token_admin = StellarAssetClient::new(&env, &client.token());
+    token_admin.mint(&staker2, &1_000_000_000i128);
+
+    client.stake(&staker1, &200_000_000i128);
+    assert_pool_invariants(&client, &[staker1.clone(), staker2.clone()]);
+
+    client.stake(&staker2, &300_000_000i128);
+    assert_pool_invariants(&client, &[staker1.clone(), staker2.clone()]);
+
+    client.unstake(&staker1, &50_000_000i128);
+    assert_pool_invariants(&client, &[staker1, staker2]);
+}
+
 // ── Issue #388: stake/unstake events ─────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- add arena lifecycle invariant test that asserts `contract_token_balance + vault_shares_value == sum(entry_fees) + yield_earned - platform_fees_paid` after every `join`, `resolve_round`, and payout setup state transition
- add arena player-count invariant checks after each `resolve_round`: `eliminated_count + survivors_count == initial_player_count`
- add payout invariant test to assert `payout_amount + platform_fee == total_prize_pool` for `distribute_winnings`
- add explicit staking regression test asserting `total_staked == sum(all staker balances)` across stake/unstake transitions

## Why
Financial conservation invariants are critical to prevent silent insolvency from rounding or accounting drift across arena, payout, and staking lifecycle transitions.

## Files Changed
- `contract/arena/src/integration_tests.rs`
- `contract/payout/src/test.rs`
- `contract/staking/src/test.rs`

## Issue
Closes #478