### PR TITLE
feat(contract): arena player views + property tests for computePayouts

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -34,6 +34,7 @@
         "@types/pino": "^7.0.4",
         "@types/pino-http": "^5.8.4",
         "@types/supertest": "^6.0.3",
+        "fast-check": "^4.8.0",
         "jest": "^30.2.0",
         "mongodb-memory-server": "^11.0.1",
         "pino": "^10.3.1",
@@ -4888,6 +4889,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-copy": {
       "version": "4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "@types/pino": "^7.0.4",
     "@types/pino-http": "^5.8.4",
     "@types/supertest": "^6.0.3",
+    "fast-check": "^4.8.0",
     "jest": "^30.2.0",
     "mongodb-memory-server": "^11.0.1",
     "pino": "^10.3.1",

--- a/backend/test/roundService.unit.test.ts
+++ b/backend/test/roundService.unit.test.ts
@@ -1,0 +1,91 @@
+import fc from 'fast-check';
+import { RoundService } from '../src/services/roundService';
+import type { PlayerChoice, Payout } from '../src/types/round';
+
+// Number of generated cases per property. Acceptance criteria requires 1,000+.
+const NUM_RUNS = 1500;
+// Floating-point tolerance for sum comparisons across many additions.
+const EPSILON = 1e-6;
+
+// computePayouts / computeEliminations are private on RoundService; they are
+// pure (no DB access) so we can construct the service with a stub PrismaClient
+// and reach them via an `any` cast.
+const service = new RoundService({} as any);
+const computeEliminations = (
+  choices: PlayerChoice[],
+  oracleYield: number,
+  seed?: string
+): string[] => (service as any).computeEliminations(choices, oracleYield, seed);
+const computePayouts = (
+  choices: PlayerChoice[],
+  eliminated: string[],
+  oracleYield: number
+): Payout[] => (service as any).computePayouts(choices, eliminated, oracleYield);
+
+// Generates a list of player choices with guaranteed-unique userIds (the
+// payout logic keys on userId, so duplicates would be ill-defined).
+const playerChoicesArb = fc
+  .array(
+    fc.record({
+      stake: fc.double({ min: 1, max: 1000, noNaN: true, noDefaultInfinity: true }),
+      choice: fc.constantFrom('heads', 'tails'),
+    }),
+    { minLength: 2, maxLength: 20 }
+  )
+  .map((records) =>
+    records.map((r, i): PlayerChoice => ({ userId: `user-${i}`, ...r }))
+  );
+
+const oracleYieldArb = fc.double({
+  min: 0,
+  max: 50,
+  noNaN: true,
+  noDefaultInfinity: true,
+});
+
+describe('RoundService.computePayouts invariants', () => {
+  it('total payouts never exceed the total pool + yield (no funds created)', () => {
+    fc.assert(
+      fc.property(playerChoicesArb, oracleYieldArb, (playerChoices, oracleYield) => {
+        const eliminated = computeEliminations(playerChoices, oracleYield);
+        const payouts = computePayouts(playerChoices, eliminated, oracleYield);
+
+        const totalStakes = playerChoices.reduce((s, p) => s + p.stake, 0);
+        const totalPool = totalStakes * (1 + oracleYield / 100);
+        const totalPayout = payouts.reduce((s, p) => s + p.amount, 0);
+
+        expect(totalPayout).toBeLessThanOrEqual(totalPool + EPSILON);
+      }),
+      { numRuns: NUM_RUNS }
+    );
+  });
+
+  it('every winner receives at least their original stake back (no winner loses money)', () => {
+    fc.assert(
+      fc.property(playerChoicesArb, oracleYieldArb, (playerChoices, oracleYield) => {
+        const eliminated = computeEliminations(playerChoices, oracleYield);
+        const payouts = computePayouts(playerChoices, eliminated, oracleYield);
+
+        const stakeByUser = new Map(playerChoices.map((p) => [p.userId, p.stake]));
+        for (const payout of payouts) {
+          const originalStake = stakeByUser.get(payout.userId)!;
+          expect(payout.amount).toBeGreaterThanOrEqual(originalStake - EPSILON);
+        }
+      }),
+      { numRuns: NUM_RUNS }
+    );
+  });
+
+  it('distributes nothing when there are no winners (all players eliminated)', () => {
+    fc.assert(
+      fc.property(playerChoicesArb, oracleYieldArb, (playerChoices, oracleYield) => {
+        // Eliminate everyone — there can be no winners to pay out.
+        const allEliminated = playerChoices.map((p) => p.userId);
+        const payouts = computePayouts(playerChoices, allEliminated, oracleYield);
+
+        expect(payouts).toEqual([]);
+      }),
+      { numRuns: NUM_RUNS }
+    );
+  });
+});

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -1,11 +1,14 @@
 #![no_std]
