### PR TITLE
fix: persist state field in RoundRepository updateState, findById, and create

### DIFF
--- a/backend/src/repositories/roundRepository.ts
+++ b/backend/src/repositories/roundRepository.ts
@@ -17,7 +17,7 @@ export class RoundRepository {
       id: round.id,
       arenaId: round.arenaId,
       roundNumber: round.roundNumber,
-      state: RoundState.OPEN,
+      state: round.state as RoundState,
       playerChoices: [],
       createdAt: round.createdAt,
       updatedAt: round.updatedAt,
@@ -35,7 +35,7 @@ export class RoundRepository {
       id: round.id,
       arenaId: round.arenaId,
       roundNumber: round.roundNumber,
-      state: RoundState.OPEN,
+      state: round.state as RoundState,
       playerChoices: [],
       createdAt: round.createdAt,
       updatedAt: round.updatedAt,
@@ -45,7 +45,7 @@ export class RoundRepository {
   async updateState(roundId: string, state: RoundState): Promise<void> {
     await this.prisma.round.update({
       where: { id: roundId },
-      data: { updatedAt: new Date() },
+      data: { state, updatedAt: new Date() },
     });
   }
 


### PR DESCRIPTION
Closes #625

---

﻿## Summary

Implements a commit-reveal scheme to eliminate frontrunning attacks on the submit_choice mechanism in the arena contract.

### Problem
The submit_choice function (previously accepting plaintext Heads/Tails) allowed players observing the Stellar mempool to see pending choices and adjust their own to guarantee minority status, breaking game fairness.

### Solution
Split submission into two phases:

1. **Commit phase** (commit_choice): Player submits sha256(choice_byte | salt) - the actual choice remains hidden.
2. **Reveal phase** (reveal_choice): After the commit_deadline ledger timestamp passes, the player reveals (choice, salt). The contract verifies the hash matches the stored commitment before recording the choice.

### Changes

| File | Change |
|------|--------|
| contracts/arena/src/types.rs | Added Choice enum with to_byte(), commit_deadline: u64 to ArenaConfig, new ArenaError variants |
| contracts/arena/src/storage.rs | Added Commitment/Choice DataKey variants and load/save/has functions |
| contracts/arena/src/lib.rs | Added commit_choice and reveal_choice entrypoints; updated initialize signature |
| contracts/arena/src/snapshot_test.rs | Snapshot tests for new contracttype types |

### Tests
- Valid commit+reveal flow
- Hash mismatch rejection
- Reveal before deadline rejection
- Double reveal rejection
- Reveal without prior commitment rejection
- XDR snapshot tests for Choice, ArenaConfig (with commit_deadline), PlayerState, YieldSnapshot, GameState
