### PR TITLE
feat: payout contract, request correlation ID, leaderboard rank badges & deployment env reference

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -166,3 +166,68 @@ Query parameters: `limit` (1–200, default 50), `action`, `adminId`.
 - [ ] Run `deploy.sh --network mainnet` — script pauses 5 s before proceeding
 - [ ] Update frontend + backend env vars with mainnet contract IDs
 - [ ] Do not use accounts from `.env.test` on mainnet
+
+---
+
+## Environment variables reference
+
+Copy `backend/.env.example` → `backend/.env` and `frontend/.env.example` →
+`frontend/.env.local`, then fill in the values below. Contract IDs come from
+`contract/deployed.json` after `deploy.sh`.
+
+### Backend (`backend/.env`)
+
+| Variable | Purpose |
+| --- | --- |
+| `PORT` | HTTP port the API listens on |
+| `DATABASE_URL` | Postgres connection string (Prisma) |
+| `MONGODB_URI` | MongoDB connection string |
+| `REDIS_URL` | Redis URL for caching (arena stats, leaderboard) |
+| `ADMIN_API_KEY` | API key gating admin routes |
+| `ADMIN_TOKEN_TTL_SECONDS` | Lifetime of issued admin tokens |
+| `JWT_SECRET` | Secret for signing auth JWTs |
+| `JWT_EXPIRES_IN` / `JWT_REFRESH_EXPIRES_IN` | Access / refresh token lifetimes |
+| `NONCE_TTL_SECONDS` | Validity window for auth challenge nonces |
+| `SOROBAN_RPC_URL` | Soroban RPC endpoint |
+| `STELLAR_NETWORK_PASSPHRASE` | Network passphrase (testnet/mainnet) |
+| `PAYOUT_CONTRACT_ID` | Deployed payout contract id |
+| `PAYOUT_SOURCE_ACCOUNT` | Account that submits payout transactions |
+| `PAYOUT_METHOD_NAME` | Payout contract method (default `distribute_winnings`) |
+| `PAYOUTS_LIVE_EXECUTION` | `true` to submit on-chain; `false` builds only |
+| `PAYOUTS_SIGN_WITH_HOT_KEY` | Sign payouts with a hot key vs. external signer |
+| `PAYOUTS_MAX_GAS_STROOPS` | Reject prepared txs whose fee exceeds this |
+| `PAYOUTS_MAX_ATTEMPTS` | Max submission attempts before a payout fails |
+| `PAYOUTS_CONFIRM_POLL_MS` / `PAYOUTS_CONFIRM_MAX_POLLS` | Confirmation polling cadence/limit |
+
+### Frontend (`frontend/.env.local`)
+
+| Variable | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_STELLAR_NETWORK` | `testnet` or `public` |
+| `NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE` | Network passphrase |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Soroban RPC endpoint |
+| `NEXT_PUBLIC_HORIZON_URL` | Horizon endpoint |
+| `NEXT_PUBLIC_FACTORY_CONTRACT_ID` | Deployed factory contract id |
+| `NEXT_PUBLIC_USDC_CONTRACT_ID` | USDC token contract id |
+| `NEXT_PUBLIC_APP_ORIGIN` | Public app origin (used for share links / sitemap) |
+| `ALLOWED_ORIGINS` | CORS allow-list for the API |
+| `REDIS_URL` | Redis URL (if the frontend uses server-side caching) |
+| `NEXT_PUBLIC_SENTRY_DSN` | Sentry DSN (optional) |
+| `NEXT_PUBLIC_SENTRY_ENVIRONMENT` / `NEXT_PUBLIC_SENTRY_RELEASE` | Sentry tagging (optional) |
+
+> There is no `docker-compose.yml` in this repo today; local services (Postgres,
+> MongoDB, Redis) are expected to be provided by the developer, and the app is run
+> with the `make backend-dev` / `make frontend-dev` targets above.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+| --- | --- |
+| `NotInitialised` from payout calls | The payout contract was deployed but `initialize(admin, token)` was never called. |
+| Payout returns `AlreadyPaid` | The `payout_id` was already executed — idempotency guard. Use a fresh id. |
+| Frontend can't reach contracts | `NEXT_PUBLIC_*` contract IDs don't match `contract/deployed.json`, or RPC URL points at the wrong network. |
+| API 500s with no obvious cause | Grab the `X-Request-Id` response header and grep the backend logs / Sentry for that id. |
+| Arena stats look stale | Redis cache TTL not yet expired; stats are invalidated automatically on round resolution. |
+| `make deploy` fails funding accounts | Testnet friendbot rate-limited — wait and retry, or fund manually (see step 2). |

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import { createApiRouter } from "./routes";
 import { createAdminRouter } from "./routes/admin";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestLogger } from "./middleware/logger";
+import { requestContextMiddleware } from "./middleware/requestContext";
 import { metricsMiddleware } from "./middleware/metrics";
 import {
   ApiKeyAuthProvider,
@@ -44,6 +45,7 @@ export function createApp(deps: AppDependencies): express.Application {
   app.use(cors());
   app.use(express.json());
   app.use(requestLogger);
+  app.use(requestContextMiddleware);
   app.use(metricsMiddleware);
 
   app.get("/health", (_req, res) => {

--- a/backend/src/middleware/requestContext.ts
+++ b/backend/src/middleware/requestContext.ts
@@ -1,0 +1,15 @@
+import type { Request, Response, NextFunction } from "express";
+import { runWithRequestContext } from "../utils/requestContext";
+
+/**
+ * Binds the request's correlation id into AsyncLocalStorage for the lifetime of
+ * the request (#661). Must be mounted *after* the pino-http request logger,
+ * which assigns `req.id` from an inbound `X-Request-ID` header or a fresh UUID.
+ */
+export function requestContextMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const requestId =
+    (req.id as string | undefined) ?? (req.headers["x-request-id"] as string | undefined) ?? "";
+  // Echo it back so clients can quote it when reporting an issue.
+  if (requestId) res.setHeader("X-Request-Id", requestId);
+  runWithRequestContext({ requestId }, () => next());
+}

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import pino from "pino";
 // @ts-ignore
 import * as Sentry from "@sentry/node";
+import { getRequestId } from "./requestContext";
 
 const redactPaths = [
     "req.headers.authorization",
@@ -30,8 +31,18 @@ export const logger = pino({
     timestamp: pino.stdTimeFunctions.isoTime,
 });
 
+/** A child logger carrying the current request id, for service-layer logs (#661). */
+export const contextLogger = () => {
+    const requestId = getRequestId();
+    return requestId ? logger.child({ requestId }) : logger;
+};
+
 export const reportErrorToSentry = (err: Error, context?: Record<string, any>) => {
     Sentry.withScope((scope: any) => {
+        // Tie the Sentry event back to the originating request (#661).
+        const requestId = getRequestId();
+        if (requestId) scope.setTag("requestId", requestId);
+
         if (context) {
             if (context.userWallet) {
                 context.userWalletMasked = maskWalletAddress(context.userWallet);

--- a/backend/src/utils/requestContext.ts
+++ b/backend/src/utils/requestContext.ts
@@ -1,0 +1,22 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Per-request context propagated via AsyncLocalStorage (#661).
+ *
+ * Lets any code reached during a request — services, repositories, error
+ * reporting — read the correlation id without threading it through every call,
+ * so logs and Sentry events can be tied back to the originating HTTP request.
+ */
+export interface RequestContext {
+  requestId: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+export function runWithRequestContext<T>(context: RequestContext, fn: () => T): T {
+  return storage.run(context, fn);
+}
+
+export function getRequestId(): string | undefined {
+  return storage.getStore()?.requestId;
+}

--- a/backend/tests/requestContext.unit.test.ts
+++ b/backend/tests/requestContext.unit.test.ts
@@ -1,0 +1,46 @@
+const setTag = jest.fn();
+const setExtras = jest.fn();
+const captureException = jest.fn();
+
+jest.mock("@sentry/node", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withScope: (fn: (scope: any) => void) => fn({ setTag, setExtras }),
+  captureException,
+}));
+
+import { runWithRequestContext, getRequestId } from "../src/utils/requestContext";
+import { reportErrorToSentry } from "../src/utils/logger";
+
+describe("request context propagation (#661)", () => {
+  beforeEach(() => {
+    setTag.mockClear();
+    captureException.mockClear();
+  });
+
+  it("has no request id outside a request scope", () => {
+    expect(getRequestId()).toBeUndefined();
+  });
+
+  it("exposes the request id within the scope, including across awaits", async () => {
+    await runWithRequestContext({ requestId: "req-123" }, async () => {
+      expect(getRequestId()).toBe("req-123");
+      await Promise.resolve();
+      expect(getRequestId()).toBe("req-123");
+    });
+    // ...and clears once the scope exits.
+    expect(getRequestId()).toBeUndefined();
+  });
+
+  it("tags Sentry events with the active request id", () => {
+    runWithRequestContext({ requestId: "req-abc" }, () => {
+      reportErrorToSentry(new Error("boom"));
+    });
+    expect(setTag).toHaveBeenCalledWith("requestId", "req-abc");
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not tag a request id when there is no active context", () => {
+    reportErrorToSentry(new Error("boom"));
+    expect(setTag).not.toHaveBeenCalledWith("requestId", expect.anything());
+  });
+});

--- a/contract/payout/src/lib.rs
+++ b/contract/payout/src/lib.rs
@@ -1,17 +1,207 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl};
+mod storage;
+mod types;
 
-/// Payout contract — records and distributes winnings to the last surviving player.
+use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Vec};
+use storage::PayoutStorage;
+use types::PayoutError;
+
+/// Payout contract — distributes winnings to the surviving player(s) of an
+/// arena (#660).
 ///
-/// Implementation is open for contribution. See the issue tracker for:
-/// - Idempotent payout execution (principal + accumulated yield)
-/// - Winner verification against arena settlement state
-/// - Admin-gated distribution controls
-/// - Payout lookup helpers for off-chain reconciliation
+/// The backend `PaymentService` builds transactions calling `distribute_winnings`
+/// on this contract; it now lives in-repo so it is open source and auditable.
 ///
-/// Architecture overview: see `ARCHITECTURE.md` in the workspace root.
+/// Distribution is admin-gated and idempotent per `payout_id`: a re-submitted
+/// payout id is rejected, so a retried backend request can never double-pay.
 #[contract]
 pub struct PayoutContract;
 
 #[contractimpl]
-impl PayoutContract {}
+impl PayoutContract {
+    /// One-time setup: record the admin authorised to distribute and the token
+    /// used for payouts.
+    pub fn initialize(env: Env, admin: Address, token: Address) -> Result<(), PayoutError> {
+        if PayoutStorage::has_admin(&env) {
+            return Err(PayoutError::AlreadyInitialised);
+        }
+        PayoutStorage::set_admin(&env, &admin);
+        PayoutStorage::set_token(&env, &token);
+        Ok(())
+    }
+
+    /// Single-winner payout: transfer `amount` of the configured token from the
+    /// contract's balance to `winner`. Idempotent on `payout_id`.
+    pub fn distribute_winnings(
+        env: Env,
+        payout_id: u64,
+        winner: Address,
+        amount: i128,
+    ) -> Result<(), PayoutError> {
+        let admin = PayoutStorage::get_admin(&env)?;
+        admin.require_auth();
+
+        if amount <= 0 {
+            return Err(PayoutError::InvalidAmount);
+        }
+        if PayoutStorage::is_paid(&env, payout_id) {
+            return Err(PayoutError::AlreadyPaid);
+        }
+
+        // Mark paid before transferring — idempotency + reentrancy guard.
+        PayoutStorage::mark_paid(&env, payout_id);
+
+        let token_addr = PayoutStorage::get_token(&env)?;
+        let client = token::TokenClient::new(&env, &token_addr);
+        client.transfer(&env.current_contract_address(), &winner, &amount);
+
+        env.events()
+            .publish((symbol_short!("payout"), winner), (payout_id, amount));
+        Ok(())
+    }
+
+    /// Multi-recipient batch payout in a single transaction. All amounts are
+    /// validated before any transfer, and the batch is idempotent on `payout_id`.
+    pub fn distribute_batch(
+        env: Env,
+        payout_id: u64,
+        recipients: Vec<(Address, i128)>,
+    ) -> Result<(), PayoutError> {
+        let admin = PayoutStorage::get_admin(&env)?;
+        admin.require_auth();
+
+        if recipients.is_empty() {
+            return Err(PayoutError::EmptyBatch);
+        }
+        for (_, amount) in recipients.iter() {
+            if amount <= 0 {
+                return Err(PayoutError::InvalidAmount);
+            }
+        }
+        if PayoutStorage::is_paid(&env, payout_id) {
+            return Err(PayoutError::AlreadyPaid);
+        }
+
+        PayoutStorage::mark_paid(&env, payout_id);
+
+        let token_addr = PayoutStorage::get_token(&env)?;
+        let client = token::TokenClient::new(&env, &token_addr);
+        let contract = env.current_contract_address();
+        for (recipient, amount) in recipients.iter() {
+            client.transfer(&contract, &recipient, &amount);
+            env.events()
+                .publish((symbol_short!("payout"), recipient), (payout_id, amount));
+        }
+        Ok(())
+    }
+
+    /// Whether a payout id has already been executed (off-chain reconciliation).
+    pub fn is_paid(env: Env, payout_id: u64) -> bool {
+        PayoutStorage::is_paid(&env, payout_id)
+    }
+
+    pub fn admin(env: Env) -> Option<Address> {
+        PayoutStorage::get_admin(&env).ok()
+    }
+
+    pub fn token(env: Env) -> Option<Address> {
+        PayoutStorage::get_token(&env).ok()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::token;
+
+    struct Fixture {
+        env: Env,
+        client: PayoutContractClient<'static>,
+        token: token::TokenClient<'static>,
+    }
+
+    /// Deploy a payout contract funded with `funding` of a fresh test token.
+    fn setup(funding: i128) -> Fixture {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_addr = sac.address();
+
+        let contract_id = env.register(PayoutContract, ());
+        let client = PayoutContractClient::new(&env, &contract_id);
+        client.initialize(&admin, &token_addr);
+
+        // Fund the payout contract so it can pay winners.
+        let token_admin = token::StellarAssetClient::new(&env, &token_addr);
+        token_admin.mint(&contract_id, &funding);
+
+        let token = token::TokenClient::new(&env, &token_addr);
+        Fixture { env, client, token }
+    }
+
+    #[test]
+    fn distributes_single_winner() {
+        let fx = setup(1_000);
+        let winner = Address::generate(&fx.env);
+
+        fx.client.distribute_winnings(&1, &winner, &600);
+
+        assert_eq!(fx.token.balance(&winner), 600);
+        assert!(fx.client.is_paid(&1));
+    }
+
+    #[test]
+    fn rejects_duplicate_payout_id() {
+        let fx = setup(1_000);
+        let winner = Address::generate(&fx.env);
+
+        fx.client.distribute_winnings(&7, &winner, &100);
+        let again = fx.client.try_distribute_winnings(&7, &winner, &100);
+        assert!(again.is_err());
+        // Only paid once.
+        assert_eq!(fx.token.balance(&winner), 100);
+    }
+
+    #[test]
+    fn rejects_non_positive_amount() {
+        let fx = setup(1_000);
+        let winner = Address::generate(&fx.env);
+        assert!(fx.client.try_distribute_winnings(&1, &winner, &0).is_err());
+    }
+
+    #[test]
+    fn distributes_batch_to_multiple_recipients() {
+        let fx = setup(1_000);
+        let a = Address::generate(&fx.env);
+        let b = Address::generate(&fx.env);
+
+        let mut recipients = Vec::new(&fx.env);
+        recipients.push_back((a.clone(), 300i128));
+        recipients.push_back((b.clone(), 150i128));
+        fx.client.distribute_batch(&42, &recipients);
+
+        assert_eq!(fx.token.balance(&a), 300);
+        assert_eq!(fx.token.balance(&b), 150);
+        assert!(fx.client.is_paid(&42));
+    }
+
+    #[test]
+    fn rejects_empty_batch() {
+        let fx = setup(1_000);
+        let recipients: Vec<(Address, i128)> = Vec::new(&fx.env);
+        assert!(fx.client.try_distribute_batch(&1, &recipients).is_err());
+    }
+
+    #[test]
+    fn distribute_before_initialise_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PayoutContract, ());
+        let client = PayoutContractClient::new(&env, &contract_id);
+        let winner = Address::generate(&env);
+        assert!(client.try_distribute_winnings(&1, &winner, &10).is_err());
+    }
+}

--- a/contract/payout/src/storage.rs
+++ b/contract/payout/src/storage.rs
@@ -1,0 +1,50 @@
+#![allow(dead_code)]
+use crate::types::PayoutError;
+use soroban_sdk::{contracttype, symbol_short, Address, Env};
+
+/// Persistent record that a given payout id has been executed, enabling
+/// idempotent distribution and off-chain reconciliation.
+#[contracttype]
+enum DataKey {
+    Paid(u64),
+}
+
+pub struct PayoutStorage;
+
+impl PayoutStorage {
+    pub fn has_admin(env: &Env) -> bool {
+        env.storage().instance().has(&symbol_short!("ADMIN"))
+    }
+
+    pub fn set_admin(env: &Env, admin: &Address) {
+        env.storage().instance().set(&symbol_short!("ADMIN"), admin);
+    }
+
+    pub fn get_admin(env: &Env) -> Result<Address, PayoutError> {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("ADMIN"))
+            .ok_or(PayoutError::NotInitialised)
+    }
+
+    pub fn set_token(env: &Env, token: &Address) {
+        env.storage().instance().set(&symbol_short!("TOKEN"), token);
+    }
+
+    pub fn get_token(env: &Env) -> Result<Address, PayoutError> {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("TOKEN"))
+            .ok_or(PayoutError::NotInitialised)
+    }
+
+    pub fn is_paid(env: &Env, payout_id: u64) -> bool {
+        env.storage().persistent().has(&DataKey::Paid(payout_id))
+    }
+
+    pub fn mark_paid(env: &Env, payout_id: u64) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Paid(payout_id), &true);
+    }
+}

--- a/contract/payout/src/types.rs
+++ b/contract/payout/src/types.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::contracterror;
+
+/// Error codes returned by the payout contract.
+#[contracterror]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PayoutError {
+    /// The contract has not been initialised with an admin and token.
+    NotInitialised = 1,
+    /// `initialize` was called on an already-initialised contract.
+    AlreadyInitialised = 2,
+    /// Caller is not the configured admin.
+    Unauthorized = 3,
+    /// A payout with this id has already been executed (idempotency guard).
+    AlreadyPaid = 4,
+    /// A payout amount was zero or negative.
+    InvalidAmount = 5,
+    /// A batch payout was submitted with no recipients.
+    EmptyBatch = 6,
+}

--- a/frontend/src/features/leaderboard/components/RankBadge.tsx
+++ b/frontend/src/features/leaderboard/components/RankBadge.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { RankMovement } from "../types";
+
+interface RankBadgeProps {
+  rank: number;
+  /**
+   * Optional rank change since the previous snapshot. When provided, an
+   * animated arrow is shown (#662). Omit when no prior rank is known.
+   */
+  movement?: RankMovement;
+}
+
+/** Medal styling for the top three ranks; plain styling below. */
+const MEDAL: Record<number, string> = {
+  1: "text-[#FFD700] drop-shadow-[0_0_6px_rgba(255,215,0,0.5)]",
+  2: "text-[#C0C0C0] drop-shadow-[0_0_6px_rgba(192,192,192,0.45)]",
+  3: "text-[#CD7F32] drop-shadow-[0_0_6px_rgba(205,127,50,0.45)]",
+};
+
+const MOVEMENT_META: Record<RankMovement, { symbol: string; className: string; label: string }> = {
+  up: { symbol: "▲", className: "text-neon-green", label: "moved up" },
+  down: { symbol: "▼", className: "text-neon-pink", label: "moved down" },
+  same: { symbol: "–", className: "text-white/40", label: "unchanged" },
+};
+
+/**
+ * Displays a leaderboard rank with medal styling for the top three and an
+ * optional animated indicator for rank changes (#662).
+ */
+export function RankBadge({ rank, movement }: RankBadgeProps) {
+  const medalClass = MEDAL[rank] ?? "text-white";
+  const move = movement ? MOVEMENT_META[movement] : null;
+
+  return (
+    <span className="inline-flex items-center gap-1.5" data-testid="rank-badge">
+      <span
+        className={`font-display text-3xl font-light italic transition-all duration-300 ${medalClass}`}
+      >
+        {rank}
+      </span>
+      {move ? (
+        <span
+          role="img"
+          aria-label={`Rank ${move.label}`}
+          className={`text-xs font-bold animate-in fade-in zoom-in duration-300 ${move.className}`}
+        >
+          {move.symbol}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/frontend/src/features/leaderboard/components/RankTableRow.tsx
+++ b/frontend/src/features/leaderboard/components/RankTableRow.tsx
@@ -2,6 +2,7 @@
 
 import { Survivor } from "../types";
 import { formatAgentId, formatCurrency } from "../data/mockLeaderboard";
+import { RankBadge } from "./RankBadge";
 
 interface RankTableRowProps {
   survivor: Survivor;
@@ -24,9 +25,7 @@ export function RankTableRow({ survivor, onChallenge }: RankTableRowProps) {
   return (
     <tr className="border-b border-white/5 transition-colors hover:bg-white/[0.02]">
       <td className="py-5 pl-6 pr-4">
-        <span className="font-display text-3xl font-light italic text-white">
-          {survivor.rank}
-        </span>
+        <RankBadge rank={survivor.rank} movement={survivor.rankMovement} />
       </td>
 
       <td className="px-4 py-5">

--- a/frontend/src/features/leaderboard/components/__tests__/RankBadge.test.tsx
+++ b/frontend/src/features/leaderboard/components/__tests__/RankBadge.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { RankBadge } from "../RankBadge";
+
+describe("RankBadge (#662)", () => {
+  it("renders the rank number", () => {
+    render(<RankBadge rank={5} />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("applies medal styling to the top three ranks", () => {
+    const { container: first } = render(<RankBadge rank={1} />);
+    const { container: tenth } = render(<RankBadge rank={10} />);
+    // Rank 1 gets the gold medal colour; rank 10 does not.
+    expect(first.querySelector('[class*="FFD700"]')).not.toBeNull();
+    expect(tenth.querySelector('[class*="FFD700"]')).toBeNull();
+  });
+
+  it("shows no movement indicator by default", () => {
+    render(<RankBadge rank={4} />);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("shows an animated up indicator when the rank improved", () => {
+    render(<RankBadge rank={2} movement="up" />);
+    const indicator = screen.getByRole("img", { name: /moved up/i });
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.className).toMatch(/animate-in/);
+  });
+
+  it("shows a down indicator when the rank dropped", () => {
+    render(<RankBadge rank={8} movement="down" />);
+    expect(screen.getByRole("img", { name: /moved down/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/leaderboard/types.ts
+++ b/frontend/src/features/leaderboard/types.ts
@@ -1,5 +1,7 @@
 // Leaderboard types
 
+export type RankMovement = "up" | "down" | "same";
+
 export interface Survivor {
   id: string;
   agentId: string; // wallet address (truncated for display)
@@ -7,6 +9,8 @@ export interface Survivor {
   survivalStreak: number;
   totalYield: number; // in USDC
   arenasWon: number;
+  /** Rank change since the previous snapshot, when known (#662). */
+  rankMovement?: RankMovement;
 }
 
 // Pagination state


### PR DESCRIPTION
## Summary

A new on-chain payout contract, request observability, a leaderboard UI touch, and deployment docs.

### Payout contract (closes #660)
- Implements `contract/payout`: **`distribute_winnings`** (single winner) and **`distribute_batch`** (multi-recipient), both **admin-gated** and **idempotent per `payout_id`** — the id is marked paid *before* transferring, guarding against double-pay and reentrancy. Adds `is_paid` / `admin` / `token` getters, `storage.rs` + `types.rs`, and 6 unit tests (using a registered test token) covering single/batch payout, duplicate-id rejection, non-positive amounts, empty batch, and pre-init guard. Brings the contract the backend `PaymentService` already calls into the repo.

### Request correlation ID (closes #661)
- The pino-http logger already assigns `req.id` from `X-Request-ID`/UUID; this adds an **AsyncLocalStorage** request context so the id is available to service-layer logs without threading it through calls, and `reportErrorToSentry` now **tags Sentry events** with the request id. 4 unit tests (propagation across awaits, Sentry tag, no-context case).

### Leaderboard rank badges (closes #662)
- New **`RankBadge`**: medal styling for the top three ranks + an optional **animated up/down indicator** for rank changes (`Survivor` gains an optional `rankMovement`); wired into `RankTableRow`. 5 component tests. (`LeaderboardTable`/`RankTableRow`/pagination already existed.)

### Deployment env reference (closes #663)
- DEPLOYMENT.md already covered prerequisites, contract deploy, and run steps; this adds the missing **consolidated environment-variable reference** (backend + frontend) and a **troubleshooting** table.

## Tests
- Contract: 6 payout unit tests (`cargo test -p payout`).
- Backend: `requestContext.unit.test.ts` (4).
- Frontend: `RankBadge` (5).

## Notes (honest disclosure)
- The leaderboard **page** test (`dashboard/leaderboard`) fails to resolve the `@/features/leaderboard` barrel under jest — this reproduces on clean `main` (pre-existing, unrelated to this PR); the new `RankBadge` tests pass.
- `contract/payout/abi_snapshot.json` is left as the placeholder `[]` consistent with every other contract's snapshot in this repo (arena/factory/staking are all `[]`). Regenerating requires the `stellar` CLI via `scripts/generate_abi_snapshots.sh`, which isn't available in my environment.
- No `docker-compose.yml` exists in the repo, so the deployment docs reflect the actual `make`-based workflow rather than inventing one.
