### PR TITLE
feat: signed payout XDR audit, PaymentService tests, arena resolve timelock & SEO files

### DIFF
--- a/backend/src/services/paymentService.ts
+++ b/backend/src/services/paymentService.ts
@@ -3,8 +3,11 @@ import {
   BASE_FEE,
   Contract,
   Keypair,
+  Transaction,
   TransactionBuilder,
   nativeToScVal,
+  scValToNative,
+  xdr,
 } from "@stellar/stellar-sdk";
 // @ts-ignore
 import { rpc } from "@stellar/stellar-sdk";
@@ -158,7 +161,9 @@ export class PaymentService {
       throw new Error(`Transaction ${transactionId} is not waiting for signature`);
     }
 
-    TransactionBuilder.fromXDR(signedXdr, this.config.networkPassphrase);
+    // Audit the signed XDR before queuing (#667): a compromised external signer
+    // could return a validly-signed transaction that redirects the payout.
+    this.assertSignedTransactionMatches(signedXdr, transaction);
 
     return this.transactions.update(transactionId, {
       signedXdr,
@@ -288,6 +293,66 @@ export class PaymentService {
     }
 
     return current;
+  }
+
+  /**
+   * Verify that a signed payout transaction matches the stored payout record
+   * and this service's configuration before it is queued for submission (#667).
+   *
+   * Rejects if the source account, invoked contract, called method, payout
+   * destination, or amount differ from what was authorised. Without this, a
+   * compromised KMS signer could return a validly-signed XDR redirecting funds.
+   */
+  private assertSignedTransactionMatches(
+    signedXdr: string,
+    transaction: TransactionRecord
+  ): void {
+    let parsed: ReturnType<typeof TransactionBuilder.fromXDR>;
+    try {
+      parsed = TransactionBuilder.fromXDR(signedXdr, this.config.networkPassphrase);
+    } catch {
+      throw new Error("Signed XDR could not be parsed");
+    }
+
+    // Fee-bump wrappers are not expected for payouts.
+    if (!(parsed instanceof Transaction)) {
+      throw new Error("Signed transaction must not be a fee-bump transaction");
+    }
+    const tx = parsed;
+
+    if (tx.source !== this.config.sourceAccount) {
+      throw new Error("Signed transaction source account does not match the payout source");
+    }
+    if (tx.operations.length !== 1) {
+      throw new Error("Signed transaction must contain exactly one operation");
+    }
+
+    const op = tx.operations[0] as { type: string; func?: xdr.HostFunction };
+    if (op.type !== "invokeHostFunction" || !op.func) {
+      throw new Error("Signed transaction operation is not a contract invocation");
+    }
+    if (op.func.switch().name !== "hostFunctionTypeInvokeContract") {
+      throw new Error("Signed transaction does not invoke a contract");
+    }
+
+    const invoke = op.func.invokeContract();
+    const contractId = Address.fromScAddress(invoke.contractAddress()).toString();
+    if (contractId !== this.config.payoutContractId) {
+      throw new Error("Signed transaction targets an unexpected contract");
+    }
+    if (invoke.functionName().toString() !== this.config.payoutMethodName) {
+      throw new Error("Signed transaction calls an unexpected contract method");
+    }
+
+    const args = invoke.args();
+    const destination = String(scValToNative(args[0]));
+    if (destination !== transaction.destinationAccount) {
+      throw new Error("Signed transaction destination does not match the payout record");
+    }
+    const amount = String(scValToNative(args[1]));
+    if (amount !== transaction.amountStroops) {
+      throw new Error("Signed transaction amount does not match the payout record");
+    }
   }
 
   private async requireTransaction(transactionId: string): Promise<TransactionRecord> {

--- a/backend/tests/payment.audit.unit.test.ts
+++ b/backend/tests/payment.audit.unit.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Jest unit tests for PaymentService covering:
+ *  - signed-XDR source/destination/amount/contract audit before queuing (#667)
+ *  - the transaction status machine with a stubbed RPC server (#681)
+ *
+ * (The existing payment.unit.test.ts uses the node:test runner; these are the
+ * jest-based additions requested by #681.)
+ */
+import {
+  Account,
+  Address,
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+} from "@stellar/stellar-sdk";
+import { PaymentService } from "../src/services/paymentService";
+import { InMemoryTransactionRepository } from "../src/repositories/inMemoryTransactionRepository";
+import type { PaymentConfig } from "../src/config/paymentConfig";
+
+const SOURCE = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+const DEST_A = Keypair.random().publicKey();
+const DEST_B = Keypair.random().publicKey();
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+const PASSPHRASE = "Test SDF Network ; September 2015";
+
+function makeConfig(): PaymentConfig {
+  return {
+    liveExecution: true,
+    signWithHotKey: false,
+    maxGasStroops: 2_000_000,
+    maxAttempts: 5,
+    confirmPollMs: 1,
+    confirmMaxPolls: 3,
+    payoutMethodName: "distribute_winnings",
+    payoutContractId: CONTRACT,
+    sourceAccount: SOURCE,
+    hotSignerSecret: undefined,
+    networkPassphrase: PASSPHRASE,
+    sorobanRpcUrl: "https://soroban-testnet.stellar.org",
+  } as PaymentConfig;
+}
+
+function makeRpc(overrides: Record<string, unknown> = {}) {
+  return {
+    getAccount: jest.fn(async () => new Account(SOURCE, "1")),
+    prepareTransaction: jest.fn(async (tx: { toXDR: () => string }) => ({
+      fee: "100",
+      toXDR: () => tx.toXDR(),
+      sign: () => {},
+    })),
+    sendTransaction: jest.fn(async () => ({ status: "PENDING", hash: "tx-hash" })),
+    getTransaction: jest.fn(async () => ({ status: rpc.Api.GetTransactionStatus.SUCCESS })),
+    ...overrides,
+  };
+}
+
+function makeService(rpcServer: ReturnType<typeof makeRpc>) {
+  const repo = new InMemoryTransactionRepository();
+  const service = new PaymentService(repo, { config: makeConfig(), rpcServer: rpcServer as never });
+  return { service, repo };
+}
+
+async function createAndSign(
+  service: PaymentService,
+  dest: string,
+  amount: string,
+  idem: string,
+) {
+  const built = await service.createPayoutTransaction({
+    payoutId: `p-${idem}`,
+    destinationAccount: dest,
+    amount,
+    asset: "XLM",
+    idempotencyKey: idem,
+  });
+  const tx = TransactionBuilder.fromXDR(built.unsignedXdr!, PASSPHRASE);
+  tx.sign(Keypair.random());
+  return { id: built.transaction.id, signedXdr: tx.toXDR() };
+}
+
+describe("PaymentService signed-XDR audit (#667)", () => {
+  it("queues a signed transaction that matches the payout record", async () => {
+    const { service } = makeService(makeRpc());
+    const { id, signedXdr } = await createAndSign(service, DEST_A, "10", "idem-ok-0001");
+
+    const result = await service.queueSignedTransaction(id, signedXdr);
+    expect(result.status).toBe("queued");
+    expect(result.signedXdr).toBe(signedXdr);
+  });
+
+  it("rejects an unparseable signed XDR", async () => {
+    const { service } = makeService(makeRpc());
+    const { id } = await createAndSign(service, DEST_A, "10", "idem-bad-0002");
+    await expect(service.queueSignedTransaction(id, "not-valid-xdr")).rejects.toThrow(/parsed/i);
+  });
+
+  it("rejects a transaction whose destination was swapped", async () => {
+    const { service } = makeService(makeRpc());
+    // Record #1 is for DEST_A; the signer returns a tx paying DEST_B.
+    const rec = await service.createPayoutTransaction({
+      payoutId: "p-dest",
+      destinationAccount: DEST_A,
+      amount: "10",
+      asset: "XLM",
+      idempotencyKey: "idem-dest-0003",
+    });
+    const malicious = await createAndSign(service, DEST_B, "10", "idem-dest-0004");
+    await expect(
+      service.queueSignedTransaction(rec.transaction.id, malicious.signedXdr),
+    ).rejects.toThrow(/destination/i);
+  });
+
+  it("rejects a transaction whose amount was altered", async () => {
+    const { service } = makeService(makeRpc());
+    const rec = await service.createPayoutTransaction({
+      payoutId: "p-amt",
+      destinationAccount: DEST_A,
+      amount: "10",
+      asset: "XLM",
+      idempotencyKey: "idem-amt-0005",
+    });
+    const malicious = await createAndSign(service, DEST_A, "999", "idem-amt-0006");
+    await expect(
+      service.queueSignedTransaction(rec.transaction.id, malicious.signedXdr),
+    ).rejects.toThrow(/amount/i);
+  });
+
+  it("rejects a transaction signed for a different source account", async () => {
+    const { service } = makeService(makeRpc());
+    const { id } = await createAndSign(service, DEST_A, "10", "idem-src-0007");
+    // A correctly-formed payout invocation, but built under a foreign source.
+    const op = new Contract(CONTRACT).call(
+      "distribute_winnings",
+      new Address(DEST_A).toScVal(),
+      nativeToScVal(BigInt("100000000"), { type: "i128" }),
+      nativeToScVal("XLM"),
+      nativeToScVal(BigInt(0), { type: "u64" }),
+      nativeToScVal("p-src"),
+    );
+    const foreign = new TransactionBuilder(new Account(DEST_B, "5"), {
+      fee: "100",
+      networkPassphrase: PASSPHRASE,
+    })
+      .addOperation(op)
+      .setTimeout(60)
+      .build();
+    foreign.sign(Keypair.random());
+    await expect(service.queueSignedTransaction(id, foreign.toXDR())).rejects.toThrow(/source/i);
+  });
+});
+
+describe("PaymentService status machine (#681)", () => {
+  let idemCounter = 0;
+  async function queuedTransaction(service: PaymentService) {
+    idemCounter += 1;
+    const { id, signedXdr } = await createAndSign(
+      service,
+      DEST_A,
+      "10",
+      `idem-status-${idemCounter}0000`,
+    );
+    await service.queueSignedTransaction(id, signedXdr);
+    return id;
+  }
+
+  it("built → queued → submitted on a PENDING send", async () => {
+    const rpcServer = makeRpc();
+    const { service } = makeService(rpcServer);
+    const id = await queuedTransaction(service);
+
+    const result = await service.submitQueuedTransaction(id);
+    expect(result.submitted).toBe(true);
+    expect(result.transaction.status).toBe("submitted");
+    expect(result.transaction.txHash).toBe("tx-hash");
+  });
+
+  it("submitted → confirmed on a SUCCESS receipt", async () => {
+    const rpcServer = makeRpc();
+    const { service } = makeService(rpcServer);
+    const id = await queuedTransaction(service);
+    await service.submitQueuedTransaction(id);
+
+    const confirmed = await service.confirmSubmittedTransaction(id);
+    expect(confirmed.status).toBe("confirmed");
+    expect(confirmed.confirmedAt).toBeTruthy();
+  });
+
+  it("queued → failed when Soroban returns ERROR", async () => {
+    const rpcServer = makeRpc({
+      sendTransaction: jest.fn(async () => ({ status: "ERROR", hash: "h" })),
+    });
+    const { service } = makeService(rpcServer);
+    const id = await queuedTransaction(service);
+
+    const result = await service.submitQueuedTransaction(id);
+    expect(result.submitted).toBe(false);
+    expect(result.transaction.status).toBe("failed");
+    expect(result.transaction.errorMessage).toMatch(/rejected/i);
+  });
+
+  it("stays queued when Soroban asks to TRY_AGAIN_LATER", async () => {
+    const rpcServer = makeRpc({
+      sendTransaction: jest.fn(async () => ({ status: "TRY_AGAIN_LATER", hash: "h" })),
+    });
+    const { service } = makeService(rpcServer);
+    const id = await queuedTransaction(service);
+
+    const result = await service.submitQueuedTransaction(id);
+    expect(result.submitted).toBe(false);
+    expect(result.transaction.status).toBe("queued");
+    expect(result.transaction.attempts).toBe(1);
+  });
+
+  it("submitted → failed on a FAILED receipt", async () => {
+    const rpcServer = makeRpc({
+      getTransaction: jest.fn(async () => ({ status: rpc.Api.GetTransactionStatus.FAILED })),
+    });
+    const { service } = makeService(rpcServer);
+    const id = await queuedTransaction(service);
+    await service.submitQueuedTransaction(id);
+
+    const confirmed = await service.confirmSubmittedTransaction(id);
+    expect(confirmed.status).toBe("failed");
+    expect(confirmed.errorMessage).toMatch(/on-chain/i);
+  });
+});

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -161,13 +161,64 @@ impl ArenaContract {
             .map(|c| c.player_count)
             .unwrap_or(0)
     }
+
+    /// Start a round, opening the submission window (#689).
+    ///
+    /// Records the round start timestamp and the minimum grace period
+    /// (`duration_seconds`) that must elapse before [`resolve_round`] can be
+    /// called. Only the admin may start a round, and only from `Open`.
+    pub fn start_round(env: Env, duration_seconds: u64) -> Result<(), ArenaError> {
+        let mut config = ArenaStorage::load_config(&env)?;
+        config.admin.require_auth();
+
+        if config.state != GameState::Open {
+            return Err(ArenaError::CannotCancelStartedGame);
+        }
+
+        config.state = GameState::Active;
+        ArenaStorage::save_config(&env, &config);
+        ArenaStorage::save_round_start(&env, env.ledger().timestamp());
+        ArenaStorage::save_round_duration(&env, duration_seconds);
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("started"),), duration_seconds);
+        Ok(())
+    }
+
+    /// Resolve the current round, enforcing the on-chain timelock (#689).
+    ///
+    /// Rejects with [`ArenaError::GracePeriodNotElapsed`] unless at least
+    /// `duration_seconds` have passed since the round started — so an admin
+    /// cannot resolve a round before players have had the window to act.
+    pub fn resolve_round(env: Env) -> Result<(), ArenaError> {
+        let mut config = ArenaStorage::load_config(&env)?;
+        config.admin.require_auth();
+
+        if config.state != GameState::Active {
+            return Err(ArenaError::RoundNotActive);
+        }
+
+        let round_start =
+            ArenaStorage::load_round_start(&env).ok_or(ArenaError::RoundNotStarted)?;
+        let grace = ArenaStorage::load_round_duration(&env);
+        if env.ledger().timestamp() < round_start.saturating_add(grace) {
+            return Err(ArenaError::GracePeriodNotElapsed);
+        }
+
+        config.state = GameState::Finished;
+        ArenaStorage::save_config(&env, &config);
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("resolved"),), ());
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::types::ArenaConfig;
-    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::{Address as _, Ledger as _};
 
     /// Register the contract and seed `n` joined players, returning the client.
     fn setup(n: u32) -> (Env, ArenaContractClient<'static>) {
@@ -391,5 +442,72 @@ mod test {
         let client = ArenaContractClient::new(&env, &contract_id);
         let result = client.try_reveal_choice(&player, &Choice::Heads, &salt);
         assert!(result.is_err());
+    }
+
+    // ── #689: admin timelock on resolve_round ──────────────────────────────
+
+    fn setup_started(duration: u64, start_ts: u64) -> (Env, ArenaContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ArenaContract, ());
+        env.as_contract(&contract_id, || {
+            let config = ArenaConfig {
+                admin: Address::generate(&env),
+                stake_token: Address::generate(&env),
+                entry_fee: 100,
+                state: GameState::Open,
+                player_count: 0,
+                commit_deadline: 0,
+            };
+            ArenaStorage::save_config(&env, &config);
+        });
+        let client = ArenaContractClient::new(&env, &contract_id);
+        env.ledger().with_mut(|li| li.timestamp = start_ts);
+        client.start_round(&duration);
+        (env, client)
+    }
+
+    fn state_of(env: &Env, client: &ArenaContractClient) -> GameState {
+        env.as_contract(&client.address, || ArenaStorage::load_config(env).unwrap().state)
+    }
+
+    #[test]
+    fn resolve_round_before_grace_elapsed_fails() {
+        let (env, client) = setup_started(60, 1_000);
+        // Only 30s have passed; the 60s grace window has not elapsed.
+        env.ledger().with_mut(|li| li.timestamp = 1_030);
+        assert!(client.try_resolve_round().is_err());
+        // State is unchanged — still Active.
+        assert_eq!(state_of(&env, &client), GameState::Active);
+    }
+
+    #[test]
+    fn resolve_round_after_grace_elapsed_succeeds() {
+        let (env, client) = setup_started(60, 1_000);
+        // Past the grace window.
+        env.ledger().with_mut(|li| li.timestamp = 1_061);
+        client.resolve_round();
+        assert_eq!(state_of(&env, &client), GameState::Finished);
+    }
+
+    #[test]
+    fn resolve_round_requires_an_active_round() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ArenaContract, ());
+        env.as_contract(&contract_id, || {
+            let config = ArenaConfig {
+                admin: Address::generate(&env),
+                stake_token: Address::generate(&env),
+                entry_fee: 100,
+                state: GameState::Open,
+                player_count: 0,
+                commit_deadline: 0,
+            };
+            ArenaStorage::save_config(&env, &config);
+        });
+        let client = ArenaContractClient::new(&env, &contract_id);
+        // Never started → not Active → rejected.
+        assert!(client.try_resolve_round().is_err());
     }
 }

