### PR TITLE
feat: RWA oracle integration, Soroban circuit breaker, Makefile targets, leaderboard pagination tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,64 @@
-.PHONY: contracts-build contracts-deploy contracts-init-factory contracts-abi-check \
-        backend-dev backend-test frontend-dev help
+.PHONY: dev test build migrate migrate-prod infra monitoring clean help \
+        contracts-build contracts-deploy contracts-init-factory contracts-abi-check \
+        backend-dev backend-test frontend-dev
 
 NETWORK ?= testnet
 SOURCE  ?= deployer
 
-help:
-	@echo "InverseArena — top-level Makefile"
-	@echo ""
-	@echo "Contract targets (run from repo root, scripts operate inside contract/):"
-	@echo "  make contracts-build           Build + optimise all Soroban contracts"
-	@echo "  make contracts-deploy          Upload + deploy to \$$NETWORK (default: testnet)"
-	@echo "  make contracts-init-factory    Initialise factory with arena WASM hash"
-	@echo "  make contracts-abi-check       Verify ABI snapshots match compiled WASM"
-	@echo ""
-	@echo "Backend targets:"
-	@echo "  make backend-dev               Start backend in watch mode"
-	@echo "  make backend-test              Run backend test suite"
-	@echo ""
-	@echo "Frontend targets:"
-	@echo "  make frontend-dev              Start Next.js dev server"
-	@echo ""
-	@echo "Options:"
-	@echo "  NETWORK=testnet|mainnet        Target Stellar network (default: testnet)"
-	@echo "  SOURCE=<identity>              Stellar CLI identity name (default: deployer)"
+## ── Convenience shortcuts ──────────────────────────────────────────────────
 
-contracts-build:
+dev: ## Start frontend + backend in development mode
+	cd backend && npm run dev &
+	cd frontend && pnpm dev
+
+test: ## Run all tests (backend + frontend)
+	cd backend && npm run test:ci
+	cd frontend && pnpm test --passWithNoTests
+
+build: ## Build frontend and backend for production
+	cd backend && npm run build
+	cd frontend && pnpm build
+
+migrate: ## Apply pending Prisma migrations (development)
+	cd backend && npm run migrate:dev
+
+migrate-prod: ## Apply migrations in production (no seed)
+	cd backend && npx prisma migrate deploy
+
+infra: ## Start PostgreSQL + Redis via Docker Compose
+	docker-compose up -d
+
+monitoring: ## Start Prometheus + Grafana monitoring stack
+	docker-compose -f backend/docker-compose.monitoring.yml up -d
+
+clean: ## Remove build artifacts and node_modules
+	rm -rf backend/dist frontend/.next
+	rm -rf backend/node_modules frontend/node_modules
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+## ── Contract targets ───────────────────────────────────────────────────────
+
+contracts-build: ## Build + optimise all Soroban contracts
 	cd contract && bash scripts/build.sh
 
-contracts-deploy:
+contracts-deploy: ## Upload + deploy to $$NETWORK (default: testnet)
 	cd contract && NETWORK=$(NETWORK) SOURCE=$(SOURCE) bash scripts/deploy.sh --network $(NETWORK) --source $(SOURCE)
 
-contracts-init-factory:
+contracts-init-factory: ## Initialise factory with arena WASM hash
 	cd contract && NETWORK=$(NETWORK) SOURCE=$(SOURCE) bash scripts/init-factory.sh --network $(NETWORK) --source $(SOURCE)
 
-contracts-abi-check:
+contracts-abi-check: ## Verify ABI snapshots match compiled WASM
 	cd contract && bash scripts/generate_abi_snapshots.sh --check
 
-backend-dev:
+## ── Granular targets (kept for backwards compatibility) ────────────────────
+
+backend-dev: ## Start backend in watch mode
 	cd backend && npm run dev
 
-backend-test:
+backend-test: ## Run backend test suite
 	cd backend && npm test
 
-frontend-dev:
-	cd frontend && npm run dev
+frontend-dev: ## Start Next.js dev server
+	cd frontend && pnpm dev

--- a/README.md
+++ b/README.md
@@ -153,7 +153,23 @@ git clone https://github.com/your-org/inversearena-frontend.git
 cd inversearena-frontend
 ```
 
-### 2. Set Up the Frontend
+### 2. Quick Start with Make
+
+A root-level `Makefile` provides a single discoverable entry point for all common tasks:
+
+```bash
+make help          # List all available targets
+make dev           # Start frontend + backend in development mode
+make test          # Run all tests (backend + frontend)
+make build         # Build both services for production
+make migrate       # Apply pending Prisma migrations (development)
+make migrate-prod  # Apply migrations in production (no seed)
+make infra         # Start PostgreSQL + Redis via Docker Compose
+make monitoring    # Start Prometheus + Grafana monitoring stack
+make clean         # Remove build artifacts and node_modules
+```
+
+### 3. Set Up the Frontend
 
 ```bash
 cd frontend
@@ -164,7 +180,7 @@ pnpm dev
 
 The frontend runs at **http://localhost:3000** by default.
 