-use soroban_sdk::{Env, contract, contractimpl, token};
+use soroban_sdk::{Address, Env, Vec, contract, contractimpl, token};
 
 mod storage;
 mod types;
 
 use storage::ArenaStorage;
-use types::{ArenaError, GameState};
+use types::{ArenaError, GameState, PlayerState};
+
+/// Number of players returned per `get_players` page.
+const PAGE_SIZE: u32 = 50;
 
 /// Arena contract — manages round lifecycle, player choices, and elimination logic.
 ///
@@ -57,5 +60,115 @@ impl ArenaContract {
             .publish((soroban_sdk::symbol_short!("cancelled"),), ());
 
         Ok(())
+    }
+
+    /// Returns a paginated list of all players with their current state.
+    ///
+    /// `page` is 0-indexed; the page size is [`PAGE_SIZE`] (50). Players are
+    /// returned in join order, so a given player appears on exactly one page
+    /// for a stable players list. Pages beyond the end return an empty list.
+    ///
+    /// Intended for indexers, analytics tools, and the backend event processor
+    /// to perform an initial state sync without replaying the event log.
+    pub fn get_players(env: Env, page: u32) -> Vec<(Address, PlayerState)> {
+        let all = ArenaStorage::load_all_players(&env);
+        let len = all.len();
+        let start = page.saturating_mul(PAGE_SIZE);
+        let end = start.saturating_add(PAGE_SIZE).min(len);
+
+        let mut result: Vec<(Address, PlayerState)> = Vec::new(&env);
+        let mut i = start;
+        while i < end {
+            let addr = all.get(i).unwrap();
+            let state = ArenaStorage::load_player(&env, &addr).unwrap_or_default();
+            result.push_back((addr, state));
+            i += 1;
+        }
+        result
+    }
+
+    /// Returns the total number of players who have joined this arena.
+    pub fn player_count(env: Env) -> u32 {
+        ArenaStorage::load_config(&env)
+            .map(|c| c.player_count)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::types::ArenaConfig;
+    use soroban_sdk::testutils::Address as _;
+
+    /// Register the contract and seed `n` joined players, returning the client.
+    fn setup(n: u32) -> (Env, ArenaContractClient<'static>) {
+        let env = Env::default();
+        let contract_id = env.register(ArenaContract, ());
+
+        env.as_contract(&contract_id, || {
+            let config = ArenaConfig {
+                admin: Address::generate(&env),
+                stake_token: Address::generate(&env),
+                entry_fee: 100,
+                state: GameState::Open,
+                player_count: 0,
+            };
+            ArenaStorage::save_config(&env, &config);
+            for _ in 0..n {
+                let player = Address::generate(&env);
+                ArenaStorage::add_player(&env, &player);
+            }
+        });
+
+        let client = ArenaContractClient::new(&env, &contract_id);
+        (env, client)
+    }
+
+    #[test]
+    fn zero_players() {
+        let (_env, client) = setup(0);
+        assert_eq!(client.player_count(), 0);
+        assert_eq!(client.get_players(&0).len(), 0);
+    }
+
+    #[test]
+    fn one_player() {
+        let (_env, client) = setup(1);
+        assert_eq!(client.player_count(), 1);
+
+        let page0 = client.get_players(&0);
+        assert_eq!(page0.len(), 1);
+        // The joined player is recorded as active with no rounds survived yet.
+        let (_addr, state) = page0.get(0).unwrap();
+        assert!(state.active);
+        assert_eq!(state.rounds_survived, 0);
+
+        // No second page.
+        assert_eq!(client.get_players(&1).len(), 0);
+    }
+
+    #[test]
+    fn fifty_one_players_cross_page_boundary() {
+        let (_env, client) = setup(51);
+        assert_eq!(client.player_count(), 51);
+
+        let page0 = client.get_players(&0);
+        let page1 = client.get_players(&1);
+        let page2 = client.get_players(&2);
+
+        assert_eq!(page0.len(), PAGE_SIZE); // 50
+        assert_eq!(page1.len(), 1);
+        assert_eq!(page2.len(), 0);
+
+        // Pagination is consistent: no player appears on two pages.
+        for (addr1, _) in page1.iter() {
+            for (addr0, _) in page0.iter() {
+                assert_ne!(addr0, addr1);
+            }
+        }
+
+        // The two pages together cover every player exactly once.
+        assert_eq!(page0.len() + page1.len(), client.player_count());
     }
 }