--- a/contract/arena/src/storage.rs
+++ b/contract/arena/src/storage.rs
@@ -29,6 +29,33 @@ impl ArenaStorage {
             .set(&symbol_short!("CONFIG"), config);
     }
 
+    /// Ledger timestamp at which the current round started (#689). `None` until
+    /// `start_round` has been called.
+    pub fn load_round_start(env: &Env) -> Option<u64> {
+        env.storage().persistent().get(&symbol_short!("RSTART"))
+    }
+
+    pub fn save_round_start(env: &Env, timestamp: u64) {
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("RSTART"), &timestamp);
+    }
+
+    /// Minimum seconds that must elapse after `start_round` before
+    /// `resolve_round` is permitted (#689). Defaults to 0 if never set.
+    pub fn load_round_duration(env: &Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&symbol_short!("RDUR"))
+            .unwrap_or(0)
+    }
+
+    pub fn save_round_duration(env: &Env, seconds: u64) {
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("RDUR"), &seconds);
+    }
+
     /// Return the list of all player addresses that have joined this arena.
     pub fn load_all_players(env: &Env) -> Vec<Address> {
         env.storage()

--- a/contract/arena/src/types.rs
+++ b/contract/arena/src/types.rs
@@ -89,4 +89,10 @@ pub enum ArenaError {
     AlreadyRevealed = 7,
     /// No prior commitment was found for this player.
     NoCommitmentFound = 8,
+    /// `resolve_round` was called before the round was started.
+    RoundNotStarted = 9,
+    /// `resolve_round` was called before the minimum grace period elapsed.
+    GracePeriodNotElapsed = 10,
+    /// The operation requires the arena to be in the Active state.
+    RoundNotActive = 11,
 }

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Allow: /leaderboard
+Disallow: /dashboard
+Disallow: /arena/
+
+Sitemap: https://app.inversearena.io/sitemap.xml

--- a/frontend/src/app/__tests__/sitemap.test.ts
+++ b/frontend/src/app/__tests__/sitemap.test.ts
@@ -1,0 +1,31 @@
+import sitemap, { SITE_URL } from "../sitemap";
+import fs from "fs";
+import path from "path";
+
+describe("sitemap (#699)", () => {
+  const entries = sitemap();
+  const urls = entries.map((e) => e.url);
+
+  it("includes the public landing and leaderboard pages", () => {
+    expect(urls).toContain(`${SITE_URL}/`);
+    expect(urls).toContain(`${SITE_URL}/leaderboard`);
+  });
+
+  it("does not expose authenticated/in-game routes", () => {
+    expect(urls.some((u) => u.includes("/dashboard"))).toBe(false);
+    expect(urls.some((u) => u.includes("/arena/"))).toBe(false);
+  });
+});
+
+describe("robots.txt (#699)", () => {
+  const robots = fs.readFileSync(path.join(process.cwd(), "public/robots.txt"), "utf8");
+
+  it("disallows dashboard and in-game arena routes", () => {
+    expect(robots).toMatch(/Disallow:\s*\/dashboard/);
+    expect(robots).toMatch(/Disallow:\s*\/arena\//);
+  });
+
+  it("references the sitemap", () => {
+    expect(robots).toMatch(/Sitemap:\s*https?:\/\/\S+\/sitemap\.xml/);
+  });
+});

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from "next";
+
+/** Public site origin; override per environment via NEXT_PUBLIC_SITE_URL. */
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") || "https://app.inversearena.io";
+
+/**
+ * Dynamic sitemap (#699). Lists only publicly indexable routes — authenticated
+ * dashboard and in-game arena views are excluded here and in robots.txt so they
+ * aren't crawled.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  return [
+    { url: `${SITE_URL}/`, lastModified, changeFrequency: "daily", priority: 1 },
+    { url: `${SITE_URL}/leaderboard`, lastModified, changeFrequency: "hourly", priority: 0.8 },
+  ];
+}


### PR DESCRIPTION
## Summary

A payout-security fix, its test coverage, an on-chain admin timelock, and SEO foundations.

### Audit signed XDR before queuing payouts (closes #667)
- `PaymentService.queueSignedTransaction` now verifies the signed transaction's **source account**, **invoked contract**, **called method**, **destination**, and **amount** against the stored payout record + config before queuing. Any mismatch is rejected. Previously only XDR-parseability was checked, so a compromised KMS signer could return a validly-signed XDR redirecting the payout.

### PaymentService unit tests (closes #681)
- New jest suite with a stubbed RPC server covering the status machine — `built → queued → submitted → confirmed`, plus `failed` (Soroban ERROR / on-chain FAILED) and `try-again` paths — and accept/reject cases for the signed-XDR audit above. (The existing `payment.unit.test.ts` uses the `node:test` runner; these are the jest additions #681 asks for.)

### Arena resolve_round timelock (closes #689)
- Added `start_round(duration_seconds)` (records round start + grace period) and `resolve_round` (rejects with `GracePeriodNotElapsed` until the window elapses), so an admin can't resolve a round before players have acted. Round timing is stored in dedicated storage keys to keep the change focused. Contract unit tests cover before/after grace and the not-active guard.

### robots.txt + dynamic sitemap (closes #699)
- `public/robots.txt` and `app/sitemap.ts`: index the public landing/leaderboard pages, disallow `/dashboard` and `/arena/`.

## Tests
- Contract: 15 arena tests (3 new timelock).
- Backend: `payment.audit.unit.test.ts` (10 tests).
- Frontend: sitemap/robots (4 tests).

## Notes
- #689 stores `round_start`/`round_duration_seconds` in dedicated storage rather than expanding `ArenaConfig`, to avoid churning every existing config literal/snapshot. The on-chain grace-period guarantee is unchanged.
