### PR TITLE
feat: wallet key validation, Sentry address scrubbing, ArenaStats & rate-limit tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
     preset: "ts-jest",
     testEnvironment: "node",
-    roots: ["<rootDir>/src", "<rootDir>/test"],
+    roots: ["<rootDir>/src", "<rootDir>/test", "<rootDir>/tests"],
     testMatch: ["**/*.test.ts"],
     transform: {
         "^.+\\.tsx?$": ["ts-jest", { tsconfig: "tsconfig.json" }],

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "express": "^4.22.1",
     "helmet": "^7.1.0",
     "ioredis": "^5.9.3",
+    "rate-limiter-flexible": "^8.2.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.4.0",
     "pg": "^8.12.0",

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -1,0 +1,105 @@
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+import {
+  RateLimiterMemory,
+  RateLimiterRedis,
+  type RateLimiterAbstract,
+} from "rate-limiter-flexible";
+import { redis } from "../cache/redisClient";
+
+export interface RateLimitConfig {
+  keyPrefix: string;
+  points: number;
+  durationSeconds: number;
+}
+
+function readPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : fallback;
+}
+
+export const nonceRateLimitConfig: RateLimitConfig = {
+  keyPrefix: process.env.RATE_LIMIT_NONCE_PREFIX ?? "rl:auth:nonce",
+  points: readPositiveInt("RATE_LIMIT_NONCE_POINTS", 5),
+  durationSeconds: readPositiveInt("RATE_LIMIT_NONCE_WINDOW_SECONDS", 60),
+};
+
+export const poolsRateLimitConfig: RateLimitConfig = {
+  keyPrefix: process.env.RATE_LIMIT_POOLS_PREFIX ?? "rl:pools:create",
+  points: readPositiveInt("RATE_LIMIT_POOLS_POINTS", 3),
+  durationSeconds: readPositiveInt("RATE_LIMIT_POOLS_WINDOW_SECONDS", 60),
+};
+
+const limiterCache = new Map<string, RateLimiterAbstract>();
+
+function getLimiter(config: RateLimitConfig): RateLimiterAbstract {
+  const cacheKey = `${config.keyPrefix}:${config.points}:${config.durationSeconds}`;
+  const existing = limiterCache.get(cacheKey);
+  if (existing) return existing;
+
+  const baseOptions = {
+    keyPrefix: config.keyPrefix,
+    points: config.points,
+    duration: config.durationSeconds,
+  };
+
+  const redisUrl = process.env.REDIS_URL;
+  const limiter = redisUrl
+    ? new RateLimiterRedis({
+        ...baseOptions,
+        storeClient: redis,
+        insuranceLimiter: new RateLimiterMemory(baseOptions),
+      })
+    : new RateLimiterMemory(baseOptions);
+
+  limiterCache.set(cacheKey, limiter);
+  return limiter;
+}
+
+function resolveIp(req: Request): string {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return req.ip ?? "unknown";
+}
+
+export function createRateLimitMiddleware(
+  config: RateLimitConfig,
+): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const ip = resolveIp(req);
+    const walletAddress =
+      typeof req.body?.walletAddress === "string"
+        ? req.body.walletAddress.toLowerCase()
+        : null;
+
+    const key = walletAddress
+      ? `ip:${ip}:wallet:${walletAddress}`
+      : `ip:${ip}`;
+
+    const limiter = getLimiter(config);
+
+    try {
+      await limiter.consume(key, 1);
+      next();
+    } catch (err) {
+      const typed = err as { msBeforeNext?: number };
+      const retryAfter = Math.max(
+        1,
+        Math.ceil((typed.msBeforeNext ?? config.durationSeconds * 1_000) / 1_000),
+      );
+      res
+        .status(429)
+        .set("Retry-After", String(retryAfter))
+        .json({ error: "Too many requests. Please retry later." });
+    }
+  };
+}
+
+/** Expose limiter cache for test teardown (reset between suites). */
+export function clearLimiterCache(): void {
+  limiterCache.clear();
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { asyncHandler } from "../middleware/validate";
+import { createRateLimitMiddleware, nonceRateLimitConfig } from "../middleware/rateLimit";
 import type { AuthController } from "../controllers/auth.controller";
 import type { RequestHandler } from "express";
 
@@ -9,8 +10,10 @@ export function createAuthRouter(
 ): Router {
   const router = Router();
 
+  const nonceRateLimiter = createRateLimitMiddleware(nonceRateLimitConfig);
+
   // Public endpoints
-  router.post("/nonce", asyncHandler(controller.requestNonce));
+  router.post("/nonce", nonceRateLimiter, asyncHandler(controller.requestNonce));
   router.post("/verify", asyncHandler(controller.verify));
   router.post("/refresh", asyncHandler(controller.refresh));
 

--- a/backend/src/routes/pools.ts
+++ b/backend/src/routes/pools.ts
@@ -4,6 +4,7 @@ import { asyncHandler } from "../middleware/validate";
 import { cacheMiddleware } from "../middleware/cache";
 import { cacheTTL } from "../cache/cacheService";
 import { prisma } from "../db/prisma";
+import { createRateLimitMiddleware, poolsRateLimitConfig } from "../middleware/rateLimit";
 import type { RequestHandler } from "express";
 
 const PaginationSchema = z.object({
@@ -49,6 +50,31 @@ function formatEliminationLog(log: {
 
 export function createPoolsRouter(authMiddleware: RequestHandler): Router {
   const router = Router();
+
+  const poolsRateLimiter = createRateLimitMiddleware(poolsRateLimitConfig);
+
+  /**
+   * POST /api/pools
+   * Rate-limited pool creation endpoint.
+   */
+  router.post(
+    "/",
+    authMiddleware,
+    poolsRateLimiter,
+    asyncHandler(async (req, res) => {
+      const PoolCreateSchema = z.object({
+        arenaId: z.string().uuid(),
+        stakeAmount: z.number().positive(),
+      });
+      const { arenaId, stakeAmount } = PoolCreateSchema.parse(req.body);
+
+      const pool = await prisma.pool.create({
+        data: { arenaId, stakeAmount },
+      });
+
+      res.status(201).json(pool);
+    }),
+  );
 
   /**
    * GET /api/pools/:id/eliminations

--- a/backend/test/integration/rateLimit.test.ts
+++ b/backend/test/integration/rateLimit.test.ts
@@ -1,0 +1,147 @@
+import request from "supertest";
+import { setupTestApp } from "./testApp";
+import { Keypair } from "@stellar/stellar-sdk";
+import { clearLimiterCache } from "../../src/middleware/rateLimit";
+
+// Use a valid Stellar keypair so the nonce endpoint accepts the address.
+const TEST_KEYPAIR = Keypair.random();
+const TEST_WALLET = TEST_KEYPAIR.publicKey();
+
+// Isolated IPs — each describe block uses its own to avoid cross-test pollution.
+const NONCE_IP = "10.1.0.1";
+const POOLS_IP = "10.1.0.2";
+
+describe("Rate limiting on POST /api/auth/nonce", () => {
+    let app: ReturnType<typeof setupTestApp>;
+
+    beforeAll(() => {
+        // Override the nonce limit to a small value so tests run quickly.
+        process.env.RATE_LIMIT_NONCE_POINTS = "3";
+        process.env.RATE_LIMIT_NONCE_WINDOW_SECONDS = "60";
+        process.env.RATE_LIMIT_NONCE_PREFIX = "rl:test:nonce:ci";
+        clearLimiterCache();
+        app = setupTestApp();
+    });
+
+    afterAll(() => {
+        clearLimiterCache();
+        delete process.env.RATE_LIMIT_NONCE_POINTS;
+        delete process.env.RATE_LIMIT_NONCE_WINDOW_SECONDS;
+        delete process.env.RATE_LIMIT_NONCE_PREFIX;
+    });
+
+    it("allows requests up to the configured limit", async () => {
+        const limit = parseInt(process.env.RATE_LIMIT_NONCE_POINTS ?? "3", 10);
+
+        for (let i = 0; i < limit; i++) {
+            const res = await request(app)
+                .post("/api/auth/nonce")
+                .set("X-Forwarded-For", NONCE_IP)
+                .send({ walletAddress: TEST_WALLET });
+
+            expect(res.status).not.toBe(429);
+        }
+    });
+
+    it("returns 429 with Retry-After on the request after the limit is exceeded", async () => {
+        // The previous test exhausted the limit; this request is one over.
+        const res = await request(app)
+            .post("/api/auth/nonce")
+            .set("X-Forwarded-For", NONCE_IP)
+            .send({ walletAddress: TEST_WALLET });
+
+        expect(res.status).toBe(429);
+        expect(res.headers["retry-after"]).toBeDefined();
+        const retryAfter = Number(res.headers["retry-after"]);
+        expect(retryAfter).toBeGreaterThanOrEqual(1);
+    });
+
+    it("scopes the limit by IP + wallet address independently", async () => {
+        // A different wallet on the same IP gets its own bucket.
+        const otherWallet = Keypair.random().publicKey();
+        const res = await request(app)
+            .post("/api/auth/nonce")
+            .set("X-Forwarded-For", NONCE_IP)
+            .send({ walletAddress: otherWallet });
+
+        expect(res.status).not.toBe(429);
+    });
+
+    it("a different IP is not affected by the exhausted limit", async () => {
+        const res = await request(app)
+            .post("/api/auth/nonce")
+            .set("X-Forwarded-For", "10.1.0.99")
+            .send({ walletAddress: TEST_WALLET });
+
+        expect(res.status).not.toBe(429);
+    });
+});
+
+describe("Rate limiting on POST /api/pools", () => {
+    let app: ReturnType<typeof setupTestApp>;
+
+    beforeAll(() => {
+        process.env.RATE_LIMIT_POOLS_POINTS = "2";
+        process.env.RATE_LIMIT_POOLS_WINDOW_SECONDS = "60";
+        process.env.RATE_LIMIT_POOLS_PREFIX = "rl:test:pools:ci";
+        clearLimiterCache();
+        app = setupTestApp();
+    });
+
+    afterAll(() => {
+        clearLimiterCache();
+        delete process.env.RATE_LIMIT_POOLS_POINTS;
+        delete process.env.RATE_LIMIT_POOLS_WINDOW_SECONDS;
+        delete process.env.RATE_LIMIT_POOLS_PREFIX;
+    });
+
+    it("returns 429 with Retry-After on POST /api/pools after the limit is exceeded", async () => {
+        if (!process.env.DATABASE_URL) return;
+
+        const limit = parseInt(process.env.RATE_LIMIT_POOLS_POINTS ?? "2", 10);
+
+        // Obtain a JWT token via the full auth flow.
+        const keypair = Keypair.random();
+        const walletAddress = keypair.publicKey();
+
+        const nonceRes = await request(app)
+            .post("/api/auth/nonce")
+            .set("X-Forwarded-For", "10.1.0.98")
+            .send({ walletAddress });
+        expect(nonceRes.status).toBe(201);
+
+        const signatureBuffer = keypair.sign(Buffer.from(nonceRes.body.nonce, "utf-8"));
+        const signature = signatureBuffer.toString("base64");
+
+        const verifyRes = await request(app)
+            .post("/api/auth/verify")
+            .set("X-Forwarded-For", "10.1.0.98")
+            .send({ walletAddress, signature });
+        expect(verifyRes.status).toBe(200);
+
+        const { accessToken } = verifyRes.body;
+
+        // Create a real arena so the pool FK constraint is satisfied.
+        const { prisma } = await import("../../src/db/prisma");
+        const arena = await prisma.arena.create({ data: { metadata: {} } });
+
+        let lastRes: request.Response | undefined;
+
+        for (let i = 0; i <= limit; i++) {
+            lastRes = await request(app)
+                .post("/api/pools")
+                .set("Authorization", `Bearer ${accessToken}`)
+                .set("X-Forwarded-For", POOLS_IP)
+                .send({ arenaId: arena.id, stakeAmount: 10 });
+        }
+
+        // Clean up arenas and pools created during test
+        await prisma.pool.deleteMany({ where: { arenaId: arena.id } });
+        await prisma.arena.delete({ where: { id: arena.id } });
+
+        expect(lastRes!.status).toBe(429);
+        expect(lastRes!.headers["retry-after"]).toBeDefined();
+        const retryAfter = Number(lastRes!.headers["retry-after"]);
+        expect(retryAfter).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/backend/tests/arenaStats.unit.test.ts
+++ b/backend/tests/arenaStats.unit.test.ts
@@ -1,0 +1,181 @@
+import { PrismaClient } from "@prisma/client";
+import { ArenaStatsService } from "../src/services/arenaStatsService";
+
+const prisma = new PrismaClient();
+const service = new ArenaStatsService(prisma);
+
+// Helpers ──────────────────────────────────────────────────────────────────
+
+async function createArena(minStake = 50) {
+  return prisma.arena.create({ data: { metadata: { minStake } } });
+}
+
+async function createUser(walletSuffix: string) {
+  return prisma.user.create({
+    data: { walletAddress: `GTEST${walletSuffix.padEnd(51, "A")}` },
+  });
+}
+
+async function cleanup(arenaId: string) {
+  await prisma.eliminationLog.deleteMany({
+    where: { round: { arenaId } },
+  });
+  await prisma.round.deleteMany({ where: { arenaId } });
+  await prisma.arena.delete({ where: { id: arenaId } }).catch(() => {});
+}
+
+async function cleanupUsers(userIds: string[]) {
+  await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+}
+
+// ── Test suite ─────────────────────────────────────────────────────────────
+
+describe("ArenaStatsService.getArenaStats", () => {
+  it("returns zero counts for an arena with no rounds", async () => {
+    if (!process.env.DATABASE_URL) return;
+
+    const arena = await createArena(50);
+
+    try {
+      const stats = await service.getArenaStats(arena.id);
+
+      expect(stats.arenaId).toBe(arena.id);
+      expect(stats.currentRound).toBe(0);
+      expect(stats.playerCount).toBe(0);
+      expect(stats.survivorCount).toBeGreaterThanOrEqual(0);
+      expect(stats.yieldAccrued).toBe(0);
+      expect(stats.currentPot).toBe(0);
+      expect(stats.entryFee).toBe(50);
+      // No rounds means no state — service falls back to "pending"
+      expect(stats.status).toBe("pending");
+    } finally {
+      await cleanup(arena.id);
+    }
+  });
+
+  it("counts players and survivors correctly after the first round with eliminations", async () => {
+    if (!process.env.DATABASE_URL) return;
+
+    const arena = await createArena(50);
+    const users = await Promise.all([
+      createUser("U1"),
+      createUser("U2"),
+      createUser("U3"),
+      createUser("U4"),
+      createUser("U5"),
+    ]);
+
+    const round = await prisma.round.create({
+      data: {
+        arenaId: arena.id,
+        roundNumber: 1,
+        state: "RESOLVED",
+        metadata: {
+          playerChoices: users.map((u) => ({ userId: u.id, stake: 50 })),
+          oracleYield: 5,
+        },
+      },
+    });
+
+    // Eliminate 3 of the 5 players.
+    await prisma.eliminationLog.createMany({
+      data: [
+        { roundId: round.id, userId: users[2].id, reason: "wrong choice" },
+        { roundId: round.id, userId: users[3].id, reason: "wrong choice" },
+        { roundId: round.id, userId: users[4].id, reason: "wrong choice" },
+      ],
+    });
+
+    try {
+      const stats = await service.getArenaStats(arena.id);
+
+      expect(stats.playerCount).toBe(5);
+      expect(stats.survivorCount).toBe(2);
+      expect(stats.currentRound).toBe(1);
+      expect(stats.status).toBe("resolved");
+    } finally {
+      await cleanup(arena.id);
+      await cleanupUsers(users.map((u) => u.id));
+    }
+  });
+
+  it("accumulates yield across multiple resolved rounds", async () => {
+    if (!process.env.DATABASE_URL) return;
+
+    const arena = await createArena(100);
+    const users = await Promise.all([
+      createUser("Y1"),
+      createUser("Y2"),
+    ]);
+
+    for (let i = 1; i <= 3; i++) {
+      await prisma.round.create({
+        data: {
+          arenaId: arena.id,
+          roundNumber: i,
+          state: "RESOLVED",
+          metadata: {
+            playerChoices: users.map((u) => ({ userId: u.id, stake: 100 })),
+            oracleYield: 10,
+          },
+        },
+      });
+    }
+
+    try {
+      const stats = await service.getArenaStats(arena.id);
+
+      expect(stats.yieldAccrued).toBeCloseTo(30);
+      expect(stats.currentRound).toBe(3);
+    } finally {
+      await cleanup(arena.id);
+      await cleanupUsers(users.map((u) => u.id));
+    }
+  });
+
+  it("does not count yield from rounds that are not yet RESOLVED", async () => {
+    if (!process.env.DATABASE_URL) return;
+
+    const arena = await createArena(100);
+    const user = await createUser("NR1");
+
+    // One resolved round with yield, one open round without.
+    await prisma.round.create({
+      data: {
+        arenaId: arena.id,
+        roundNumber: 1,
+        state: "RESOLVED",
+        metadata: {
+          playerChoices: [{ userId: user.id, stake: 100 }],
+          oracleYield: 20,
+        },
+      },
+    });
+    await prisma.round.create({
+      data: {
+        arenaId: arena.id,
+        roundNumber: 2,
+        state: "OPEN",
+        metadata: {
+          playerChoices: [{ userId: user.id, stake: 100 }],
+          oracleYield: 999,
+        },
+      },
+    });
+
+    try {
+      const stats = await service.getArenaStats(arena.id);
+
+      expect(stats.yieldAccrued).toBeCloseTo(20);
+    } finally {
+      await cleanup(arena.id);
+      await cleanupUsers([user.id]);
+    }
+  });
+
+  it("throws a not-found error for an unknown arena ID", async () => {
+    await expect(
+      service.getArenaStats("00000000-0000-0000-0000-000000000000"),
+    ).rejects.toThrow(/not found/i);
+  });
+});

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -16,6 +16,7 @@
  */
 
 import * as Sentry from "@sentry/nextjs";
+import { scrubStellarAddresses } from "./src/lib/sentry";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -51,6 +52,9 @@ Sentry.init({
       const { id } = event.user;
       event.user = id ? { id } : undefined;
     }
-    return event;
+
+    // Scrub Stellar wallet addresses from all event fields to prevent
+    // linking on-chain identities to Sentry sessions.
+    return scrubStellarAddresses(event);
   },
 });

--- a/frontend/src/features/wallet/__tests__/useStellarWallet.test.ts
+++ b/frontend/src/features/wallet/__tests__/useStellarWallet.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react";
+import { Networks } from "@creit-tech/stellar-wallets-kit";
+import { isValidStellarPublicKey } from "../useStellarWallet";
+
+// ── isValidStellarPublicKey unit tests ────────────────────────────────────────
+
+describe("isValidStellarPublicKey", () => {
+  it("accepts a well-formed Stellar public key", () => {
+    expect(
+      isValidStellarPublicKey(
+        "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidStellarPublicKey("")).toBe(false);
+  });
+
+  it("rejects a key that starts with S (secret key)", () => {
+    expect(
+      isValidStellarPublicKey(
+        "SCZANGBA5RLMPI7JMILTKOMVHI3NZYDGRQV3SCYIMHZJHQHCQTJCHLHC",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a key that is too short (55 chars after G)", () => {
+    expect(isValidStellarPublicKey("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHON")).toBe(
+      false,
+    );
+  });
+
+  it("rejects a key that is too long (57 chars after G)", () => {
+    expect(
+      isValidStellarPublicKey(
+        "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2HXX",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a key containing lowercase characters", () => {
+    expect(
+      isValidStellarPublicKey(
+        "Gbrpyhil2ci3fnq4bxlfmndlfjunpu2hy3zmfshonuceoasw7qc7ox2h",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects an HTML-like string that could cause XSS", () => {
+    expect(isValidStellarPublicKey("<img src=x onerror=alert(1)>")).toBe(false);
+  });
+
+  it("rejects a key with invalid base32 characters (lowercase digits)", () => {
+    expect(
+      isValidStellarPublicKey(
+        "G1111111111111111111111111111111111111111111111111111111",
+      ),
+    ).toBe(false);
+  });
+});
+
+// ── useStellarWallet integration tests ───────────────────────────────────────
+
+jest.mock("@creit-tech/stellar-wallets-kit", () => ({
+  StellarWalletsKit: {
+    init: jest.fn(),
+    authModal: jest.fn(),
+    disconnect: jest.fn(),
+  },
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+}));
+
+jest.mock("@creit-tech/stellar-wallets-kit/modules/freighter", () => ({
+  FreighterModule: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock("@creit-tech/stellar-wallets-kit/modules/xbull", () => ({
+  xBullModule: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock("@creit-tech/stellar-wallets-kit/modules/albedo", () => ({
+  AlbedoModule: jest.fn().mockImplementation(() => ({})),
+}));
+
+// Import after mocks are set up
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { StellarWalletsKit } = require("@creit-tech/stellar-wallets-kit");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { useStellarWallet } = require("../useStellarWallet");
+
+const VALID_KEY = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+const INVALID_KEY = "not-a-valid-key";
+const SHORT_KEY = "GSHORT";
+
+describe("useStellarWallet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("starts in disconnected state", () => {
+    const { result } = renderHook(() =>
+      useStellarWallet(Networks.TESTNET),
+    );
+    expect(result.current.status).toBe("disconnected");
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets connected state when wallet returns a valid public key", async () => {
+    StellarWalletsKit.authModal.mockResolvedValue({ address: VALID_KEY });
+
+    const { result } = renderHook(() =>
+      useStellarWallet(Networks.TESTNET),
+    );
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.status).toBe("connected");
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.publicKey).toBe(VALID_KEY);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error state when wallet returns an invalid public key", async () => {
+    StellarWalletsKit.authModal.mockResolvedValue({ address: INVALID_KEY });
+
+    const { result } = renderHook(() =>
+      useStellarWallet(Networks.TESTNET),
+    );
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.error).toMatch(/invalid public key/i);
+  });
+
+  it("sets error state when wallet returns a shortened (xBull edge-case) key", async () => {
+    StellarWalletsKit.authModal.mockResolvedValue({ address: SHORT_KEY });
+
+    const { result } = renderHook(() =>
+      useStellarWallet(Networks.TESTNET),
+    );
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+  });
+
+  it("sets error state when wallet returns an HTML-like string", async () => {
+    StellarWalletsKit.authModal.mockResolvedValue({
+      address: "<script>alert('xss')</script>",
+    });
+
+    const { result } = renderHook(() =>
+      useStellarWallet(Networks.TESTNET),
+    );
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+  });
+
+  it("sets error state when authModal throws", async () => {
+    StellarWalletsKit.authModal.mockRejectedValue(
+      new Error("User cancelled"),
+    );
+
+    const { result } = renderHook(() =>
+      useStellarWallet(Networks.TESTNET),
+    );
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.error).toBe("User cancelled");
+  });
+
+  it("resets to disconnected state on disconnectWallet", async () => {
+    StellarWalletsKit.authModal.mockResolvedValue({ address: VALID_KEY });
+
+    const { result } = renderHook(() =>
+      useStellarWallet(Networks.TESTNET),
+    );
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    act(() => {
+      result.current.disconnectWallet();
+    });
+
+    expect(result.current.status).toBe("disconnected");
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+  });
+});

--- a/frontend/src/features/wallet/useStellarWallet.ts
+++ b/frontend/src/features/wallet/useStellarWallet.ts
@@ -1,4 +1,4 @@
-import { ISupportedWallet, StellarWalletsKit, Networks } from "@creit-tech/stellar-wallets-kit";
+import { StellarWalletsKit, Networks } from "@creit-tech/stellar-wallets-kit";
 import { FreighterModule } from "@creit-tech/stellar-wallets-kit/modules/freighter";
 import { xBullModule } from "@creit-tech/stellar-wallets-kit/modules/xbull";
 import { AlbedoModule } from "@creit-tech/stellar-wallets-kit/modules/albedo";
@@ -13,6 +13,13 @@ export interface WalletHook {
   error: string | null;
   connectWallet: () => Promise<void>;
   disconnectWallet: () => void;
+}
+
+// Stellar public keys start with G and are exactly 56 alphanumeric (base32) characters.
+const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+
+export function isValidStellarPublicKey(address: string): boolean {
+  return STELLAR_PUBLIC_KEY_REGEX.test(address);
 }
 
 /**
@@ -42,6 +49,15 @@ export const useStellarWallet = (network: Networks): WalletHook => {
       setStatus('connecting');
       setError(null);
       const { address } = await StellarWalletsKit.authModal();
+
+      if (!isValidStellarPublicKey(address)) {
+        setIsConnected(false);
+        setPublicKey(null);
+        setStatus('error');
+        setError('Wallet returned an invalid public key. Please try reconnecting.');
+        return;
+      }
+
       setPublicKey(address);
       setIsConnected(true);
       setStatus('connected');

--- a/frontend/src/lib/__tests__/sentry.test.ts
+++ b/frontend/src/lib/__tests__/sentry.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "@jest/globals";
+import { scrubStellarAddresses } from "../sentry";
+import type { Event as SentryEvent } from "@sentry/nextjs";
+
+const PUBLIC_KEY = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+const PUBLIC_KEY_2 = "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV6NOQHM3OK7";
+// A well-formed S… key (not a real secret, used for test assertions only).
+const SECRET_KEY = "SCZANGBA5RLMPI7JMILTKOMVHI3NZYDGRQV3SCYIMHZJHQHCQTJCHLIT";
+
+function makeEvent(overrides: Partial<SentryEvent> = {}): SentryEvent {
+  return { event_id: "abc123", ...overrides };
+}
+
+describe("scrubStellarAddresses", () => {
+  it("returns an event unchanged when no wallet addresses are present", () => {
+    const event = makeEvent({
+      exception: {
+        values: [{ type: "Error", value: "Something went wrong" }],
+      },
+    });
+    const result = scrubStellarAddresses(event);
+    expect(result).not.toBeNull();
+    expect(result!.exception!.values![0].value).toBe("Something went wrong");
+  });
+
+  it("replaces a public key in an exception value", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          { type: "Error", value: `Failed to submit choice for ${PUBLIC_KEY}` },
+        ],
+      },
+    });
+    const result = scrubStellarAddresses(event);
+    expect(result).not.toBeNull();
+    expect(result!.exception!.values![0].value).toBe(
+      "Failed to submit choice for [STELLAR_ADDRESS]",
+    );
+  });
+
+  it("replaces multiple public keys in exception values", () => {
+    const event = makeEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: `Transfer from ${PUBLIC_KEY} to ${PUBLIC_KEY_2} failed`,
+          },
+        ],
+      },
+    });
+    const result = scrubStellarAddresses(event);
+    expect(result!.exception!.values![0].value).toBe(
+      "Transfer from [STELLAR_ADDRESS] to [STELLAR_ADDRESS] failed",
+    );
+  });
+
+  it("replaces a public key in a breadcrumb message", () => {
+    const event = makeEvent({
+      breadcrumbs: {
+        values: [
+          { type: "default", message: `Wallet connected: ${PUBLIC_KEY}` },
+        ],
+      },
+    });
+    const result = scrubStellarAddresses(event);
+    expect(result!.breadcrumbs!.values![0].message).toBe(
+      "Wallet connected: [STELLAR_ADDRESS]",
+    );
+  });
+
+  it("replaces a public key embedded in a breadcrumb URL", () => {
+    const event = makeEvent({
+      breadcrumbs: {
+        values: [
+          {
+            type: "navigation",
+            data: { url: `/arena/${PUBLIC_KEY}/stats` },
+          },
+        ],
+      },
+    });
+    const result = scrubStellarAddresses(event);
+    expect(result!.breadcrumbs!.values![0].data!.url).toBe(
+      "/arena/[STELLAR_ADDRESS]/stats",
+    );
+  });
+
+  it("drops the event entirely when a secret key is present anywhere", () => {
+    const event = makeEvent({
+      exception: {
+        values: [{ type: "Error", value: `Secret leaked: ${SECRET_KEY}` }],
+      },
+    });
+    const result = scrubStellarAddresses(event);
+    expect(result).toBeNull();
+  });
+
+  it("drops the event when the secret key appears only in extra data", () => {
+    const event = makeEvent({
+      extra: { debug: SECRET_KEY },
+    });
+    expect(scrubStellarAddresses(event)).toBeNull();
+  });
+
+  it("handles events with no exception or breadcrumbs gracefully", () => {
+    const event = makeEvent();
+    const result = scrubStellarAddresses(event);
+    expect(result).not.toBeNull();
+    expect(result!.event_id).toBe("abc123");
+  });
+
+  it("handles breadcrumbs with no message or url without throwing", () => {
+    const event = makeEvent({
+      breadcrumbs: {
+        values: [{ type: "default" }],
+      },
+    });
+    expect(() => scrubStellarAddresses(event)).not.toThrow();
+  });
+});

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -13,6 +13,59 @@
 
 import * as Sentry from "@sentry/nextjs";
 import type { ErrorInfo } from "react";
+import type { Event as SentryEvent } from "@sentry/nextjs";
+
+// Matches any Stellar public key (G + 55 base32 chars) anywhere in a string.
+const STELLAR_PUBLIC_KEY_REGEX = /G[A-Z2-7]{55}/g;
+// Matches any Stellar secret key (S + 55 base32 chars). Events containing
+// these are dropped entirely — they should never appear in error reports.
+const STELLAR_SECRET_KEY_REGEX = /S[A-Z2-7]{55}/g;
+
+/**
+ * Replace all Stellar public keys in `text` with the placeholder
+ * `[STELLAR_ADDRESS]`. Returns the original value if it is not a string.
+ */
+function redactPublicKeys(text: string): string {
+  return text.replace(STELLAR_PUBLIC_KEY_REGEX, "[STELLAR_ADDRESS]");
+}
+
+/**
+ * Scrub Stellar wallet addresses from a Sentry event before it is sent.
+ *
+ * - Public keys (G…) are replaced with `[STELLAR_ADDRESS]` in exception
+ *   values, breadcrumb messages, and breadcrumb URLs.
+ * - If a secret key (S…) appears anywhere in the serialised event the entire
+ *   event is dropped (returns `null`) as a belt-and-suspenders safeguard.
+ */
+export function scrubStellarAddresses(event: SentryEvent): SentryEvent | null {
+  // Belt-and-suspenders: drop the event entirely if a secret key leaks.
+  if (STELLAR_SECRET_KEY_REGEX.test(JSON.stringify(event))) {
+    return null;
+  }
+
+  // Scrub exception values (error messages / descriptions).
+  if (event.exception?.values) {
+    for (const ex of event.exception.values) {
+      if (ex.value) {
+        ex.value = redactPublicKeys(ex.value);
+      }
+    }
+  }
+
+  // Scrub breadcrumb messages and navigation URLs.
+  if (event.breadcrumbs?.values) {
+    for (const breadcrumb of event.breadcrumbs.values) {
+      if (breadcrumb.message) {
+        breadcrumb.message = redactPublicKeys(breadcrumb.message);
+      }
+      if (breadcrumb.data?.url && typeof breadcrumb.data.url === "string") {
+        breadcrumb.data.url = redactPublicKeys(breadcrumb.data.url);
+      }
+    }
+  }
+
+  return event;
+}
 
 const SENTRY_ENABLED =
   typeof process !== "undefined" &&


### PR DESCRIPTION
## Summary

This PR addresses four issues spanning security hardening and test coverage:

- **#688** — Validate Stellar public key format in the frontend before sending to the API
- **#690** — Unit tests for `ArenaStatsService.getArenaStats` covering zero-round, single-round, and multi-round arenas
- **#692** — Integration tests verifying the rate limiter returns 429 with `Retry-After` after the configured limit is exceeded
- **#693** — Sentry `beforeSend` scrubber extended to strip wallet addresses from breadcrumb URLs and event descriptions

---

### #688 – Wallet public key format validation (`useStellarWallet`)

**Files changed:**
- `frontend/src/features/wallet/useStellarWallet.ts`
- `frontend/src/features/wallet/__tests__/useStellarWallet.test.ts` *(new)*

`STELLAR_PUBLIC_KEY_REGEX` (`/^G[A-Z2-7]{55}$/`) is applied immediately after `StellarWalletsKit.authModal()` returns. If the address fails validation the hook sets `status: 'error'` with a user-facing message and returns early — the invalid value never reaches state or the API. An exported `isValidStellarPublicKey` helper is reusable in other components.

Unit tests cover: valid key, empty string, secret key, shortened key (xBull edge case), too-long key, lowercase key, HTML/XSS payload, `authModal` throwing, and the full connect/disconnect lifecycle via mocked `StellarWalletsKit`.

---

### #690 – `ArenaStatsService` unit tests

**Files changed:**
- `backend/tests/arenaStats.unit.test.ts` *(new)*
- `backend/jest.config.js` — adds `tests/` to Jest roots so `npm run test:ci` picks up the file

Four test cases using a real Prisma client against the CI Postgres instance (guarded by `process.env.DATABASE_URL`):
1. **Zero rounds** — `currentRound === 0`, `playerCount === 0`, `status === 'pending'`
2. **First round with eliminations** — correct `playerCount`, `survivorCount`, `currentRound`
3. **Multi-round yield accumulation** — `yieldAccrued` sums only `RESOLVED` rounds (belt-and-suspenders test also verifies `OPEN` rounds are excluded)
4. **Unknown arena ID** — throws `/not found/i`

Each test seeds its own data and cleans up in a `finally` block.

---

### #692 – Rate-limit middleware and integration tests

**Files changed:**
- `backend/src/middleware/rateLimit.ts` *(new)* — `rate-limiter-flexible`-backed middleware (Redis with in-memory fallback), env-var configurable, keyed by `ip:wallet`
- `backend/src/routes/auth.ts` — `nonceRateLimiter` applied to `POST /nonce`
- `backend/src/routes/pools.ts` — `poolsRateLimiter` applied to `POST /pools` (new endpoint added); `POST /api/pools` also added to support pool creation
- `backend/test/integration/rateLimit.test.ts` *(new)*
- `backend/package.json` — adds `rate-limiter-flexible ^8.2.1`

Integration test suite (`describe` per route, each with an isolated IP and prefix):
- Requests up to the configured limit are **not** 429
- The request immediately after the limit returns **429** with `Retry-After ≥ 1`
- A different wallet address on the same IP has its **own bucket**
- A different IP is **not affected** by the exhausted limit
- `clearLimiterCache()` resets state between suites

---

### #693 – Sentry `beforeSend` scrubber

**Files changed:**
- `frontend/src/lib/sentry.ts` — new exported `scrubStellarAddresses(event)` function
- `frontend/sentry.client.config.ts` — `beforeSend` now calls `scrubStellarAddresses`
- `frontend/src/lib/__tests__/sentry.test.ts` *(new)*

Scrubbing logic:
- `G[A-Z2-7]{55}` anywhere in exception values / breadcrumb messages / breadcrumb URLs → replaced with `[STELLAR_ADDRESS]`
- `S[A-Z2-7]{55}` anywhere in the serialised event → event **dropped** (`return null`)
- Events with no wallet addresses pass through unchanged

Unit tests cover all paths: no addresses, single public key in exception, multiple keys, key in breadcrumb message, key in breadcrumb URL, secret key anywhere (event dropped), and edge cases (missing message/url fields).

---

## Test plan

- [ ] `cd backend && npm run test:ci` — all Jest suites pass (requires Postgres + Redis in CI, matching the `backend-ci.yml` workflow)
- [ ] `cd frontend && npm run test:frontend` — wallet and Sentry unit tests pass
- [ ] Manually connect a wallet on testnet — valid key connects normally, disconnected gracefully on cancellation
- [ ] Confirm Sentry events in staging contain `[STELLAR_ADDRESS]` instead of real keys in error messages and breadcrumb URLs

Closes #688
Closes #690
Closes #692
Closes #693