### PR TITLE
fix: use timingSafeEqual for admin API key comparison

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/inversearena?schema=p
 MONGODB_URI=mongodb://localhost:27017/inversearena
 
 # Admin auth
+# Must be ≥32 characters (enforced at startup) to resist timing attacks
 ADMIN_API_KEY=change-me-in-production
 ADMIN_TOKEN_TTL_SECONDS=900
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "crypto";
 import type { Request, Response, NextFunction, RequestHandler } from "express";
 import type { AuthService } from "../services/authService";
 
@@ -44,13 +45,17 @@ export class ApiKeyAuthProvider implements AdminAuthProvider {
   constructor() {
     const key = process.env.ADMIN_API_KEY;
     if (!key) throw new Error("ADMIN_API_KEY environment variable is required");
+    if (key.length < 32) {
+      throw new Error("ADMIN_API_KEY must be at least 32 characters to resist brute-force and timing attacks");
+    }
     this.apiKey = key;
   }
 
   async isAdmin(req: Request): Promise<boolean> {
     const header = req.headers.authorization ?? "";
     const token = header.startsWith("Bearer ") ? header.slice(7) : "";
-    return token === this.apiKey;
+    if (!token || token.length !== this.apiKey.length) return false;
+    return timingSafeEqual(Buffer.from(token), Buffer.from(this.apiKey));
   }
 
   getAdminId(req: Request): string {

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 process.env.JWT_SECRET = "super-secret-test-key-must-be-at-least-32-chars";
 process.env.NONCE_TTL_SECONDS = "300";
-process.env.ADMIN_API_KEY = "test-admin-key";
+process.env.ADMIN_API_KEY = "test-admin-key-at-least-32-chars-long";
 process.env.MONGOMS_MD5_CHECK = "0";
 
 import { redis } from "../src/cache/redisClient";

--- a/backend/tests/auth-middleware.unit.test.ts
+++ b/backend/tests/auth-middleware.unit.test.ts
@@ -1,0 +1,81 @@
+import { test, mock, afterEach, describe } from "node:test";
+import assert from "node:assert";
+import { Request } from "express";
+import { ApiKeyAuthProvider } from "../src/middleware/auth";
+
+const VALID_KEY = "a-32-character-long-admin-api-key!!";
+
+function fakeRequest(authHeader?: string): Request {
+  return {
+    headers: authHeader ? { authorization: authHeader } : {},
+  } as Request;
+}
+
+describe("ApiKeyAuthProvider", () => {
+  afterEach(() => {
+    delete process.env.ADMIN_API_KEY;
+    mock.reset();
+  });
+
+  describe("constructor", () => {
+    test("throws when ADMIN_API_KEY is not set", () => {
+      assert.throws(() => new ApiKeyAuthProvider(), {
+        message: "ADMIN_API_KEY environment variable is required",
+      });
+    });
+
+    test("throws when ADMIN_API_KEY is shorter than 32 characters", () => {
+      process.env.ADMIN_API_KEY = "too-short";
+      assert.throws(() => new ApiKeyAuthProvider(), {
+        message: /at least 32 characters/,
+      });
+    });
+
+    test("does not throw when ADMIN_API_KEY is 32+ characters", () => {
+      process.env.ADMIN_API_KEY = VALID_KEY;
+      assert.doesNotThrow(() => new ApiKeyAuthProvider());
+    });
+  });
+
+  describe("isAdmin", () => {
+    test("returns true for the correct key", async () => {
+      process.env.ADMIN_API_KEY = VALID_KEY;
+      const provider = new ApiKeyAuthProvider();
+      const req = fakeRequest(`Bearer ${VALID_KEY}`);
+      const result = await provider.isAdmin(req);
+      assert.strictEqual(result, true);
+    });
+
+    test("returns false for an incorrect key", async () => {
+      process.env.ADMIN_API_KEY = VALID_KEY;
+      const provider = new ApiKeyAuthProvider();
+      const req = fakeRequest("Bearer wrong-key-with-same-length-12345");
+      const result = await provider.isAdmin(req);
+      assert.strictEqual(result, false);
+    });
+
+    test("returns false for mismatched-length token without throwing", async () => {
+      process.env.ADMIN_API_KEY = VALID_KEY;
+      const provider = new ApiKeyAuthProvider();
+      const req = fakeRequest("Bearer short");
+      const result = await provider.isAdmin(req);
+      assert.strictEqual(result, false);
+    });
+
+    test("returns false for empty token without throwing", async () => {
+      process.env.ADMIN_API_KEY = VALID_KEY;
+      const provider = new ApiKeyAuthProvider();
+      const req = fakeRequest("Bearer ");
+      const result = await provider.isAdmin(req);
+      assert.strictEqual(result, false);
+    });
+
+    test("returns false when there is no Authorization header", async () => {
+      process.env.ADMIN_API_KEY = VALID_KEY;
+      const provider = new ApiKeyAuthProvider();
+      const req = fakeRequest();
+      const result = await provider.isAdmin(req);
+      assert.strictEqual(result, false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #626

---

## Summary

Replaces \===\ string equality with \crypto.timingSafeEqual\ in \ApiKeyAuthProvider.isAdmin\ to prevent timing attacks against the admin API key.

## Changes

- **\ackend/src/middleware/auth.ts\**: Import \	imingSafeEqual\ from \crypto\, validate \ADMIN_API_KEY\ minimum length (≥32 chars) in constructor, and use constant-time comparison in \isAdmin\ with a length guard to prevent the underlying API from throwing on mismatched-length inputs.
- **\ackend/.env.example\**: Document the 32-character minimum requirement.
- **\ackend/test/setup.ts\**: Update test key to meet the new 32-character minimum.
- **\ackend/tests/auth-middleware.unit.test.ts\**: Add 8 unit tests covering constructor validation and constant-time token comparison, including the mismatched-length-no-throw case.

## Verification

- All 8 new unit tests pass (Node built-in test runner)
- No new TypeScript compilation errors introduced
- Existing tests continue to work (test setup key updated)