-### 3. Set Up the Backend
+### 4. Set Up the Backend
 
 ```bash
 cd backend

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -52,6 +52,15 @@ export function createApp(deps: AppDependencies): express.Application {
     res.json({ status: "ok" });
   });
 
+  app.get("/ready", (_req, res) => {
+    const breakerStats = deps.paymentService.getSorobanBreakerStats();
+    const sorobanUp = breakerStats.state !== "open";
+    res.status(sorobanUp ? 200 : 503).json({
+      status: sorobanUp ? "ready" : "degraded",
+      sorobanCircuitBreaker: breakerStats,
+    });
+  });
+
   app.get("/metrics", async (_req, res) => {
     try {
       await refreshArenaMetrics(prisma);

--- a/backend/src/services/paymentService.ts
+++ b/backend/src/services/paymentService.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import { getPaymentConfig, type PaymentConfig } from "../config/paymentConfig";
 import type { TransactionRepository } from "../repositories/transactionRepository";
 import { payoutsSuccessTotal } from "../utils/metrics";
+import { CircuitOpenError, getSorobanBreaker, type CircuitBreaker } from "../utils/circuitBreaker";
 import type {
   BuildPayoutResult,
   CreatePayoutRequest,
@@ -77,11 +78,13 @@ const delay = async (ms: number): Promise<void> =>
 export interface PaymentServiceOptions {
   config?: PaymentConfig;
   rpcServer?: any;
+  circuitBreaker?: CircuitBreaker;
 }
 
 export class PaymentService {
   private readonly config: PaymentConfig;
   private readonly rpcServer: any;
+  private readonly breaker: CircuitBreaker;
 
   constructor(
     private readonly transactions: TransactionRepository,
@@ -89,6 +92,11 @@ export class PaymentService {
   ) {
     this.config = options.config ?? getPaymentConfig();
     this.rpcServer = options.rpcServer ?? new Server(this.config.sorobanRpcUrl);
+    this.breaker = options.circuitBreaker ?? getSorobanBreaker();
+  }
+
+  getSorobanBreakerStats() {
+    return this.breaker.getStats();
   }
 
   async createPayoutTransaction(input: unknown): Promise<BuildPayoutResult> {
@@ -209,7 +217,18 @@ export class PaymentService {
         transaction.signedXdr,
         this.config.networkPassphrase
       );
-      const sendResult = await this.rpcServer.sendTransaction(signedTransaction);
+
+      let sendResult: Awaited<ReturnType<typeof this.rpcServer.sendTransaction>>;
+      try {
+        sendResult = await this.breaker.fire(() =>
+          this.rpcServer.sendTransaction(signedTransaction)
+        );
+      } catch (err) {
+        if (err instanceof CircuitOpenError) {
+          return { transaction, submitted: false };
+        }
+        throw err;
+      }
 
       if (sendResult.status === "ERROR") {
         const failed = await this.transactions.update(transaction.id, {
@@ -258,7 +277,17 @@ export class PaymentService {
       return transaction;
     }
 
-    const onChain = await this.rpcServer.getTransaction(transaction.txHash);
+    let onChain: Awaited<ReturnType<typeof this.rpcServer.getTransaction>>;
+    try {
+      onChain = await this.breaker.fire(() =>
+        this.rpcServer.getTransaction(transaction.txHash)
+      );
+    } catch (err) {
+      if (err instanceof CircuitOpenError) {
+        return transaction;
+      }
+      throw err;
+    }
 
     if (onChain.status === Api.GetTransactionStatus.SUCCESS) {
       payoutsSuccessTotal.inc({ asset: transaction.asset });
@@ -364,7 +393,9 @@ export class PaymentService {
   }
 
   private async buildPreparedTransaction(request: CreatePayoutRequest, nonce: number) {
-    const sourceAccount = await this.rpcServer.getAccount(this.config.sourceAccount);
+    const sourceAccount = await this.breaker.fire(() =>
+      this.rpcServer.getAccount(this.config.sourceAccount)
+    );
     const contract = new Contract(this.config.payoutContractId);
     const amountStroops = toStroops(request.amount);
 
@@ -385,7 +416,9 @@ export class PaymentService {
       .setTimeout(60)
       .build();
 
-    const preparedTransaction = await this.rpcServer.prepareTransaction(built);
+    const preparedTransaction = await this.breaker.fire(() =>
+      this.rpcServer.prepareTransaction(built)
+    );
 
     const feeStroops = Number(preparedTransaction.fee);
     if (!Number.isFinite(feeStroops) || feeStroops <= 0) {

--- a/backend/src/utils/circuitBreaker.ts
+++ b/backend/src/utils/circuitBreaker.ts
@@ -1,0 +1,174 @@
+type CircuitState = "closed" | "open" | "half-open";
+
+interface CircuitBreakerOptions {
+  timeout: number;
+  errorThresholdPercentage: number;
+  resetTimeout: number;
+  volumeThreshold?: number;
+}
+
+interface CircuitBreakerStats {
+  state: CircuitState;
+  failures: number;
+  successes: number;
+  lastFailureTime: number | null;
+}
+
+export class CircuitBreaker {
+  private state: CircuitState = "closed";
+  private failures = 0;
+  private successes = 0;
+  private lastFailureTime: number | null = null;
+  private readonly windowStart: number;
+  private readonly options: Required<CircuitBreakerOptions>;
+  private readonly listeners: Map<string, Array<() => void>> = new Map();
+
+  constructor(options: CircuitBreakerOptions) {
+    this.options = {
+      volumeThreshold: 5,
+      ...options,
+    };
+    this.windowStart = Date.now();
+  }
+
+  async fire<T>(action: () => Promise<T>): Promise<T> {
+    if (this.state === "open") {
+      if (this.shouldAttemptReset()) {
+        this.transitionTo("half-open");
+      } else {
+        throw new CircuitOpenError("Soroban RPC circuit is OPEN — request rejected");
+      }
+    }
+
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`Soroban RPC call timed out after ${this.options.timeout}ms`)),
+        this.options.timeout,
+      ),
+    );
+
+    try {
+      const result = await Promise.race([action(), timeoutPromise]);
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      this.onFailure();
+      throw err;
+    }
+  }
+
+  getStats(): CircuitBreakerStats {
+    return {
+      state: this.state,
+      failures: this.failures,
+      successes: this.successes,
+      lastFailureTime: this.lastFailureTime,
+    };
+  }
+
+  on(event: "open" | "close" | "halfOpen", listener: () => void): void {
+    if (!this.listeners.has(event)) this.listeners.set(event, []);
+    this.listeners.get(event)!.push(listener);
+  }
+
+  private onSuccess(): void {
+    this.successes++;
+    if (this.state === "half-open") {
+      this.transitionTo("closed");
+      this.reset();
+    }
+  }
+
+  private onFailure(): void {
+    this.failures++;
+    this.lastFailureTime = Date.now();
+
+    const total = this.failures + this.successes;
+    if (total < this.options.volumeThreshold) return;
+
+    const errorRate = (this.failures / total) * 100;
+    if (errorRate >= this.options.errorThresholdPercentage) {
+      this.transitionTo("open");
+    }
+  }
+
+  private shouldAttemptReset(): boolean {
+    if (!this.lastFailureTime) return false;
+    return Date.now() - this.lastFailureTime >= this.options.resetTimeout;
+  }
+
+  private transitionTo(next: CircuitState): void {
+    if (this.state === next) return;
+    this.state = next;
+
+    const eventMap: Record<CircuitState, string> = {
+      open: "open",
+      closed: "close",
+      "half-open": "halfOpen",
+    };
+
+    const eventName = eventMap[next];
+    const handlers = this.listeners.get(eventName) ?? [];
+    for (const handler of handlers) handler();
+  }
+
+  private reset(): void {
+    this.failures = 0;
+    this.successes = 0;
+  }
+}
+
+export class CircuitOpenError extends Error {
+  readonly isCircuitOpen = true;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "CircuitOpenError";
+  }
+}
+
+let _sorobanBreaker: CircuitBreaker | null = null;
+
+export function getSorobanBreaker(): CircuitBreaker {
+  if (!_sorobanBreaker) {
+    _sorobanBreaker = new CircuitBreaker({
+      timeout: 10_000,
+      errorThresholdPercentage: 50,
+      resetTimeout: 30_000,
+      volumeThreshold: 5,
+    });
+
+    _sorobanBreaker.on("open", () => {
+      console.warn("[circuit-breaker] Soroban RPC circuit OPEN — calls will be rejected");
+      try {
+        const { sorobanCircuitBreakerState, sorobanCircuitTransitionsTotal } =
+          require("./metrics") as typeof import("./metrics");
+        sorobanCircuitBreakerState.set(2);
+        sorobanCircuitTransitionsTotal.inc({ to_state: "open" });
+      } catch { /* metrics not available in test environments */ }
+    });
+    _sorobanBreaker.on("halfOpen", () => {
+      console.info("[circuit-breaker] Soroban RPC circuit HALF-OPEN — probing");
+      try {
+        const { sorobanCircuitBreakerState, sorobanCircuitTransitionsTotal } =
+          require("./metrics") as typeof import("./metrics");
+        sorobanCircuitBreakerState.set(1);
+        sorobanCircuitTransitionsTotal.inc({ to_state: "half-open" });
+      } catch { /* metrics not available in test environments */ }
+    });
+    _sorobanBreaker.on("close", () => {
+      console.info("[circuit-breaker] Soroban RPC circuit CLOSED — normal operation");
+      try {
+        const { sorobanCircuitBreakerState, sorobanCircuitTransitionsTotal } =
+          require("./metrics") as typeof import("./metrics");
+        sorobanCircuitBreakerState.set(0);
+        sorobanCircuitTransitionsTotal.inc({ to_state: "closed" });
+      } catch { /* metrics not available in test environments */ }
+    });
+  }
+  return _sorobanBreaker;
+}
+
+export function resetSorobanBreakerForTest(): void {
+  _sorobanBreaker = null;
+}

--- a/backend/src/utils/metrics.ts
+++ b/backend/src/utils/metrics.ts
@@ -76,6 +76,20 @@ export const payoutsSuccessTotal = new Counter({
   registers: [register],
 });
 
+// 0 = closed (healthy), 1 = half-open (probing), 2 = open (failing)
+export const sorobanCircuitBreakerState = new Gauge({
+  name: 'inversearena_soroban_circuit_breaker_state',
+  help: 'Soroban RPC circuit breaker state: 0=closed, 1=half-open, 2=open',
+  registers: [register],
+});
+
+export const sorobanCircuitTransitionsTotal = new Counter({
+  name: 'inversearena_soroban_circuit_transitions_total',
+  help: 'Total Soroban RPC circuit breaker state transitions',
+  labelNames: ['to_state'],
+  registers: [register],
+});
+
 export async function refreshArenaMetrics(prisma: PrismaClient): Promise<void> {
   const activeRounds = await prisma.round.findMany({
     where: {

--- a/backend/tests/leaderboard.test.ts
+++ b/backend/tests/leaderboard.test.ts
@@ -22,12 +22,17 @@ function makeRes(): { json: (body: unknown) => void; captured: unknown; status: 
   return res;
 }
 
-async function setupTestData() {
-  // Clean slate
+// ── Seed helpers ───────────────────────────────────────────────────
+
+async function cleanDb() {
   await prisma.eliminationLog.deleteMany();
   await prisma.round.deleteMany();
   await prisma.arena.deleteMany();
   await prisma.user.deleteMany();
+}
+
+async function setupTestData() {
+  await cleanDb();
 
   const arena1 = await prisma.arena.create({ data: {} });
   const arena2 = await prisma.arena.create({ data: {} });
@@ -87,6 +92,43 @@ async function setupTestData() {
   return { arena1, arena2, u1, u2, u3 };
 }
 
+/**
+ * Seeds `count` users across unique arenas with deterministic stats.
+ * User i has totalYield = (count - i) * 10 and arenasWon = 1 (never eliminated).
+ * Ordering is deterministic so rank assertions hold across test runs.
+ */
+async function seedLeaderboardData(count: number) {
+  await cleanDb();
+
+  const users: { id: string }[] = [];
+  for (let i = 0; i < count; i++) {
+    const user = await prisma.user.create({
+      data: { walletAddress: `G${"A".repeat(54 - String(i).length)}${i}` },
+    });
+    users.push(user);
+  }
+
+  for (let i = 0; i < count; i++) {
+    const arena = await prisma.arena.create({ data: {} });
+    await prisma.round.create({
+      data: {
+        arenaId: arena.id,
+        roundNumber: 1,
+        state: "RESOLVED",
+        metadata: {
+          playerChoices: [{ userId: users[i].id, choice: "HIGH", stake: 100 }],
+          resolution: {
+            eliminatedPlayers: [],
+            payouts: [{ userId: users[i].id, amount: (count - i) * 10 }],
+          },
+        },
+      },
+    });
+  }
+
+  return users;
+}
+
 // ── Tests ──────────────────────────────────────────────────────────
 
 async function testNonEmptyLeaderboard() {
@@ -131,11 +173,7 @@ async function testNonEmptyLeaderboard() {
 async function testEmptyLeaderboard() {
   console.log("\n🧪 Test: Empty leaderboard returns no players");
 
-  // Wipe all game data
-  await prisma.eliminationLog.deleteMany();
-  await prisma.round.deleteMany();
-  await prisma.arena.deleteMany();
-  await prisma.user.deleteMany();
+  await cleanDb();
 
   const controller = new LeaderboardController(prisma);
   const res = makeRes();
@@ -148,6 +186,222 @@ async function testEmptyLeaderboard() {
     console.log("✅ PASS: Empty leaderboard handled gracefully");
   } else {
     console.log("❌ FAIL: Expected empty players array");
+    process.exit(1);
+  }
+}
+
+async function testSingleUserRankOne() {
+  console.log("\n🧪 Test: Single user has rank 1");
+
+  await cleanDb();
+
+  const user = await prisma.user.create({ data: { walletAddress: "GSOLO000" } });
+  const arena = await prisma.arena.create({ data: {} });
+  await prisma.round.create({
+    data: {
+      arenaId: arena.id,
+      roundNumber: 1,
+      state: "RESOLVED",
+      metadata: {
+        playerChoices: [{ userId: user.id, choice: "HIGH", stake: 100 }],
+        resolution: { eliminatedPlayers: [], payouts: [{ userId: user.id, amount: 150 }] },
+      },
+    },
+  });
+
+  const controller = new LeaderboardController(prisma);
+  const res = makeRes();
+  await controller.getLeaderboard(makeReq(), res as unknown as Response);
+
+  const body = res.captured as { players: { id: string; rank: number }[]; nextCursor: null };
+
+  if (body.players.length === 1 && body.players[0].rank === 1 && body.players[0].id === user.id) {
+    console.log("✅ PASS: Single user is correctly ranked 1");
+  } else {
+    console.log("❌ FAIL: Single-user rank assertion failed");
+    console.log("Received:", JSON.stringify(body, null, 2));
+    process.exit(1);
+  }
+}
+
+async function testTwoHundredUsersNonOverlappingPages() {
+  console.log("\n🧪 Test: 200-user dataset — pages are non-overlapping and cover all users");
+
+  await seedLeaderboardData(200);
+
+  const controller = new LeaderboardController(prisma);
+
+  const page1Res = makeRes();
+  await controller.getLeaderboard(makeReq({ limit: "25" }), page1Res as unknown as Response);
+  const page1 = page1Res.captured as { players: { id: string; rank: number }[]; nextCursor: string };
+
+  const page2Res = makeRes();
+  await controller.getLeaderboard(
+    makeReq({ limit: "25", cursor: page1.nextCursor }),
+    page2Res as unknown as Response,
+  );
+  const page2 = page2Res.captured as { players: { id: string; rank: number }[]; nextCursor: string };
+
+  const page3Res = makeRes();
+  await controller.getLeaderboard(
+    makeReq({ limit: "25", cursor: page2.nextCursor }),
+    page3Res as unknown as Response,
+  );
+  const page3 = page3Res.captured as { players: { id: string; rank: number }[]; nextCursor: string | null };
+
+  const ids1 = page1.players.map((p) => p.id);
+  const ids2 = page2.players.map((p) => p.id);
+  const ids3 = page3.players.map((p) => p.id);
+
+  const noOverlap12 = !ids1.some((id) => ids2.includes(id));
+  const noOverlap23 = !ids2.some((id) => ids3.includes(id));
+  const noOverlap13 = !ids1.some((id) => ids3.includes(id));
+
+  const ranksAscending = page1.players.every((p, i) =>
+    i === 0 || p.rank === page1.players[i - 1].rank + 1,
+  );
+
+  const page2StartsAfterPage1 =
+    page2.players[0]?.rank === page1.players[page1.players.length - 1].rank + 1;
+
+  if (
+    page1.players.length === 25 &&
+    page2.players.length === 25 &&
+    page3.players.length === 25 &&
+    noOverlap12 && noOverlap23 && noOverlap13 &&
+    ranksAscending && page2StartsAfterPage1
+  ) {
+    console.log("✅ PASS: Pages are non-overlapping and correctly ordered");
+  } else {
+    console.log("❌ FAIL: Pagination non-overlap assertion failed");
+    console.log(`Pages: ${page1.players.length}, ${page2.players.length}, ${page3.players.length}`);
+    console.log(`No overlap 1-2: ${noOverlap12}, 2-3: ${noOverlap23}, 1-3: ${noOverlap13}`);
+    process.exit(1);
+  }
+}
+
+async function testInvalidCursorFallsBackToPageOne() {
+  console.log("\n🧪 Test: Invalid cursor falls back to first page");
+
+  await setupTestData();
+
+  const controller = new LeaderboardController(prisma);
+  const res = makeRes();
+
+  await controller.getLeaderboard(
+    makeReq({ cursor: "!!!not-a-valid-cursor!!!" }),
+    res as unknown as Response,
+  );
+
+  const body = res.captured as { players: { rank: number }[]; nextCursor: string | null };
+
+  if (body.players.length > 0 && body.players[0].rank === 1) {
+    console.log("✅ PASS: Invalid cursor gracefully defaults to page 1");
+  } else {
+    console.log("❌ FAIL: Invalid cursor did not default to page 1");
+    console.log("Received:", JSON.stringify(body, null, 2));
+    process.exit(1);
+  }
+}
+
+async function testLimitBoundaries() {
+  console.log("\n🧪 Test: limit boundary values — limit=1 and limit capped at 100");
+
+  await seedLeaderboardData(150);
+
+  const controller = new LeaderboardController(prisma);
+
+  // limit=1 returns exactly one player
+  const res1 = makeRes();
+  await controller.getLeaderboard(makeReq({ limit: "1" }), res1 as unknown as Response);
+  const body1 = res1.captured as { players: unknown[]; nextCursor: string | null };
+
+  // limit=100 returns at most 100 players
+  const res100 = makeRes();
+  await controller.getLeaderboard(makeReq({ limit: "100" }), res100 as unknown as Response);
+  const body100 = res100.captured as { players: unknown[]; nextCursor: string | null };
+
+  // limit=101 should be capped — controller schema max is 100, zod will reject or cap
+  const res101 = makeRes();
+  let limit101Error: unknown;
+  try {
+    await controller.getLeaderboard(makeReq({ limit: "101" }), res101 as unknown as Response);
+  } catch (err) {
+    limit101Error = err;
+  }
+
+  const limitOneOk = body1.players.length === 1 && body1.nextCursor !== null;
+  const limitHundredOk = body100.players.length === 100 && body100.nextCursor !== null;
+  const limitOverCapped = limit101Error !== undefined; // zod rejects > 100
+
+  if (limitOneOk && limitHundredOk && limitOverCapped) {
+    console.log("✅ PASS: limit=1 returns 1 player, limit=100 caps correctly, limit=101 rejected");
+  } else {
+    console.log("❌ FAIL: limit boundary test failed");
+    console.log(`limit=1: ${body1.players.length} players, nextCursor: ${body1.nextCursor}`);
+    console.log(`limit=100: ${body100.players.length} players, nextCursor: ${body100.nextCursor}`);
+    console.log(`limit=101 error thrown: ${limit101Error !== undefined}`);
+    process.exit(1);
+  }
+}
+
+async function testTieBreakingByArenasWon() {
+  console.log("\n🧪 Test: Tie-breaking by arenasWon when totalYield is equal");
+
+  await cleanDb();
+
+  const [uA, uB] = await Promise.all([
+    prisma.user.create({ data: { walletAddress: "GTIE_A000000000000000000000000000000000000000000000000000" } }),
+    prisma.user.create({ data: { walletAddress: "GTIE_B000000000000000000000000000000000000000000000000000" } }),
+  ]);
+
+  // Both users have the same totalYield (100), but uA won 2 arenas vs uB's 1
+  for (let i = 0; i < 2; i++) {
+    const arena = await prisma.arena.create({ data: {} });
+    await prisma.round.create({
+      data: {
+        arenaId: arena.id,
+        roundNumber: 1,
+        state: "RESOLVED",
+        metadata: {
+          playerChoices: [{ userId: uA.id, choice: "HIGH", stake: 100 }],
+          resolution: { eliminatedPlayers: [], payouts: [{ userId: uA.id, amount: 50 }] },
+        },
+      },
+    });
+  }
+
+  const arena3 = await prisma.arena.create({ data: {} });
+  await prisma.round.create({
+    data: {
+      arenaId: arena3.id,
+      roundNumber: 1,
+      state: "RESOLVED",
+      metadata: {
+        playerChoices: [{ userId: uB.id, choice: "HIGH", stake: 100 }],
+        resolution: { eliminatedPlayers: [], payouts: [{ userId: uB.id, amount: 100 }] },
+      },
+    },
+  });
+
+  const controller = new LeaderboardController(prisma);
+  const res = makeRes();
+  await controller.getLeaderboard(makeReq(), res as unknown as Response);
+
+  const body = res.captured as { players: { id: string; rank: number; totalYield: number; arenasWon: number }[] };
+
+  const rankA = body.players.find((p) => p.id === uA.id);
+  const rankB = body.players.find((p) => p.id === uB.id);
+
+  const sameYield = rankA?.totalYield === rankB?.totalYield;
+  const uAWinsOnArenas = rankA !== undefined && rankB !== undefined && rankA.rank < rankB.rank;
+
+  if (sameYield && uAWinsOnArenas) {
+    console.log("✅ PASS: arenasWon correctly breaks yield ties");
+  } else {
+    console.log("❌ FAIL: Tie-breaking by arenasWon failed");
+    console.log("uA:", JSON.stringify(rankA));
+    console.log("uB:", JSON.stringify(rankB));
     process.exit(1);
   }
 }
@@ -229,6 +483,11 @@ async function runTests() {
   try {
     await testNonEmptyLeaderboard();
     await testEmptyLeaderboard();
+    await testSingleUserRankOne();
+    await testTwoHundredUsersNonOverlappingPages();
+    await testInvalidCursorFallsBackToPageOne();
+    await testLimitBoundaries();
+    await testTieBreakingByArenasWon();
     await testPagination();
     await testCrossUserLeaderboardConsistency();
     console.log("\n🎉 All leaderboard tests passed");

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "arena",
     "factory",
+    "oracle",
     "payout",
     "staking",
     "rwa-adapter",

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -2,6 +2,7 @@
 use soroban_sdk::{Address, Bytes, BytesN, Env, Vec, contract, contractimpl, token};
 
 mod eliminations;
+mod oracle;
 mod snapshot_test;
 mod state_machine;
 mod storage;
@@ -38,6 +39,7 @@ impl ArenaContract {
         stake_token: Address,
         yield_vault: Address,
         entry_fee: i128,
+        oracle_contract: Address,
     ) -> Result<(), ArenaError> {
         admin.require_auth();
 
@@ -50,6 +52,7 @@ impl ArenaContract {
             player_count: 0,
             commit_deadline: u64::MAX,
             round_count: 0,
+            oracle_contract,
         };
         ArenaStorage::save_config(&env, &config);
 
@@ -286,11 +289,16 @@ impl ArenaContract {
             return Err(ArenaError::GracePeriodNotElapsed);
         }
 
+        // Fetch the current yield rate from the on-chain oracle. Defaults to
+        // 0 bps if the oracle is unavailable — liveness over precision.
+        let yield_bps = oracle::fetch_yield_bps(&env, &config.oracle_contract);
+        ArenaStorage::save_round_yield_bps(&env, config.round_count, yield_bps);
+
         config.state = GameState::Finished;
         ArenaStorage::save_config(&env, &config);
 
         env.events()
-            .publish((soroban_sdk::symbol_short!("resolved"),), ());
+            .publish((soroban_sdk::symbol_short!("resolved"),), yield_bps);
         Ok(())
     }
 
@@ -346,12 +354,24 @@ impl ArenaContract {
 mod test {
     use super::*;
     use crate::types::ArenaConfig;
-    use soroban_sdk::testutils::{Address as _, Ledger as _};
+    use soroban_sdk::{contract, contractimpl, testutils::{Address as _, Ledger as _}};
+
+    /// Minimal mock oracle that always returns 0 bps — enough for resolve_round tests.
+    #[contract]
+    struct MockOracle;
+
+    #[contractimpl]
+    impl MockOracle {
+        pub fn get_current_yield_bps(_env: Env) -> u32 {
+            0
+        }
+    }
 
     /// Register the contract and seed `n` joined players, returning the client.
     fn setup(n: u32) -> (Env, ArenaContractClient<'static>) {
         let env = Env::default();
         let contract_id = env.register(ArenaContract, ());
+        let oracle_id = env.register(MockOracle, ());
 
         env.as_contract(&contract_id, || {
             let config = ArenaConfig {
@@ -363,6 +383,7 @@ mod test {
                 commit_deadline: u64::MAX,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
+                oracle_contract: oracle_id,
             };
             ArenaStorage::save_config(&env, &config);
             for _ in 0..n {
@@ -452,6 +473,7 @@ mod test {
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
+                oracle_contract: Address::generate(&env),
             };
             ArenaStorage::save_config(&env, &config);
             ArenaStorage::save_commitment(&env, &player, &commitment);
@@ -485,6 +507,7 @@ mod test {
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
+                oracle_contract: Address::generate(&env),
             };
             ArenaStorage::save_config(&env, &config);
             ArenaStorage::save_commitment(&env, &player, &commitment);
@@ -514,6 +537,7 @@ mod test {
                 commit_deadline: 1,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
+                oracle_contract: Address::generate(&env),
             };
             ArenaStorage::save_config(&env, &config);
             ArenaStorage::save_commitment(&env, &player, &commitment);
@@ -544,6 +568,7 @@ mod test {
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
+                oracle_contract: Address::generate(&env),
             };
             ArenaStorage::save_config(&env, &config);
             ArenaStorage::save_commitment(&env, &player, &commitment);
@@ -575,6 +600,7 @@ mod test {
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
+                oracle_contract: Address::generate(&env),
             };
             ArenaStorage::save_config(&env, &config);
         });
@@ -590,6 +616,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let contract_id = env.register(ArenaContract, ());
+        let oracle_id = env.register(MockOracle, ());
         env.as_contract(&contract_id, || {
             let config = ArenaConfig {
                 admin: Address::generate(&env),
@@ -600,6 +627,7 @@ mod test {
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
+                oracle_contract: oracle_id,
             };
             ArenaStorage::save_config(&env, &config);
         });
@@ -647,6 +675,7 @@ mod test {
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
+                oracle_contract: Address::generate(&env),
             };
             ArenaStorage::save_config(&env, &config);
         });

--- a/contract/arena/src/oracle.rs
+++ b/contract/arena/src/oracle.rs
@@ -1,0 +1,62 @@
+use oracle::OracleContractClient;
+use soroban_sdk::{Address, Env};
+
+/// Fetch the current yield rate in basis points from the on-chain oracle.
+///
+/// Calls `get_current_yield_bps` on the configured oracle contract and returns
+/// the rate. Returns `0` if the oracle call fails for any reason — liveness
+/// over precision. A 0-bps round uses only the principal, which is correct.
+///
+/// The oracle contract is a simple admin-settable rate contract (see
+/// `contract/oracle/`). Future upgrades can swap in an autonomous feed such as
+/// Band Protocol on Stellar or Ondo's own exchange-rate contract.
+pub fn fetch_yield_bps(env: &Env, oracle_contract: &Address) -> u32 {
+    let client = OracleContractClient::new(env, oracle_contract);
+    client
+        .try_get_current_yield_bps()
+        .unwrap_or(Ok(0))
+        .unwrap_or(0)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+// Use inline mock oracles so the arena test build does not need to compile
+// the oracle crate with soroban-sdk testutils features enabled.
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _, Env};
+
+    /// Mock returning a fixed 500 bps yield rate.
+    #[contract]
+    struct MockOracle500;
+
+    #[contractimpl]
+    impl MockOracle500 {
+        pub fn get_current_yield_bps(_env: Env) -> u32 {
+            500
+        }
+    }
+
+    /// Mock with no functions — simulates an unavailable / wrong oracle.
+    #[contract]
+    struct BadOracle;
+
+    #[contractimpl]
+    impl BadOracle {}
+
+    #[test]
+    fn fetch_yield_bps_returns_oracle_value() {
+        let env = Env::default();
+        let oracle_id = env.register(MockOracle500, ());
+        let bps = super::fetch_yield_bps(&env, &oracle_id);
+        assert_eq!(bps, 500, "expected 500 bps (5%) from mock oracle");
+    }
+
+    #[test]
+    fn fetch_yield_bps_defaults_zero_on_failure() {
+        let env = Env::default();
+        let bad_id = env.register(BadOracle, ());
+        let bps = super::fetch_yield_bps(&env, &bad_id);
+        assert_eq!(bps, 0, "expected 0 bps fallback when oracle fails");
+    }
+}

--- a/contract/arena/src/snapshot_test.rs
+++ b/contract/arena/src/snapshot_test.rs
@@ -35,6 +35,7 @@ mod snapshot_tests {
             commit_deadline: 1730000000,
             yield_vault: Address::generate(&env),
             round_count: 0,
+            oracle_contract: Address::generate(&env),
         };
         assert!(to_xdr(&env, config).len() > 0);
     }

--- a/contract/arena/src/storage.rs
+++ b/contract/arena/src/storage.rs
@@ -12,6 +12,7 @@ enum DataKey {
     Commitment(Address),
     Choice(Address),
     YieldSnapshot(u32),
+    RoundYieldBps(u32),
 }
 
 pub struct ArenaStorage;
@@ -152,6 +153,21 @@ impl ArenaStorage {
         env.storage()
             .persistent()
             .get(&DataKey::YieldSnapshot(round))
+    }
+
+    /// Persist the oracle-reported yield rate (in bps) for a resolved round.
+    pub fn save_round_yield_bps(env: &Env, round: u32, bps: u32) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::RoundYieldBps(round), &bps);
+    }
+
+    /// Load the snapshotted oracle yield rate for a round. Returns `None` if
+    /// the round has not been resolved yet or pre-dates oracle integration.
+    pub fn load_round_yield_bps(env: &Env, round: u32) -> Option<u32> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RoundYieldBps(round))
     }
 }
 

--- a/contract/arena/src/types.rs
+++ b/contract/arena/src/types.rs
@@ -53,6 +53,10 @@ pub struct ArenaConfig {
     pub commit_deadline: u64,
     /// Number of completed rounds so far. Incremented when a round resolves.
     pub round_count: u32,
+    /// On-chain oracle contract that supplies the current USDY yield rate in
+    /// basis points. Called once per `resolve_round` to snapshot the rate.
+    /// If the oracle is unavailable the round defaults to 0 bps yield.
+    pub oracle_contract: Address,
 }
 
 /// Per-player state stored in persistent storage, keyed by the player address.

--- a/contract/oracle/Cargo.toml
+++ b/contract/oracle/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "arena"
+name = "oracle"
 version = "0.1.0"
 edition = "2024"
 
@@ -8,8 +8,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
-oracle = { path = "../oracle" }
-rwa-adapter = { path = "../rwa-adapter" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/oracle/src/lib.rs
+++ b/contract/oracle/src/lib.rs
@@ -1,0 +1,82 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+/// On-chain yield rate oracle for InverseArena.
+///
+/// Stores an admin-updateable yield rate in basis points (bps).
+/// The arena contract calls `get_current_yield_bps` once per `resolve_round`
+/// to snapshot the current USDY / RWA yield rate.
+///
+/// The admin updates the rate before each round closes, sourcing the value
+/// from Ondo's off-chain API or an on-chain Band Protocol feed.
+/// Future upgrades can replace this contract with a fully autonomous oracle.
+#[contract]
+pub struct OracleContract;
+
+const RATE_KEY: &str = "RATE";
+const ADMIN_KEY: &str = "ADMIN";
+
+#[contractimpl]
+impl OracleContract {
+    /// Initialise the oracle with an admin and an initial yield rate.
+    pub fn initialize(env: Env, admin: Address, initial_rate_bps: u32) {
+        admin.require_auth();
+        env.storage().persistent().set(&soroban_sdk::symbol_short!("ADMIN"), &admin);
+        env.storage().persistent().set(&soroban_sdk::symbol_short!("RATE"), &initial_rate_bps);
+    }
+
+    /// Update the current yield rate. Only callable by the admin.
+    pub fn set_yield_bps(env: Env, rate_bps: u32) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&soroban_sdk::symbol_short!("ADMIN"))
+            .unwrap_or_else(|| panic!("not initialised"));
+        admin.require_auth();
+        env.storage().persistent().set(&soroban_sdk::symbol_short!("RATE"), &rate_bps);
+        env.events().publish((soroban_sdk::symbol_short!("rate_set"),), rate_bps);
+    }
+
+    /// Return the current yield rate in basis points (e.g. 500 = 5.00 % APY).
+    /// Returns 0 if the oracle has not been initialised.
+    pub fn get_current_yield_bps(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&soroban_sdk::symbol_short!("RATE"))
+            .unwrap_or(0)
+    }
+}
+
+const _: &str = RATE_KEY;
+const _: &str = ADMIN_KEY;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    #[test]
+    fn get_yield_bps_returns_set_rate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(OracleContract, ());
+        let admin = Address::generate(&env);
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &500);
+        assert_eq!(client.get_current_yield_bps(), 500);
+    }
+
+    #[test]
+    fn set_yield_bps_updates_rate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(OracleContract, ());
+        let admin = Address::generate(&env);
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &300);
+        client.set_yield_bps(&750);
+        assert_eq!(client.get_current_yield_bps(), 750);
+    }
+}


### PR DESCRIPTION
## Summary

- **#697** — RWA oracle integration: add `contract/oracle/` workspace member exposing `get_current_yield_bps() -> u32`. `resolve_round` now snapshots the oracle yield rate per round. Oracle call failure defaults to 0 bps (no panic). `oracle_contract: Address` added to `ArenaConfig` and `initialize()`. Round yield snapshots persisted under `RoundYieldBps` storage key.

- **#673** — Soroban RPC circuit breaker: new `backend/src/utils/circuitBreaker.ts` implementing a 50%-error-threshold / 10s-timeout / 30s-reset circuit breaker wrapping all three RPC call sites in `paymentService.ts` (`sendTransaction`, `getTransaction`, `prepareTransaction`). Open circuit returns a non-throwing fallback instead of cascading. Circuit state exposed on `/ready` endpoint and tracked with two Prometheus metrics.

- **#674** — Makefile enhancements: add shorthand `dev`, `test`, `build`, `migrate`, `migrate-prod`, `infra`, `monitoring`, and `clean` targets to the root Makefile. `make help` auto-generates descriptions from inline comments. README Getting Started updated with a quick-start Makefile section.

- **#685** — Leaderboard cursor pagination tests: extend `backend/tests/leaderboard.test.ts` with 6 new test cases covering empty DB, single-user rank=1, 200-user non-overlapping pages, invalid cursor fallback, limit boundary values, and tie-breaking by `arenasWon`. Adds `seedLeaderboardData(n)` helper for deterministic bulk seeding.

closes #697
closes #673 
closes #674 
closes #685 