### PR TITLE
fix: resolve issues #781, #782, #786, #787

### DIFF
--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -13,7 +13,7 @@ mod types;
 use events::ArenaEvents;
 use rwa_adapter::RwaAdapterClient;
 use storage::ArenaStorage;
-use types::{ArenaConfig, ArenaError, Choice, GameState, PlayerState, RoundResult, YieldSnapshot};
+use types::{ArenaConfig, ArenaError, Choice, GameState, PendingAdmin, PlayerState, RoundResult, YieldSnapshot};
 
 const PAGE_SIZE: u32 = 50;
 
@@ -136,17 +136,15 @@ impl ArenaContract {
 
     pub fn get_players(env: Env, page: u32) -> Vec<(Address, PlayerState)> {
         let all = ArenaStorage::load_all_players(&env);
-        let len = all.len();
-        let start = page.saturating_mul(PAGE_SIZE);
-        let end = start.saturating_add(PAGE_SIZE).min(len);
+        let start = (page.saturating_mul(PAGE_SIZE)) as usize;
+        let end = (start.saturating_add(PAGE_SIZE as usize)).min(all.len() as usize);
 
         let mut result: Vec<(Address, PlayerState)> = Vec::new(&env);
-        let mut i = start;
-        while i < end {
-            let addr = all.get(i).unwrap();
-            let state = ArenaStorage::load_player(&env, &addr).unwrap_or_default();
-            result.push_back((addr, state));
-            i += 1;
+        for i in start..end {
+            if let Some(addr) = all.get(i as u32) {
+                let state = ArenaStorage::load_player(&env, &addr).unwrap_or_default();
+                result.push_back((addr, state));
+            }
         }
         result
     }
@@ -279,6 +277,31 @@ impl ArenaContract {
         Ok(())
     }
 
+    /// Propose a new admin. The current admin calls this to start the transfer.
+    /// The new admin must then call `accept_admin` to complete the transfer.
+    pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), ArenaError> {
+        let config = ArenaStorage::load_config(&env)?;
+        config.admin.require_auth();
+        ArenaStorage::save_pending_admin(&env, &PendingAdmin { new_admin });
+        Ok(())
+    }
+
+    /// Accept a pending admin transfer. Only the proposed new admin can call this.
+    pub fn accept_admin(env: Env) -> Result<(), ArenaError> {
+        let pending = ArenaStorage::load_pending_admin(&env)
+            .ok_or(ArenaError::NoPendingAdmin)?;
+        pending.new_admin.require_auth();
+        let mut config = ArenaStorage::load_config(&env)?;
+        let old_admin = config.admin.clone();
+        config.admin = pending.new_admin;
+        ArenaStorage::save_config(&env, &config);
+        ArenaStorage::delete_pending_admin(&env);
+        ArenaEvents::admin_changed(&env, &old_admin, &config.admin.clone());
+        Ok(())
+    }
+
+    /// Immediate single-step admin transfer (deprecated — use propose_admin /
+    /// accept_admin instead). Kept for backward compatibility.
     pub fn change_admin(env: Env, new_admin: Address) -> Result<(), ArenaError> {
         let mut config = ArenaStorage::load_config(&env)?;
         config.admin.require_auth();
@@ -883,5 +906,101 @@ mod test {
             .expect("eliminated player claim must error")
             .expect("error must be a contract error");
         assert_eq!(err, ArenaError::PlayerEliminated);
+    }
+
+    #[test]
+    fn propose_then_accept_admin_changes_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ArenaContract, ());
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let config = ArenaConfig {
+                admin: admin.clone(),
+                stake_token: Address::generate(&env),
+                entry_fee: 100,
+                state: GameState::Open,
+                player_count: 0,
+                commit_deadline: 0,
+                yield_vault: Address::generate(&env),
+                round_count: 0,
+                oracle_contract: Address::generate(&env),
+            };
+            ArenaStorage::save_config(&env, &config);
+        });
+
+        let client = ArenaContractClient::new(&env, &contract_id);
+        client.propose_admin(&new_admin);
+        client.accept_admin();
+
+        env.as_contract(&contract_id, || {
+            let config = ArenaStorage::load_config(&env).unwrap();
+            assert_eq!(config.admin, new_admin);
+        });
+    }
+
+    #[test]
+    fn accept_without_propose_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ArenaContract, ());
+        let admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let config = ArenaConfig {
+                admin: admin.clone(),
+                stake_token: Address::generate(&env),
+                entry_fee: 100,
+                state: GameState::Open,
+                player_count: 0,
+                commit_deadline: 0,
+                yield_vault: Address::generate(&env),
+                round_count: 0,
+                oracle_contract: Address::generate(&env),
+            };
+            ArenaStorage::save_config(&env, &config);
+        });
+
+        let client = ArenaContractClient::new(&env, &contract_id);
+        let err = client
+            .try_accept_admin()
+            .err()
+            .expect("accept without propose must error")
+            .expect("error must be a contract error");
+        assert_eq!(err, ArenaError::NoPendingAdmin);
+    }
+
+    #[test]
+    fn propose_admin_updates_pending_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ArenaContract, ());
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let config = ArenaConfig {
+                admin: admin.clone(),
+                stake_token: Address::generate(&env),
+                entry_fee: 100,
+                state: GameState::Open,
+                player_count: 0,
+                commit_deadline: 0,
+                yield_vault: Address::generate(&env),
+                round_count: 0,
+                oracle_contract: Address::generate(&env),
+            };
+            ArenaStorage::save_config(&env, &config);
+        });
+
+        let client = ArenaContractClient::new(&env, &contract_id);
+        client.propose_admin(&new_admin);
+
+        env.as_contract(&contract_id, || {
+            let pending = ArenaStorage::load_pending_admin(&env).unwrap();
+            assert_eq!(pending.new_admin, new_admin);
+        });
     }
 }

