### PR TITLE
fix: cache arena yield and update deploy docs

### DIFF
--- a/contract/DEPLOY.md
+++ b/contract/DEPLOY.md
@@ -23,6 +23,29 @@ stellar --version
 rustc --version
 ```
 
+### Testnet deployment checklist
+
+Before you deploy to testnet, confirm the following:
+
+1. `main` is up to date with `upstream/main`.
+2. Your working branch is created from that synced `main`.
+3. The deployer account is funded on the target network.
+4. You have the contract IDs and init arguments for each contract you plan to invoke.
+5. You have the frontend env values ready for the new deployment.
+
+### Account setup
+
+Use a dedicated deployer identity for each network:
+
+```bash
+stellar keys generate deployer-testnet
+stellar keys address deployer-testnet
+stellar keys generate deployer-mainnet
+stellar keys address deployer-mainnet
+```
+
+Keep the testnet and mainnet identities separate. Do not reuse a mainnet deployer key on testnet or vice versa.
+
 ---
 
 ## Repository layout
@@ -134,6 +157,16 @@ The command prints the **contract ID** (starts with `C` on Soroban). Save it.
 Repeat for `arena`, `payout`, and `staking` with the correct WASM paths.
 
 > If your CLI uses **upload + deploy** in two steps, follow [Stellar’s upload & deploy cookbook](https://developers.stellar.org/docs/tools/cli/cookbook/upload-deploy): upload WASM, then deploy the contract instance from the uploaded hash.
+
+### Contract initialization sequence
+
+After deployment, initialize the contracts in dependency order:
+
+1. Deploy the shared contracts first if they are referenced by address elsewhere.
+2. Initialize the arena contract with the admin, stake token, yield vault, fee, and oracle addresses.
+3. Initialize payout and staking contracts with the arena or factory addresses they depend on.
+4. Verify each contract can be read back with `stellar contract inspect` or a read-only invoke.
+5. Only after the on-chain addresses are confirmed, publish the values to the frontend environment.
 
 ---
 

--- a/contract/arena/src/lib.rs
+++ b/contract/arena/src/lib.rs
@@ -13,7 +13,10 @@ mod types;
 use events::ArenaEvents;
 use rwa_adapter::RwaAdapterClient;
 use storage::ArenaStorage;
-use types::{ArenaConfig, ArenaError, Choice, GameState, PendingAdmin, PlayerState, RoundResult, YieldSnapshot};
+use types::{
+    ArenaConfig, ArenaError, Choice, GameState, PendingAdmin, PlayerState, RoundResult,
+    YieldSnapshot,
+};
 
 const PAGE_SIZE: u32 = 50;
 
@@ -42,6 +45,7 @@ impl ArenaContract {
             entry_fee,
             state: GameState::Open,
             player_count: 0,
+            cumulative_yield: 0,
             commit_deadline: 0,
             round_count: 0,
             oracle_contract,
@@ -206,6 +210,7 @@ impl ArenaContract {
         ArenaStorage::save_round_yield_bps(&env, round, yield_bps);
         ArenaStorage::save_yield_snapshot(&env, round, &snapshot);
         ArenaStorage::save_last_vault_balance(&env, vault_balance);
+        config.cumulative_yield = config.cumulative_yield.saturating_add(accrued);
 
         let (eliminated, survivors, winner) = Self::resolve_players(&env, round);
         let result = RoundResult {
@@ -288,8 +293,7 @@ impl ArenaContract {
 
     /// Accept a pending admin transfer. Only the proposed new admin can call this.
     pub fn accept_admin(env: Env) -> Result<(), ArenaError> {
-        let pending = ArenaStorage::load_pending_admin(&env)
-            .ok_or(ArenaError::NoPendingAdmin)?;
+        let pending = ArenaStorage::load_pending_admin(&env).ok_or(ArenaError::NoPendingAdmin)?;
         pending.new_admin.require_auth();
         let mut config = ArenaStorage::load_config(&env)?;
         let old_admin = config.admin.clone();
@@ -313,18 +317,9 @@ impl ArenaContract {
     }
 
     pub fn get_total_yield(env: Env) -> i128 {
-        let round_count = ArenaStorage::load_config(&env)
-            .map(|c| c.round_count)
-            .unwrap_or(0);
-        let mut total = 0i128;
-        let mut round = 1u32;
-        while round <= round_count {
-            if let Some(snapshot) = ArenaStorage::load_yield_snapshot(&env, round) {
-                total = total.saturating_add(snapshot.accrued);
-            }
-            round += 1;
-        }
-        total
+        ArenaStorage::load_config(&env)
+            .map(|c| c.cumulative_yield)
+            .unwrap_or(0)
     }
 
     pub fn get_yield_snapshot(env: Env, round: u32) -> Option<YieldSnapshot> {
@@ -438,6 +433,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: u64::MAX,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -516,6 +512,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -550,6 +547,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -580,6 +578,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 1,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -611,6 +610,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -641,6 +641,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -666,6 +667,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -713,6 +715,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -750,6 +753,7 @@ mod test {
         env.as_contract(&client.address, || {
             let mut config = ArenaStorage::load_config(&env).unwrap();
             config.round_count = 3;
+            config.cumulative_yield = 60;
             ArenaStorage::save_config(&env, &config);
             for round in 1..=3 {
                 ArenaStorage::save_yield_snapshot(
@@ -784,6 +788,7 @@ mod test {
                     entry_fee: 100,
                     state: GameState::Open,
                     player_count: 1,
+                    cumulative_yield: 0,
                     commit_deadline: 0,
                     yield_vault: vault_id.clone(),
                     round_count: 0,
@@ -836,6 +841,7 @@ mod test {
                     entry_fee: 100,
                     state: GameState::Finished,
                     player_count: 1,
+                    cumulative_yield: 0,
                     commit_deadline: 0,
                     yield_vault: Address::generate(&env),
                     round_count: 0,
@@ -883,6 +889,7 @@ mod test {
                     entry_fee: 100,
                     state: GameState::Finished,
                     player_count: 1,
+                    cumulative_yield: 0,
                     commit_deadline: 0,
                     yield_vault: Address::generate(&env),
                     round_count: 0,
@@ -923,6 +930,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -955,6 +963,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,
@@ -987,6 +996,7 @@ mod test {
                 entry_fee: 100,
                 state: GameState::Open,
                 player_count: 0,
+                cumulative_yield: 0,
                 commit_deadline: 0,
                 yield_vault: Address::generate(&env),
                 round_count: 0,

--- a/contract/arena/src/snapshot_test.rs
+++ b/contract/arena/src/snapshot_test.rs
@@ -76,6 +76,7 @@ mod snapshot_tests {
             entry_fee: 100,
             state: GameState::Open,
             player_count: 42,
+            cumulative_yield: 0,
             commit_deadline: 1_730_000_000,
             round_count: 0,
             oracle_contract: Address::generate(&env),
@@ -87,6 +88,7 @@ mod snapshot_tests {
             entry_fee: 200, // differs from config_a
             state: GameState::Open,
             player_count: 42,
+            cumulative_yield: 0,
             commit_deadline: 1_730_000_000,
             round_count: 0,
             oracle_contract: Address::generate(&env),

--- a/contract/arena/src/storage.rs
+++ b/contract/arena/src/storage.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use crate::types::{ArenaConfig, ArenaError, Choice, PendingAdmin, PlayerState, RoundResult, YieldSnapshot};
+use crate::types::{
+    ArenaConfig, ArenaError, Choice, PendingAdmin, PlayerState, RoundResult, YieldSnapshot,
+};
 use soroban_sdk::{Address, BytesN, Env, Vec, contracttype, symbol_short};
 
 const PENDING_ADMIN_KEY: &str = "PENDING_ADMIN";
@@ -204,14 +206,10 @@ impl ArenaStorage {
     }
 
     pub fn load_pending_admin(env: &Env) -> Option<PendingAdmin> {
-        env.storage()
-            .persistent()
-            .get(&symbol_short!("PADMIN"))
+        env.storage().persistent().get(&symbol_short!("PADMIN"))
     }
 
     pub fn delete_pending_admin(env: &Env) {
-        env.storage()
-            .persistent()
-            .remove(&symbol_short!("PADMIN"));
+        env.storage().persistent().remove(&symbol_short!("PADMIN"));
     }
 }

--- a/contract/arena/src/types.rs
+++ b/contract/arena/src/types.rs
@@ -48,6 +48,8 @@ pub struct ArenaConfig {
     /// Total number of players that have ever joined this arena. Kept in sync
     /// by `ArenaStorage::add_player` so it can be read without scanning storage.
     pub player_count: u32,
+    /// Cumulative yield accrued across all resolved rounds.
+    pub cumulative_yield: i128,
     /// Ledger timestamp (seconds) after which commitments are no longer
     /// accepted and the reveal phase begins.
     pub commit_deadline: u64,


### PR DESCRIPTION
Caches arena yield in config, updates arena config snapshots, and expands the deployment runbook with testnet setup and initialization steps.

Closes #788
Closes #792
Closes #778
Closes #779