### PR TITLE
feat: implement arena config and creator stake flow

### DIFF
--- a/backend/grafana-dashboard.json
+++ b/backend/grafana-dashboard.json
@@ -61,6 +61,46 @@
             "legendFormat": "p95"
           }
         ]
+      },
+      {
+        "title": "Active Arenas",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "inversearena_arenas_active_total",
+            "legendFormat": "active arenas"
+          }
+        ]
+      },
+      {
+        "title": "Arena State Transitions",
+        "type": "graph",
+        "targets": [
+          {
+            "expr": "rate(inversearena_arena_state_transitions_total[5m])",
+            "legendFormat": "{{from_state}} -> {{to_state}}"
+          }
+        ]
+      },
+      {
+        "title": "Players Eliminated",
+        "type": "graph",
+        "targets": [
+          {
+            "expr": "rate(inversearena_players_eliminated_total[5m])",
+            "legendFormat": "eliminations"
+          }
+        ]
+      },
+      {
+        "title": "Payout Success Rate",
+        "type": "graph",
+        "targets": [
+          {
+            "expr": "rate(inversearena_payouts_success_total[5m])",
+            "legendFormat": "{{asset}}"
+          }
+        ]
       }
     ],
     "refresh": "10s",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,7 +19,7 @@ import { UsersController } from "./controllers/users.controller";
 import { LeaderboardController } from "./controllers/leaderboard.controller";
 import { TransactionsController } from "./controllers/transactions.controller";
 import { RoundController } from "./controllers/round.controller";
-import { register } from "./utils/metrics";
+import { refreshArenaMetrics, register } from "./utils/metrics";
 import type { PaymentService } from "./services/paymentService";
 import type { PaymentWorker } from "./workers/paymentWorker";
 import type { TransactionRepository } from "./repositories/transactionRepository";
@@ -51,6 +51,11 @@ export function createApp(deps: AppDependencies): express.Application {
   });
 
   app.get("/metrics", async (_req, res) => {
+    try {
+      await refreshArenaMetrics(prisma);
+    } catch {
+      // Keep the metrics endpoint available even if the database is degraded.
+    }
     res.set("Content-Type", register.contentType);
     res.send(await register.metrics());
   });

--- a/backend/src/repositories/roundRepository.ts
+++ b/backend/src/repositories/roundRepository.ts
@@ -1,5 +1,10 @@
-import { PrismaClient } from '@prisma/client';
-import type { RoundData, PlayerChoice, RoundResolution } from '../types/round';
+import { Prisma, PrismaClient } from '@prisma/client';
+import type {
+  PaginatedResult,
+  RoundData,
+  RoundMetadata,
+  RoundResolution,
+} from '../types/round';
 import { RoundState } from '../types/round';
 
 export class RoundRepository {
@@ -14,13 +19,7 @@ export class RoundRepository {
     });
 
     return {
-      id: round.id,
-      arenaId: round.arenaId,
-      roundNumber: round.roundNumber,
-      state: RoundState.OPEN,
-      playerChoices: [],
-      createdAt: round.createdAt,
-      updatedAt: round.updatedAt,
+      ...this.mapRound(round),
     };
   }
 
@@ -31,31 +30,162 @@ export class RoundRepository {
 
     if (!round) return null;
 
-    return {
-      id: round.id,
-      arenaId: round.arenaId,
-      roundNumber: round.roundNumber,
-      state: RoundState.OPEN,
-      playerChoices: [],
-      createdAt: round.createdAt,
-      updatedAt: round.updatedAt,
-    };
+    return this.mapRound(round);
   }
 
   async updateState(roundId: string, state: RoundState): Promise<void> {
     await this.prisma.round.update({
       where: { id: roundId },
-      data: { updatedAt: new Date() },
+      data: {
+        state,
+        updatedAt: new Date(),
+      },
     });
   }
 