--- a/contract/arena/src/storage.rs
+++ b/contract/arena/src/storage.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::types::{ArenaConfig, ArenaError, Choice, PlayerState, RoundResult, YieldSnapshot};
+use crate::types::{ArenaConfig, ArenaError, Choice, PendingAdmin, PlayerState, RoundResult, YieldSnapshot};
 use soroban_sdk::{Address, BytesN, Env, Vec, contracttype, symbol_short};
 
 const PENDING_ADMIN_KEY: &str = "PENDING_ADMIN";
@@ -196,7 +196,22 @@ impl ArenaStorage {
             .persistent()
             .set(&DataKey::PrizeClaimed, &true);
     }
-}
 
-// Silence unused-import warnings until the full contract is wired up
-const _: &str = PENDING_ADMIN_KEY;
+    pub fn save_pending_admin(env: &Env, pending: &PendingAdmin) {
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("PADMIN"), pending);
+    }
+
+    pub fn load_pending_admin(env: &Env) -> Option<PendingAdmin> {
+        env.storage()
+            .persistent()
+            .get(&symbol_short!("PADMIN"))
+    }
+
+    pub fn delete_pending_admin(env: &Env) {
+        env.storage()
+            .persistent()
+            .remove(&symbol_short!("PADMIN"));
+    }
+}

--- a/contract/arena/src/types.rs
+++ b/contract/arena/src/types.rs
@@ -133,4 +133,6 @@ pub enum ArenaError {
     PrizeAlreadyClaimed = 12,
     /// Player was eliminated and cannot perform this action.
     PlayerEliminated = 13,
+    /// No pending admin transfer to accept.
+    NoPendingAdmin = 14,
 }

--- a/contract/oracle/src/lib.rs
+++ b/contract/oracle/src/lib.rs
@@ -19,8 +19,16 @@ const ADMIN_KEY: &str = "ADMIN";
 #[contractimpl]
 impl OracleContract {
     /// Initialise the oracle with an admin and an initial yield rate.
+    /// Reverts if the oracle has already been initialised.
     pub fn initialize(env: Env, admin: Address, initial_rate_bps: u32) {
         admin.require_auth();
+        if env
+            .storage()
+            .persistent()
+            .has(&soroban_sdk::symbol_short!("ADMIN"))
+        {
+            panic!("already initialised");
+        }
         env.storage()
             .persistent()
             .set(&soroban_sdk::symbol_short!("ADMIN"), &admin);
@@ -71,6 +79,22 @@ mod tests {
         let client = OracleContractClient::new(&env, &contract_id);
 
         client.initialize(&admin, &500);
+        assert_eq!(client.get_current_yield_bps(), 500);
+    }
+
+    #[test]
+    fn initialize_twice_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(OracleContract, ());
+        let admin = Address::generate(&env);
+        let other = Address::generate(&env);
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &500);
+        let result = client.try_initialize(&other, &300);
+        assert!(result.is_err());
+        // Original rate should be unchanged after rejected second call.
         assert_eq!(client.get_current_yield_bps(), 500);
     }
 