--- a/contract/arena/src/storage.rs
+++ b/contract/arena/src/storage.rs
@@ -1,9 +1,15 @@
 #![allow(dead_code)]
-use crate::types::{ArenaConfig, ArenaError};
-use soroban_sdk::{Address, Env, Vec, symbol_short};
+use crate::types::{ArenaConfig, ArenaError, PlayerState};
+use soroban_sdk::{Address, Env, Vec, contracttype, symbol_short};
 
 const CONFIG_KEY: &str = "CONFIG";
 const PLAYERS_KEY: &str = "PLAYERS";
+
+/// Storage key for an individual player's state, keyed by their address.
+#[contracttype]
+enum DataKey {
+    Player(Address),
+}
 
 pub struct ArenaStorage;
 
@@ -39,6 +45,36 @@ impl ArenaStorage {
         let mut players = Self::load_all_players(env);
         players.push_back(player.clone());
         Self::save_players(env, &players);
+
+        // Initialise the joining player's state (active, no rounds survived yet).
+        Self::save_player(
+            env,
+            player,
+            &PlayerState {
+                active: true,
+                rounds_survived: 0,
+            },
+        );
+
+        // Keep the cached player count in `config` in sync so `player_count`
+        // can be served without scanning the players list.
+        if let Ok(mut config) = Self::load_config(env) {
+            config.player_count = players.len();
+            Self::save_config(env, &config);
+        }
+    }
+
+    /// Load a single player's state, or `None` if they never joined.
+    pub fn load_player(env: &Env, player: &Address) -> Option<PlayerState> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Player(player.clone()))
+    }
+
+    pub fn save_player(env: &Env, player: &Address, state: &PlayerState) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Player(player.clone()), state);
     }
 }
 

--- a/contract/arena/src/types.rs
+++ b/contract/arena/src/types.rs
@@ -23,6 +23,23 @@ pub struct ArenaConfig {
     pub stake_token: Address,
     pub entry_fee: i128,
     pub state: GameState,
+    /// Total number of players that have ever joined this arena. Kept in sync
+    /// by `ArenaStorage::add_player` so it can be read without scanning storage.
+    pub player_count: u32,
+}
+
+/// Per-player state stored in persistent storage, keyed by the player address.
+///
+/// Returned (alongside the address) by `get_players` so indexers, analytics
+/// tools, and the backend event processor can sync arena state without
+/// replaying the `player_joined` event log.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct PlayerState {
+    /// Whether the player is still in the game (not yet eliminated).
+    pub active: bool,
+    /// Number of rounds the player has survived so far.
+    pub rounds_survived: u32,
 }
 
 /// Error codes returned by arena contract functions.


### PR DESCRIPTION
## Summary

Implements two issues on a single branch.

### Arena player view functions (#717)
Indexers, analytics tools, and the backend event processor can now query arena player state without replaying the `player_joined` event log.

- `get_players(page)` — paginated list (50 per page, 0-indexed, stable join order) of `(Address, PlayerState)` where `PlayerState` carries `active` and `rounds_survived`.
- `player_count()` — total players joined, served from a cached `player_count` on `ArenaConfig`.
- `storage.rs` — per-player state keyed by address (`load_player`/`save_player`); `add_player` initializes each joiner's state and keeps `player_count` in sync.
- Tests cover 0 players, 1 player, and 51 players (crosses the page boundary, asserts no player appears on two pages). `cargo test -p arena` → 3/3 passing.

### Property-based tests for `RoundService.computePayouts` (#700)
- Adds `fast-check` as a dev dependency.
- New `backend/test/roundService.unit.test.ts` with three 1,500-case property tests (runs under `npm run test:ci`):
  - total payouts never exceed total pool + yield (no funds created from thin air)
  - every winner receives at least their original stake back
  - no winners (all eliminated) → empty payouts

## Closes
Closes #717
Closes #700