-  async saveResolution(roundId: string, resolution: RoundResolution): Promise<void> {
-    await this.prisma.eliminationLog.createMany({
-      data: resolution.eliminatedPlayers.map(userId => ({
-        roundId,
-        userId,
-        reason: 'ELIMINATED_BY_ROUND',
-      })),
+  async saveResolution(
+    roundId: string,
+    resolution: RoundResolution,
+    metadata: RoundMetadata,
+  ): Promise<void> {
+    await this.prisma.round.update({
+      where: { id: roundId },
+      data: {
+        metadata: this.toJsonMetadata({
+          ...metadata,
+          resolution,
+        }),
+        updatedAt: new Date(),
+      },
     });
+
+    if (resolution.eliminatedPlayers.length > 0) {
+      await this.prisma.eliminationLog.createMany({
+        data: resolution.eliminatedPlayers.map((userId) => ({
+          roundId,
+          userId,
+          reason: 'ELIMINATED_BY_ROUND',
+        })),
+      });
+    }
+  }
+
+  async listByArenaId(
+    arenaId: string,
+    limit: number,
+    cursor?: string,
+  ): Promise<PaginatedResult<RoundData>> {
+    const rounds = await this.prisma.round.findMany({
+      where: { arenaId },
+      orderBy: [{ roundNumber: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      ...(cursor
+        ? {
+            skip: 1,
+            cursor: { id: cursor },
+          }
+        : {}),
+    });
+
+    const hasMore = rounds.length > limit;
+    const items = rounds.slice(0, limit).map((round) => this.mapRound(round));
+
+    return {
+      items,
+      cursor: hasMore ? items[items.length - 1]?.id ?? null : null,
+      hasMore,
+    };
+  }
+
+  async findByArenaAndNumber(
+    arenaId: string,
+    roundNumber: number,
+  ): Promise<RoundData | null> {
+    const round = await this.prisma.round.findUnique({
+      where: {
+        arenaId_roundNumber: {
+          arenaId,
+          roundNumber,
+        },
+      },
+    });
+
+    return round ? this.mapRound(round) : null;
+  }
+
+  async resolveAtomically(
+    roundId: string,
+    state: RoundState,
+    resolution: RoundResolution,
+    metadata: RoundMetadata,
+  ): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      if (resolution.eliminatedPlayers.length > 0) {
+        await tx.eliminationLog.createMany({
+          data: resolution.eliminatedPlayers.map((userId) => ({
+            roundId,
+            userId,
+            reason: 'ELIMINATED_BY_ROUND',
+          })),
+        });
+      }
+
+      await tx.round.update({
+        where: { id: roundId },
+        data: {
+          state,
+          metadata: this.toJsonMetadata({
+            ...metadata,
+            resolution,
+          }),
+          updatedAt: new Date(),
+        },
+      });
+    });
+  }
+
+  private mapRound(round: {
+    id: string;
+    arenaId: string;
+    roundNumber: number;
+    state: string;
+    metadata: Prisma.JsonValue | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): RoundData {
+    const metadata = this.fromJsonMetadata(round.metadata);
+
+    return {
+      id: round.id,
+      arenaId: round.arenaId,
+      roundNumber: round.roundNumber,
+      state: this.parseState(round.state),
+      playerChoices: metadata?.playerChoices ?? [],
+      oracleYield: metadata?.oracleYield,
+      randomSeed: metadata?.randomSeed,
+      resolution: metadata?.resolution,
+      metadata: metadata ?? undefined,
+      createdAt: round.createdAt,
+      updatedAt: round.updatedAt,
+    };
+  }
+
+  private parseState(state: string): RoundState {
+    if (Object.values(RoundState).includes(state as RoundState)) {
+      return state as RoundState;
+    }
+    return RoundState.OPEN;
+  }
+
+  private fromJsonMetadata(metadata: Prisma.JsonValue | null): RoundMetadata | null {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return null;
+    }
+
+    return metadata as unknown as RoundMetadata;
+  }
+
+  private toJsonMetadata(metadata: RoundMetadata): Prisma.InputJsonValue {
+    return JSON.parse(JSON.stringify(metadata)) as Prisma.InputJsonValue;
   }
 }

--- a/backend/src/services/paymentService.ts
+++ b/backend/src/services/paymentService.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 
 import { getPaymentConfig, type PaymentConfig } from "../config/paymentConfig";
 import type { TransactionRepository } from "../repositories/transactionRepository";
+import { payoutsSuccessTotal } from "../utils/metrics";
 import type {
   BuildPayoutResult,
   CreatePayoutRequest,
@@ -255,6 +256,7 @@ export class PaymentService {
     const onChain = await this.rpcServer.getTransaction(transaction.txHash);
 
     if (onChain.status === Api.GetTransactionStatus.SUCCESS) {
+      payoutsSuccessTotal.inc({ asset: transaction.asset });
       return this.transactions.update(transaction.id, {
         status: "confirmed",
         confirmedAt: new Date(),

--- a/backend/src/services/roundService.ts
+++ b/backend/src/services/roundService.ts
@@ -1,8 +1,14 @@
 import { PrismaClient } from '@prisma/client';
 import { RoundRepository } from '../repositories/roundRepository';
-import type { RoundInput, RoundResolution, Payout } from '../types/round';
+import type { RoundInput, RoundMetadata, RoundResolution, Payout } from '../types/round';
 import { RoundState } from '../types/round';
-import { roundResolutionsTotal, roundResolutionDuration } from '../utils/metrics';
+import {
+  arenaStateTransitionsTotal,
+  playersEliminatedTotal,
+  refreshArenaMetrics,
+  roundResolutionsTotal,
+  roundResolutionDuration,
+} from '../utils/metrics';
 
 export class RoundService {
   private roundRepo: RoundRepository;
@@ -15,58 +21,50 @@ export class RoundService {
     const start = Date.now();
 
     try {
-      const result = await this.prisma.$transaction(async (tx: any) => {
-        const round = await tx.round.findUnique({
-          where: { id: input.roundId },
-          include: { eliminationLogs: true },
-        });
+      const round = await this.roundRepo.findById(input.roundId);
+      if (!round) throw new Error('Round not found');
+      if (round.state !== RoundState.OPEN && round.state !== RoundState.CLOSED) {
+        throw new Error(`Round already in state: ${round.state}`);
+      }
 
-        if (!round) throw new Error('Round not found');
-        if (round.state !== RoundState.OPEN && round.state !== RoundState.CLOSED) {
-          throw new Error(`Round already in state: ${round.state}`);
-        }
+      const eliminatedPlayers = this.computeEliminations(
+        input.playerChoices,
+        input.oracleYield,
+        input.randomSeed
+      );
 
-        const eliminatedPlayers = this.computeEliminations(
-          input.playerChoices,
-          input.oracleYield,
-          input.randomSeed
-        );
+      const payouts = this.computePayouts(
+        input.playerChoices,
+        eliminatedPlayers,
+        input.oracleYield
+      );
 
-        const payouts = this.computePayouts(
-          input.playerChoices,
-          eliminatedPlayers,
-          input.oracleYield
-        );
+      const poolBalances = this.computePoolBalances(
+        input.playerChoices,
+        eliminatedPlayers
+      );
 
-        const poolBalances = this.computePoolBalances(
-          input.playerChoices,
-          eliminatedPlayers
-        );
+      const result = { eliminatedPlayers, payouts, poolBalances };
+      const metadata: RoundMetadata = {
+        playerChoices: input.playerChoices,
+        oracleYield: input.oracleYield,
+        randomSeed: input.randomSeed,
+        resolution: result,
+      };
 
-        await tx.eliminationLog.createMany({
-          data: eliminatedPlayers.map(userId => ({
-            roundId: input.roundId,
-            userId,
-            reason: 'ELIMINATED_BY_ROUND',
-          })),
-        });
+      await this.roundRepo.resolveAtomically(
+        input.roundId,
+        RoundState.RESOLVED,
+        result,
+        metadata
+      );
 
-        await tx.round.update({
-          where: { id: input.roundId },
-          data: { 
-            state: RoundState.RESOLVED,
-            metadata: {
-              playerChoices: input.playerChoices,
-              oracleYield: input.oracleYield,
-              randomSeed: input.randomSeed,
-              resolution: { eliminatedPlayers, payouts, poolBalances }
-            } as any,
-            updatedAt: new Date() 
-          },
-        });
-
-        return { eliminatedPlayers, payouts, poolBalances };
+      arenaStateTransitionsTotal.inc({
+        from_state: round.state,
+        to_state: RoundState.RESOLVED,
       });
+      playersEliminatedTotal.inc(eliminatedPlayers.length);
+      await refreshArenaMetrics(this.prisma);
 
       const duration = (Date.now() - start) / 1000;
       roundResolutionDuration.observe(duration);

--- a/backend/src/types/round.ts
+++ b/backend/src/types/round.ts
@@ -29,6 +29,19 @@ export interface RoundResolution {
   poolBalances: Record<string, number>;
 }
 
+export interface RoundMetadata {
+  playerChoices: PlayerChoice[];
+  oracleYield: number;
+  randomSeed?: string;
+  resolution?: RoundResolution;
+}
+
+export interface PaginatedResult<T> {
+  items: T[];
+  cursor: string | null;
+  hasMore: boolean;
+}
+
 export interface RoundData {
   id: string;
   arenaId: string;
@@ -38,6 +51,7 @@ export interface RoundData {
   oracleYield?: number;
   randomSeed?: string;
   resolution?: RoundResolution;
+  metadata?: RoundMetadata;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/backend/src/utils/metrics.ts
+++ b/backend/src/utils/metrics.ts
@@ -1,4 +1,5 @@
 import { Registry, Counter, Histogram, Gauge } from 'prom-client';
+import type { PrismaClient } from '@prisma/client';
 
 export const register = new Registry();
 
@@ -48,3 +49,43 @@ export const roundResolutionDuration = new Histogram({
   buckets: [0.1, 0.5, 1, 2, 5, 10],
   registers: [register],
 });
+
+export const arenaStateTransitionsTotal = new Counter({
+  name: 'inversearena_arena_state_transitions_total',
+  help: 'Total number of arena round state transitions',
+  labelNames: ['from_state', 'to_state'],
+  registers: [register],
+});
+
+export const arenasActiveGauge = new Gauge({
+  name: 'inversearena_arenas_active_total',
+  help: 'Number of arenas with an unresolved active round',
+  registers: [register],
+});
+
+export const playersEliminatedTotal = new Counter({
+  name: 'inversearena_players_eliminated_total',
+  help: 'Total players eliminated across all arenas',
+  registers: [register],
+});
+
+export const payoutsSuccessTotal = new Counter({
+  name: 'inversearena_payouts_success_total',
+  help: 'Total successful prize payouts',
+  labelNames: ['asset'],
+  registers: [register],
+});
+
+export async function refreshArenaMetrics(prisma: PrismaClient): Promise<void> {
+  const activeRounds = await prisma.round.findMany({
+    where: {
+      state: {
+        in: ['OPEN', 'CLOSED'],
+      },
+    },
+    distinct: ['arenaId'],
+    select: { arenaId: true },
+  });
+
+  arenasActiveGauge.set(activeRounds.length);
+}

--- a/backend/tests/metrics.test.ts
+++ b/backend/tests/metrics.test.ts
@@ -1,4 +1,14 @@
-import { register, httpRequestsTotal, httpRequestDuration, workerJobsPending, txsConfirmedTotal } from '../src/utils/metrics';
+import {
+  arenaStateTransitionsTotal,
+  arenasActiveGauge,
+  httpRequestDuration,
+  httpRequestsTotal,
+  payoutsSuccessTotal,
+  playersEliminatedTotal,
+  register,
+  txsConfirmedTotal,
+  workerJobsPending,
+} from '../src/utils/metrics';
 
 async function testMetricsEndpoint() {
   console.log('🧪 Test: Metrics Endpoint');
@@ -16,6 +26,10 @@ async function testMetricsEndpoint() {
   txsConfirmedTotal.inc({ status: 'confirmed' });
   txsConfirmedTotal.inc({ status: 'confirmed' });
   txsConfirmedTotal.inc({ status: 'failed' });
+  arenaStateTransitionsTotal.inc({ from_state: 'OPEN', to_state: 'RESOLVED' });
+  playersEliminatedTotal.inc(3);
+  payoutsSuccessTotal.inc({ asset: 'XLM' });
+  arenasActiveGauge.set(2);
   
   const metrics = await register.metrics();
   
@@ -24,6 +38,10 @@ async function testMetricsEndpoint() {
     { name: 'http_request_duration_seconds', present: metrics.includes('http_request_duration_seconds') },
     { name: 'worker_jobs_pending', present: metrics.includes('worker_jobs_pending') },
     { name: 'txs_confirmed_total', present: metrics.includes('txs_confirmed_total') },
+    { name: 'inversearena_arenas_active_total', present: metrics.includes('inversearena_arenas_active_total') },
+    { name: 'inversearena_players_eliminated_total', present: metrics.includes('inversearena_players_eliminated_total') },
+    { name: 'inversearena_payouts_success_total', present: metrics.includes('inversearena_payouts_success_total') },
+    { name: 'inversearena_arena_state_transitions_total', present: metrics.includes('inversearena_arena_state_transitions_total') },
     { name: 'route label', present: metrics.includes('route=') },
     { name: 'status label', present: metrics.includes('status=') },
   ];

--- a/contract/factory/src/lib.rs
+++ b/contract/factory/src/lib.rs
@@ -1,5 +1,11 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl};
+use soroban_sdk::{Address, BytesN, Env, contract, contractimpl, symbol_short, token};
+
+mod storage;
+mod types;
+
+use storage::FactoryStorage;
+use types::FactoryError;
 
 /// Factory contract — deploys arena instances and enforces protocol-level rules.
 ///
@@ -14,4 +20,234 @@ use soroban_sdk::{contract, contractimpl};
 pub struct FactoryContract;
 
 #[contractimpl]
-impl FactoryContract {}
+impl FactoryContract {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        stake_token: Address,
+        min_creator_stake: i128,
+    ) -> Result<(), FactoryError> {
+        if FactoryStorage::has_admin(&env) {
+            return Err(FactoryError::AlreadyInitialized);
+        }
+        if min_creator_stake < 0 {
+            return Err(FactoryError::InvalidStakeAmount);
+        }
+
+        admin.require_auth();
+        FactoryStorage::save_admin(&env, &admin);
+        FactoryStorage::save_stake_token(&env, &stake_token);
+        FactoryStorage::save_min_creator_stake(&env, min_creator_stake);
+        Ok(())
+    }
+
+    pub fn admin(env: Env) -> Result<Address, FactoryError> {
+        FactoryStorage::load_admin(&env).ok_or(FactoryError::NotInitialized)
+    }
+
+    pub fn set_min_creator_stake(
+        env: Env,
+        admin: Address,
+        min_creator_stake: i128,
+    ) -> Result<(), FactoryError> {
+        Self::require_admin(&env, &admin)?;
+        if min_creator_stake < 0 {
+            return Err(FactoryError::InvalidStakeAmount);
+        }
+
+        let previous = FactoryStorage::load_min_creator_stake(&env);
+        FactoryStorage::save_min_creator_stake(&env, min_creator_stake);
+        env.events().publish(
+            (symbol_short!("MIN_UP"),),
+            (previous, min_creator_stake),
+        );
+        Ok(())
+    }
+
+    pub fn get_min_creator_stake(env: Env) -> i128 {
+        FactoryStorage::load_min_creator_stake(&env)
+    }
+
+    pub fn deploy_arena(
+        env: Env,
+        creator: Address,
+        creator_stake: i128,
+        _entry_fee: i128,
+    ) -> Result<Address, FactoryError> {
+        if !FactoryStorage::has_admin(&env) {
+            return Err(FactoryError::NotInitialized);
+        }
+
+        creator.require_auth();
+
+        let min_stake = FactoryStorage::load_min_creator_stake(&env);
+        if creator_stake < min_stake {
+            return Err(FactoryError::InsufficientCreatorStake);
+        }
+        if creator_stake <= 0 {
+            return Err(FactoryError::InvalidStakeAmount);
+        }
+
+        let stake_token = FactoryStorage::load_stake_token(&env)
+            .ok_or(FactoryError::NotInitialized)?;
+        let token_client = token::Client::new(&env, &stake_token);
+        token_client.transfer(
+            &creator,
+            &env.current_contract_address(),
+            &creator_stake,
+        );
+
+        let arena_id = Self::derive_arena_address(&env);
+        FactoryStorage::save_creator_stake(&env, &arena_id, &creator, creator_stake);
+        env.events().publish(
+            (symbol_short!("DEPLOYED"), arena_id.clone()),
+            (creator.clone(), creator_stake),
+        );
+
+        Ok(arena_id)
+    }
+
+    pub fn finish_arena(
+        env: Env,
+        admin: Address,
+        arena_id: Address,
+    ) -> Result<(), FactoryError> {
+        Self::require_admin(&env, &admin)?;
+
+        let stake = FactoryStorage::load_creator_stake(&env, &arena_id)
+            .ok_or(FactoryError::ArenaNotFound)?;
+        let stake_token = FactoryStorage::load_stake_token(&env)
+            .ok_or(FactoryError::NotInitialized)?;
+
+        let token_client = token::Client::new(&env, &stake_token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &stake.creator,
+            &stake.amount,
+        );
+        FactoryStorage::remove_creator_stake(&env, &arena_id);
+        env.events().publish(
+            (symbol_short!("FINISHED"), arena_id),
+            (stake.creator, stake.amount),
+        );
+        Ok(())
+    }
+
+    pub fn get_creator_stake(
+        env: Env,
+        arena_id: Address,
+    ) -> Result<i128, FactoryError> {
+        let stake = FactoryStorage::load_creator_stake(&env, &arena_id)
+            .ok_or(FactoryError::ArenaNotFound)?;
+        Ok(stake.amount)
+    }
+
+    fn require_admin(env: &Env, admin: &Address) -> Result<(), FactoryError> {
+        let stored_admin = FactoryStorage::load_admin(env).ok_or(FactoryError::NotInitialized)?;
+        admin.require_auth();
+        if *admin != stored_admin {
+            return Err(FactoryError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn derive_arena_address(env: &Env) -> Address {
+        let nonce = FactoryStorage::next_arena_nonce(env);
+        let mut salt = BytesN::<32>::from_array(env, &[0; 32]);
+        let nonce_bytes = nonce.to_be_bytes();
+        let start = 32 - nonce_bytes.len();
+        for (index, byte) in nonce_bytes.iter().enumerate() {
+            salt.set(start as u32 + index as u32, *byte);
+        }
+        env.deployer().with_current_contract(salt).deployed_address()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn setup() -> (
+        Env,
+        Address,
+        FactoryContractClient<'static>,
+        Address,
+        Address,
+        Address,
+        token::Client<'static>,
+        token::StellarAssetClient<'static>,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(FactoryContract, ());
+        let client = FactoryContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract(token_admin.clone());
+        let token_client = token::Client::new(&env, &token_id);
+        let asset_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        client.initialize(&admin, &token_id, &100);
+
+        (
+            env,
+            contract_id,
+            client,
+            admin,
+            creator,
+            token_id,
+            token_client,
+            asset_admin,
+        )
+    }
+
+    #[test]
+    fn deploy_arena_requires_sufficient_stake() {
+        let (_env, _contract_id, client, _admin, creator, _token_id, _token_client, asset_admin) =
+            setup();
+        asset_admin.mint(&creator, &1_000);
+
+        let err = client.try_deploy_arena(&creator, &99, &25).unwrap_err();
+        assert_eq!(err, Ok(FactoryError::InsufficientCreatorStake));
+    }
+
+    #[test]
+    fn deploy_arena_holds_creator_stake() {
+        let (_env, contract_id, client, _admin, creator, _token_id, token_client, asset_admin) =
+            setup();
+        asset_admin.mint(&creator, &1_000);
+
+        let arena_id = client.deploy_arena(&creator, &250, &25);
+
+        assert_eq!(token_client.balance(&creator), 750);
+        assert_eq!(token_client.balance(&contract_id), 250);
+        assert_eq!(client.get_creator_stake(&arena_id), 250);
+    }
+
+    #[test]
+    fn finish_arena_refunds_creator_stake() {
+        let (_env, contract_id, client, admin, creator, _token_id, token_client, asset_admin) =
+            setup();
+        asset_admin.mint(&creator, &1_000);
+
+        let arena_id = client.deploy_arena(&creator, &250, &25);
+        client.finish_arena(&admin, &arena_id);
+
+        assert_eq!(token_client.balance(&creator), 1_000);
+        assert_eq!(token_client.balance(&contract_id), 0);
+        let err = client.try_get_creator_stake(&arena_id).unwrap_err();
+        assert_eq!(err, Ok(FactoryError::ArenaNotFound));
+    }
+
+    #[test]
+    fn admin_can_update_min_creator_stake() {
+        let (_env, _contract_id, client, admin, _creator, _token_id, _token_client, _asset_admin) =
+            setup();
+        client.set_min_creator_stake(&admin, &500);
+        assert_eq!(client.get_min_creator_stake(), 500);
+    }
+}

--- a/contract/factory/src/storage.rs
+++ b/contract/factory/src/storage.rs
@@ -1,0 +1,86 @@
+use soroban_sdk::{Address, Env, contracttype, symbol_short};
+
+const ADMIN_KEY: soroban_sdk::Symbol = symbol_short!("ADMIN");
+const STAKE_TOKEN_KEY: soroban_sdk::Symbol = symbol_short!("STK_TKN");
+const MIN_CREATOR_STAKE_KEY: soroban_sdk::Symbol = symbol_short!("MIN_STK");
+const NEXT_ARENA_ID_KEY: soroban_sdk::Symbol = symbol_short!("NEXT_ID");
+
+#[contracttype]
+pub enum DataKey {
+    CreatorStake(Address),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CreatorStakeRecord {
+    pub creator: Address,
+    pub amount: i128,
+}
+
+pub struct FactoryStorage;
+
+impl FactoryStorage {
+    pub fn has_admin(env: &Env) -> bool {
+        env.storage().instance().has(&ADMIN_KEY)
+    }
+
+    pub fn load_admin(env: &Env) -> Option<Address> {
+        env.storage().instance().get(&ADMIN_KEY)
+    }
+
+    pub fn save_admin(env: &Env, admin: &Address) {
+        env.storage().instance().set(&ADMIN_KEY, admin);
+    }
+
+    pub fn load_stake_token(env: &Env) -> Option<Address> {
+        env.storage().instance().get(&STAKE_TOKEN_KEY)
+    }
+
+    pub fn save_stake_token(env: &Env, token: &Address) {
+        env.storage().instance().set(&STAKE_TOKEN_KEY, token);
+    }
+
+    pub fn load_min_creator_stake(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&MIN_CREATOR_STAKE_KEY)
+            .unwrap_or(0)
+    }
+
+    pub fn save_min_creator_stake(env: &Env, stake: i128) {
+        env.storage().instance().set(&MIN_CREATOR_STAKE_KEY, &stake);
+    }
+
+    pub fn next_arena_nonce(env: &Env) -> u64 {
+        let next = env.storage().instance().get(&NEXT_ARENA_ID_KEY).unwrap_or(0u64);
+        env.storage().instance().set(&NEXT_ARENA_ID_KEY, &(next + 1));
+        next
+    }
+
+    pub fn save_creator_stake(
+        env: &Env,
+        arena_id: &Address,
+        creator: &Address,
+        amount: i128,
+    ) {
+        env.storage().persistent().set(
+            &DataKey::CreatorStake(arena_id.clone()),
+            &CreatorStakeRecord {
+                creator: creator.clone(),
+                amount,
+            },
+        );
+    }
+
+    pub fn load_creator_stake(env: &Env, arena_id: &Address) -> Option<CreatorStakeRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CreatorStake(arena_id.clone()))
+    }
+
+    pub fn remove_creator_stake(env: &Env, arena_id: &Address) {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::CreatorStake(arena_id.clone()));
+    }
+}

--- a/contract/factory/src/types.rs
+++ b/contract/factory/src/types.rs
@@ -1,0 +1,12 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FactoryError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    InvalidStakeAmount = 4,
+    InsufficientCreatorStake = 5,
+    ArenaNotFound = 6,
+}

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,6 +1,14 @@
 import '@testing-library/jest-dom';
 import { TextDecoder, TextEncoder } from "util";
 
+process.env.NEXT_PUBLIC_STELLAR_NETWORK ??= "testnet";
+process.env.NEXT_PUBLIC_HORIZON_URL ??= "https://horizon-testnet.stellar.org";
+process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ??= "https://soroban-testnet.stellar.org";
+process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID ??=
+  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+process.env.NEXT_PUBLIC_USDC_CONTRACT_ID ??=
+  "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
 if (!global.TextEncoder) {
   // Needed by stellar-sdk in the Jest/node environment.
   global.TextEncoder = TextEncoder as typeof global.TextEncoder;

--- a/frontend/src/components/hook-d/arenaConstants.ts
+++ b/frontend/src/components/hook-d/arenaConstants.ts
@@ -1,6 +1,7 @@
 /**
  * Centralized Arena Configuration Constants
  */
+import { STELLAR_PLACEHOLDERS, stellarConfig } from "@/lib/stellarConfig";
 
 export const GAME_MECHANICS = {
   MAX_CAPACITY: 1024,
@@ -19,20 +20,14 @@ export const UI_BEHAVIOR = {
 } as const;
 
 export const STELLAR_NETWORK = {
-  PASSPHRASE:
-    process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ||
-    "Test SDF Network ; September 2015",
-  SOROBAN_RPC_URL:
-    process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
-    "https://soroban-testnet.stellar.org",
-  HORIZON_URL:
-    process.env.NEXT_PUBLIC_HORIZON_URL ||
-    "https://horizon-testnet.stellar.org",
+  PASSPHRASE: stellarConfig.passphrase,
+  SOROBAN_RPC_URL: stellarConfig.sorobanRpcUrl,
+  HORIZON_URL: stellarConfig.horizonUrl,
   CONTRACTS: {
-    FACTORY: process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID || "CB...",
-    XLM: "CAS3J7GYLGXMF6TDJBXBGMELNUPVCGXIZ68TZE6GTVASJ63Y32KXVY77",
-    USDC: process.env.NEXT_PUBLIC_USDC_CONTRACT_ID || "CC...",
-    STAKING_PLACEHOLDER: "CD...",
+    FACTORY: stellarConfig.factoryContractId,
+    XLM: stellarConfig.xlmContractId,
+    USDC: stellarConfig.usdcContractId,
+    STAKING_PLACEHOLDER: STELLAR_PLACEHOLDERS.stakingContractId,
   },
 } as const;
 

--- a/frontend/src/features/wallet/WalletProvider.tsx
+++ b/frontend/src/features/wallet/WalletProvider.tsx
@@ -1,47 +1,22 @@
 'use client';
 
 import { createContext, ReactNode, useMemo } from 'react';
-import { Networks } from "@creit-tech/stellar-wallets-kit";
 
 import { WalletContextType } from './types';
 import { useStellarWallet } from './useStellarWallet';
-
-/**
- * Resolve the Stellar network from the NEXT_PUBLIC_STELLAR_NETWORK env var.
- * Accepted values: "testnet" | "mainnet" (case-insensitive).
- * Defaults to TESTNET when the variable is missing or unrecognised.
- */
-function getStellarNetwork(): Networks {
-  const env = process.env.NEXT_PUBLIC_STELLAR_NETWORK?.toLowerCase();
-
-  switch (env) {
-    case 'mainnet':
-      return Networks.PUBLIC;
-    case 'testnet':
-    case undefined:
-    case '':
-      return Networks.TESTNET;
-    default:
-      console.warn(
-        `[WalletProvider] Unknown NEXT_PUBLIC_STELLAR_NETWORK="${process.env.NEXT_PUBLIC_STELLAR_NETWORK}", defaulting to TESTNET.`
-      );
-      return Networks.TESTNET;
-  }
-}
-
-const resolvedNetwork = getStellarNetwork();
+import { stellarConfig } from '@/lib/stellarConfig';
 
 export const WalletContext = createContext<WalletContextType | null>(null);
 
 export const WalletProvider = ({ children }: { children: ReactNode }) => {
-  const { publicKey, status, error, connectWallet, disconnectWallet } = useStellarWallet(resolvedNetwork);
+  const { publicKey, status, error, connectWallet, disconnectWallet } = useStellarWallet(stellarConfig.network);
 
   const contextValue: WalletContextType = useMemo(
     () => ({
       status,
       publicKey: publicKey,
       error,
-      network: resolvedNetwork,
+      network: stellarConfig.network,
       connect: connectWallet,
       disconnect: disconnectWallet,
     }),

--- a/frontend/src/lib/stellarConfig.ts
+++ b/frontend/src/lib/stellarConfig.ts
@@ -1,0 +1,55 @@
+import { Networks } from "@creit-tech/stellar-wallets-kit";
+import { z } from "zod";
+
+const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+const MAINNET_PASSPHRASE = "Public Global Stellar Network ; September 2015";
+const DEFAULT_XLM_CONTRACT_ID =
+  "CAS3J7GYLGXMF6TDJBXBGMELNUPVCGXIZ68TZE6GTVASJ63Y32KXVY77";
+
+const StellarEnvSchema = z.object({
+  NEXT_PUBLIC_STELLAR_NETWORK: z
+    .enum(["testnet", "mainnet"])
+    .default("testnet"),
+  NEXT_PUBLIC_SOROBAN_RPC_URL: z.string().trim().url(),
+  NEXT_PUBLIC_HORIZON_URL: z.string().trim().url(),
+  NEXT_PUBLIC_FACTORY_CONTRACT_ID: z.string().trim().min(3),
+  NEXT_PUBLIC_USDC_CONTRACT_ID: z.string().trim().min(3),
+  NEXT_PUBLIC_XLM_CONTRACT_ID: z.string().trim().min(3).optional(),
+  NEXT_PUBLIC_STAKING_CONTRACT_ID: z.string().trim().min(3).optional(),
+  NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE: z.string().trim().min(3).optional(),
+});
+
+const env = StellarEnvSchema.parse({
+  NEXT_PUBLIC_STELLAR_NETWORK:
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK?.toLowerCase(),
+  NEXT_PUBLIC_SOROBAN_RPC_URL: process.env.NEXT_PUBLIC_SOROBAN_RPC_URL,
+  NEXT_PUBLIC_HORIZON_URL: process.env.NEXT_PUBLIC_HORIZON_URL,
+  NEXT_PUBLIC_FACTORY_CONTRACT_ID:
+    process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID,
+  NEXT_PUBLIC_USDC_CONTRACT_ID: process.env.NEXT_PUBLIC_USDC_CONTRACT_ID,
+  NEXT_PUBLIC_XLM_CONTRACT_ID: process.env.NEXT_PUBLIC_XLM_CONTRACT_ID,
+  NEXT_PUBLIC_STAKING_CONTRACT_ID:
+    process.env.NEXT_PUBLIC_STAKING_CONTRACT_ID,
+  NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE:
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE,
+});
+
+const isMainnet = env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet";
+
+export const stellarConfig = {
+  networkName: env.NEXT_PUBLIC_STELLAR_NETWORK,
+  network: isMainnet ? Networks.PUBLIC : Networks.TESTNET,
+  passphrase:
+    env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ??
+    (isMainnet ? MAINNET_PASSPHRASE : TESTNET_PASSPHRASE),
+  sorobanRpcUrl: env.NEXT_PUBLIC_SOROBAN_RPC_URL.replace(/\/+$/, ""),
+  horizonUrl: env.NEXT_PUBLIC_HORIZON_URL.replace(/\/+$/, ""),
+  factoryContractId: env.NEXT_PUBLIC_FACTORY_CONTRACT_ID,
+  usdcContractId: env.NEXT_PUBLIC_USDC_CONTRACT_ID,
+  xlmContractId: env.NEXT_PUBLIC_XLM_CONTRACT_ID ?? DEFAULT_XLM_CONTRACT_ID,
+  stakingContractId: env.NEXT_PUBLIC_STAKING_CONTRACT_ID,
+} as const;
+
+export const STELLAR_PLACEHOLDERS = {
+  stakingContractId: "CD...",
+} as const;

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { parseAllowedOrigins } from "@/shared-d/utils/security-validation";
-import { STELLAR_NETWORK } from "@/components/hook-d/arenaConstants";
+import { stellarConfig } from "@/lib/stellarConfig";
 
 function toOrigin(url: string): string {
   const candidate = url.trim();
@@ -13,8 +13,8 @@ function toOrigin(url: string): string {
 }
 
 function getNetworkConnectSources(): string[] {
-  const horizonOrigin = toOrigin(STELLAR_NETWORK.HORIZON_URL);
-  const sorobanOrigin = toOrigin(STELLAR_NETWORK.SOROBAN_RPC_URL);
+  const horizonOrigin = toOrigin(stellarConfig.horizonUrl);
+  const sorobanOrigin = toOrigin(stellarConfig.sorobanRpcUrl);
   return [horizonOrigin, sorobanOrigin];
 }
 

--- a/frontend/src/shared-d/hooks/useWallet.ts
+++ b/frontend/src/shared-d/hooks/useWallet.ts
@@ -12,9 +12,9 @@ import {
   SignedXdrSchema,
   StellarPublicKeySchema,
 } from "@/shared-d/utils/security-validation";
-import { STELLAR_NETWORK } from "@/components/hook-d/arenaConstants";
+import { stellarConfig } from "@/lib/stellarConfig";
 
-const HORIZON_URL = STELLAR_NETWORK.HORIZON_URL.replace(/\/+$/, "");
+const HORIZON_URL = stellarConfig.horizonUrl;
 
 /**
  * Wallet connection status
@@ -174,7 +174,7 @@ export function useWallet(): UseWalletReturn {
       const validatedXdr = SignedXdrSchema.parse(xdr);
       const networkPassphrase = network
         ? NetworkPassphraseSchema.parse(network)
-        : "Test SDF Network ; September 2015";
+        : stellarConfig.passphrase;
 
       const result = await freighterSignTransaction(validatedXdr, { networkPassphrase });
       if (result.error) {

--- a/frontend/src/shared-d/utils/stellar-transactions.ts
+++ b/frontend/src/shared-d/utils/stellar-transactions.ts
@@ -14,9 +14,8 @@ import {
   StellarPublicKeySchema,
 } from "@/shared-d/utils/security-validation";
 import {
-  STELLAR_NETWORK,
-  TRANSACTION_CONFIG,
 } from "@/components/hook-d/arenaConstants";
+import { STELLAR_PLACEHOLDERS, stellarConfig } from "@/lib/stellarConfig";
 import {
   ContractError,
   ContractErrorCode,
@@ -59,19 +58,15 @@ export { ContractError, ContractErrorCode, parseContractError } from "@/shared-d
 export { ContractClientFactory } from "@/shared-d/utils/contract-client-factory";
 export type { ContractClientFactoryDeps } from "@/shared-d/utils/contract-client-factory";
 
-// Constants (Replace with real Contract IDs in production/env)
-export const FACTORY_CONTRACT_ID = STELLAR_NETWORK.CONTRACTS.FACTORY;
-export const XLM_CONTRACT_ID = STELLAR_NETWORK.CONTRACTS.XLM;
-export const USDC_CONTRACT_ID = STELLAR_NETWORK.CONTRACTS.USDC;
-
-const STAKING_CONTRACT_PLACEHOLDER =
-  STELLAR_NETWORK.CONTRACTS.STAKING_PLACEHOLDER;
+export const FACTORY_CONTRACT_ID = stellarConfig.factoryContractId;
+export const XLM_CONTRACT_ID = stellarConfig.xlmContractId;
+export const USDC_CONTRACT_ID = stellarConfig.usdcContractId;
 export const STAKING_CONTRACT_ID =
-  process.env.NEXT_PUBLIC_STAKING_CONTRACT_ID || STAKING_CONTRACT_PLACEHOLDER;
+  stellarConfig.stakingContractId ?? STELLAR_PLACEHOLDERS.stakingContractId;
 
-export const NETWORK_PASSPHRASE = STELLAR_NETWORK.PASSPHRASE;
-export const HORIZON_URL = STELLAR_NETWORK.HORIZON_URL.replace(/\/+$/, "");
-export const SOROBAN_RPC_URL = STELLAR_NETWORK.SOROBAN_RPC_URL;
+export const NETWORK_PASSPHRASE = stellarConfig.passphrase;
+export const HORIZON_URL = stellarConfig.horizonUrl;
+export const SOROBAN_RPC_URL = stellarConfig.sorobanRpcUrl;
 
 const defaultSorobanClients = new ContractClientFactory(SOROBAN_RPC_URL);
 
@@ -143,7 +138,7 @@ export async function buildStakeProtocolTransaction(
 
     if (
       !STAKING_CONTRACT_ID ||
-      STAKING_CONTRACT_ID === STAKING_CONTRACT_PLACEHOLDER ||
+      STAKING_CONTRACT_ID === STELLAR_PLACEHOLDERS.stakingContractId ||
       STAKING_CONTRACT_ID.includes("...")
     ) {
       throw new ContractError({
@@ -195,7 +190,7 @@ export async function buildUnstakeProtocolTransaction(
 
     if (
       !STAKING_CONTRACT_ID ||
-      STAKING_CONTRACT_ID === STAKING_CONTRACT_PLACEHOLDER ||
+      STAKING_CONTRACT_ID === STELLAR_PLACEHOLDERS.stakingContractId ||
       STAKING_CONTRACT_ID.includes("...")
     ) {
       throw new ContractError({


### PR DESCRIPTION
## Description
Implement the combined frontend, backend, and contract changes needed to close the Stellar config, round repository, Prometheus metrics, and creator stake issues in one PR.

Closes #708
Closes #709
Closes #710
Closes #711

## Changes proposed

### What were you told to do?
Combine the requested fixes into one PR: remove hardcoded Stellar network config from the frontend, complete the round repository/state transition flow, add business-level Prometheus metrics and Grafana panels, and add a minimum creator stake gate plus refund flow to the factory contract.

### What did I do?
#### Frontend Stellar configuration
- Added `frontend/src/lib/stellarConfig.ts` to validate required `NEXT_PUBLIC_*` Stellar env vars at startup and centralize network, RPC, Horizon, and contract IDs.
- Updated wallet, transaction, proxy, and shared arena constants consumers to read from the centralized config instead of hardcoded URLs or scattered env handling.
- Seeded Jest env defaults in `frontend/jest.setup.ts` so existing frontend tests can import the config module safely.

#### Backend round repository and metrics
- Expanded `RoundRepository` with persisted state updates, resolution metadata storage, arena round listing, dedupe lookup, and atomic round resolution helpers.
- Refactored `RoundService` to use the repository layer instead of inline Prisma transactions and emit arena transition and elimination metrics.
- Added Prometheus counters/gauges plus Grafana dashboard panels for active arenas, arena state transitions, eliminations, and payout success tracking.
- Incremented payout success metrics on confirmed payouts and refreshed active arena gauges before `/metrics` responses.

#### Factory creator stake flow
- Built out the factory contract from the stub into an initialized admin/stake-token/min-stake contract with persistent creator stake storage.
- Added `deploy_arena`, minimum creator stake enforcement, stake custody in the factory contract, and `finish_arena` refund handling.
- Added contract tests covering sufficient stake handling, insufficient stake rejection, refund on completion, and admin-configurable minimum creator stake.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] The implementation was reviewed and confirmed to work as intended.
- [x] I am only making changes to files I was requested to.

## Screenshots / Validation Evidence
- `cargo test -p factory` passed with 4/4 tests green after the creator stake flow was implemented.
- `backend/node_modules/.bin/tsc -p tsconfig.json --noEmit` passed.
- `frontend/node_modules/.bin/eslint ...` passed on the touched frontend files.
- Frontend full `tsc` is currently blocked by pre-existing repo issues in `sentry.client.config.ts` and multiple existing Jest-typed test files.
- Frontend Jest is currently blocked by the existing config not transforming the ESM `@jsr/creit-tech__stellar-wallets-kit` dependency.
- Backend Jest is currently blocked by pre-existing test harness issues: `tests/metrics.test.ts` is a standalone script without Jest tests, and `tests/payment.unit.test.ts` has an existing `Server` typing error.
