### PR TITLE
feat: implement RWA vault deposit on player join via Stellar Asset Contract + persist round state

### DIFF
--- a/backend/src/repositories/roundRepository.ts
+++ b/backend/src/repositories/roundRepository.ts
@@ -17,7 +17,7 @@ export class RoundRepository {
       id: round.id,
       arenaId: round.arenaId,
       roundNumber: round.roundNumber,
-      state: RoundState.OPEN,
+      state: round.state as RoundState,
       playerChoices: [],
       createdAt: round.createdAt,
       updatedAt: round.updatedAt,
@@ -35,7 +35,7 @@ export class RoundRepository {
       id: round.id,
       arenaId: round.arenaId,
       roundNumber: round.roundNumber,
-      state: RoundState.OPEN,
+      state: round.state as RoundState,
       playerChoices: [],
       createdAt: round.createdAt,
       updatedAt: round.updatedAt,
@@ -45,7 +45,7 @@ export class RoundRepository {
   async updateState(roundId: string, state: RoundState): Promise<void> {
     await this.prisma.round.update({
       where: { id: roundId },
-      data: { updatedAt: new Date() },
+      data: { state, updatedAt: new Date() },
     });
   }
 


### PR DESCRIPTION
Closes #627

---

## Summary

This PR combines two changes:

### 1. RWA vault deposit on player join via Stellar Asset Contract

Implements the core yield-bearing mechanism for Inverse Arena.

**New: \contracts/rwa-adapter/\**
- Adapter contract with deposit tracking, yield accrual (5% simulated), and withdrawal
- RwaConfig, YieldAccrual, RwaError types with persistent storage

**Updated: \contracts/arena/\**
- \	ypes.rs\: Added \yield_vault\ and \ound_count\ to \ArenaConfig\, \GameState::Settled\, \YieldSnapshot\, and new error variants
- \storage.rs\: Yield snapshot persistence and initialization guards
- \lib.rs\: \initialize()\, \join()\ with SAC transfer + vault deposit, \esolve_round()\, \claim()\ with vault withdrawal + yield snapshot

**Flow:**
1. **Join**: Player SAC transfer → arena → vault deposit via adapter
2. **Claim**: Vault withdrawal → arena → winner payout with yield snapshot

### 2. Persist state field in RoundRepository

Fixes round state persistence in updateState, findById, and create methods.