--- a/contract/payout/src/lib.rs
+++ b/contract/payout/src/lib.rs
@@ -63,6 +63,7 @@ impl PayoutContract {
 
     /// Multi-recipient batch payout in a single transaction. All amounts are
     /// validated before any transfer, and the batch is idempotent on `payout_id`.
+    /// Duplicate recipient addresses are rejected to prevent double-payment.
     pub fn distribute_batch(
         env: Env,
         payout_id: u64,
@@ -74,10 +75,15 @@ impl PayoutContract {
         if recipients.is_empty() {
             return Err(PayoutError::EmptyBatch);
         }
-        for (_, amount) in recipients.iter() {
+        let mut seen: Vec<Address> = Vec::new(&env);
+        for (recipient, amount) in recipients.iter() {
             if amount <= 0 {
                 return Err(PayoutError::InvalidAmount);
             }
+            if seen.contains(&recipient) {
+                return Err(PayoutError::DuplicateRecipient);
+            }
+            seen.push_back(recipient);
         }
         if PayoutStorage::is_paid(&env, payout_id) {
             return Err(PayoutError::AlreadyPaid);
@@ -194,6 +200,20 @@ mod test {
         let fx = setup(1_000);
         let recipients: Vec<(Address, i128)> = Vec::new(&fx.env);
         assert!(fx.client.try_distribute_batch(&1, &recipients).is_err());
+    }
+
+    #[test]
+    fn distribute_batch_rejects_duplicate_recipients() {
+        let fx = setup(1_000);
+        let a = Address::generate(&fx.env);
+
+        let mut recipients = Vec::new(&fx.env);
+        recipients.push_back((a.clone(), 200i128));
+        recipients.push_back((a.clone(), 300i128));
+        let err = fx.client.try_distribute_batch(&1, &recipients);
+        assert!(err.is_err());
+        // Recipient should not have received any payment.
+        assert_eq!(fx.token.balance(&a), 0);
     }
 
     #[test]

--- a/contract/payout/src/types.rs
+++ b/contract/payout/src/types.rs
@@ -16,4 +16,6 @@ pub enum PayoutError {
     InvalidAmount = 5,
     /// A batch payout was submitted with no recipients.
     EmptyBatch = 6,
+    /// A batch contains duplicate recipient addresses.
+    DuplicateRecipient = 7,
 }


### PR DESCRIPTION
## summary

 admin two-step transfer, payout dedup check, oracle init guard, and get_players refactor

## Changes

### 1. Payout: reject duplicate recipients in distribute_batch (Closes #781)

**contract/payout/src/types.rs** - Added `DuplicateRecipient` error variant.

**contract/payout/src/lib.rs** - `distribute_batch()` now checks for duplicate recipient addresses before processing transfers. A `Vec<Address>` tracks seen recipients and returns `DuplicateRecipient` if a duplicate is found.

**Tests added:**
- `distribute_batch_rejects_duplicate_recipients` - batch with same address twice is rejected, no payment occurs

### 2. Oracle: reject second initialize call (Closes #782 )

**contract/oracle/src/lib.rs** - `initialize()` now checks if admin is already stored and panics if called a second time.

**Tests added:**
- `initialize_twice_is_rejected` - second call fails, original rate unchanged

### 3. Arena: two-step admin transfer (Closes #786 )

**contract/arena/src/types.rs** - Added `NoPendingAdmin` error variant.

**contract/arena/src/storage.rs** - Added `save_pending_admin`, `load_pending_admin`, and `delete_pending_admin` storage functions.

**contract/arena/src/lib.rs** - Implemented `propose_admin()` and `accept_admin()` for a two-step admin transfer flow. The current admin proposes a new address, then the proposed address accepts. `change_admin()` is kept for backward compatibility.

**Tests added:**
- `propose_then_accept_admin_changes_admin` - full two-step flow succeeds
- `accept_without_propose_fails` - calling accept without a prior proposal returns `NoPendingAdmin`
- `propose_admin_updates_pending_admin` - proposal correctly stores the pending admin

### 4. Arena: refactor get_players() iterator (Closes #787 )

**contract/arena/src/lib.rs** - Replaced the index-based `while` loop with a `for` loop over a range. Removed `unwrap()` on array index access, using `if let Some` instead for safety. Pagination behavior is identical.

## Testing

All 49 tests pass across all three contracts:
- Payout: 8 tests
- Oracle: 3 tests
- Arena: 38 tests

Closes #786 
Closes #782 
Closes #787 
Closes #781
