### PR TITLE
fix(rwa-adapter): add require_auth to deposit/withdraw_all; add auth regression tests

### DIFF
--- a/contract/rwa-adapter/src/lib.rs
+++ b/contract/rwa-adapter/src/lib.rs
@@ -33,6 +33,7 @@ impl RwaAdapter {
     }
 
     pub fn deposit(env: Env, from: Address, amount: i128) -> Result<(), RwaError> {
+        from.require_auth();
         if amount <= 0 {
             return Err(RwaError::InvalidAmount);
         }
@@ -58,6 +59,7 @@ impl RwaAdapter {
     }
 
     pub fn withdraw_all(env: Env, from: Address) -> Result<i128, RwaError> {
+        from.require_auth();
         let config = RwaStorage::load_config(&env)?;
 
         let pos = RwaStorage::load_position(&env, &from);
@@ -120,5 +122,122 @@ impl RwaAdapter {
         RwaStorage::load_config(&env)
             .map(|c| c.total_deposited)
             .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate std;
+
+    use super::*;
+    use soroban_sdk::{Address, Env, testutils::Address as _, token::StellarAssetClient};
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /// Register the RwaAdapter and wire up a SAC token, writing config directly
+    /// into storage so tests can control auth independently of `initialize`.
+    fn setup(env: &Env) -> (RwaAdapterClient<'static>, Address, Address) {
+        let contract_id = env.register(RwaAdapter, ());
+        let token_admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        let admin = Address::generate(env);
+
+        env.as_contract(&contract_id, || {
+            let config = RwaConfig {
+                admin: admin.clone(),
+                stake_token: token_id.clone(),
+                total_deposited: 0,
+            };
+            RwaStorage::save_config(env, &config);
+            RwaStorage::set_initialized(env);
+        });
+
+        let env_static: &'static Env = unsafe { &*(env as *const Env) };
+        let client = RwaAdapterClient::new(env_static, &contract_id);
+        (client, token_id, contract_id)
+    }
+
+    // ── Authorization tests for deposit() ────────────────────────────────────
+
+    /// deposit() must panic when the `from` address has not authorized the call.
+    #[test]
+    #[should_panic]
+    fn deposit_without_auth_panics() {
+        let env = Env::default();
+        // Intentionally no mock_all_auths — auth is enforced.
+        let (client, _, _) = setup(&env);
+        let from = Address::generate(&env);
+        // from has not signed anything; require_auth() should panic.
+        client.deposit(&from, &100);
+    }
+
+    /// deposit() records the position when the caller provides authorization.
+    #[test]
+    fn deposit_with_auth_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _, _) = setup(&env);
+        let from = Address::generate(&env);
+
+        client.deposit(&from, &100);
+
+        // balance_of returns principal + 5% simulated yield
+        assert_eq!(client.balance_of(&from), 105);
+        assert_eq!(client.get_total_deposited(), 100);
+    }
+
+    // ── Authorization tests for withdraw_all() ────────────────────────────────
+
+    /// withdraw_all() must panic when the `from` address has not authorized the call.
+    #[test]
+    #[should_panic]
+    fn withdraw_without_auth_panics() {
+        let env = Env::default();
+        // Intentionally no mock_all_auths — auth is enforced.
+        let (client, _, contract_id) = setup(&env);
+        let from = Address::generate(&env);
+
+        // Seed a position directly so the test reaches require_auth() without
+        // going through deposit (which also requires auth).
+        env.as_contract(&contract_id, || {
+            RwaStorage::save_position(
+                &env,
+                &from,
+                &types::YieldAccrual {
+                    principal: 100,
+                    accrued_yield: 0,
+                    withdrawn: false,
+                },
+            );
+        });
+
+        // from has not signed anything; require_auth() should panic.
+        client.withdraw_all(&from);
+    }
+
+    /// withdraw_all() transfers principal + yield to the caller when authorized.
+    #[test]
+    fn withdraw_with_auth_returns_correct_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, token_id, contract_id) = setup(&env);
+        let from = Address::generate(&env);
+
+        // Deposit 1000 tokens worth of position.
+        client.deposit(&from, &1_000);
+
+        // Expected payout: 1000 principal + 5% yield = 1050.
+        let expected: i128 = 1_050;
+
+        // Fund the contract so the token transfer in withdraw_all can succeed.
+        StellarAssetClient::new(&env, &token_id).mint(&contract_id, &expected);
+
+        let returned = client.withdraw_all(&from);
+        assert_eq!(returned, expected);
+
+        // After withdrawal the position is closed; balance_of must return 0.
+        assert_eq!(client.balance_of(&from), 0);
     }
 }

--- a/contract/rwa-adapter/src/types.rs
+++ b/contract/rwa-adapter/src/types.rs
@@ -26,5 +26,5 @@ pub enum RwaError {
     AlreadyWithdrawn = 5,
     InsufficientBalance = 6,
     ArithmeticOverflow = 7,
-    InvalidAmount = 7,
+    InvalidAmount = 8,
 }


### PR DESCRIPTION
## Summary

- Adds `from.require_auth()` to `deposit()` and `withdraw_all()` in `contract/rwa-adapter/src/lib.rs`
- Adds a `mod test` block with 4 auth regression tests covering all acceptance criteria

## Changes

### Implementation (`lib.rs`)
- `deposit()`: `from.require_auth()` added as first statement
- `withdraw_all()`: `from.require_auth()` added as first statement

### Tests

| Test | Criteria |
|---|---|
| `deposit_without_auth_panics` | Unauthorized deposit panics |
| `deposit_with_auth_succeeds` | Authorized deposit records position; `balance_of` returns principal + 5% yield |
| `withdraw_without_auth_panics` | Unauthorized withdraw panics (position seeded directly to isolate from deposit's own auth) |
| `withdraw_with_auth_returns_correct_amount` | Authorized withdraw returns `principal + yield`; `balance_of` returns 0 after withdrawal |

## Test plan

- [x] `cargo test` in `contract/rwa-adapter` — 4/4 pass
- [x] No existing tests broken

Closes #780
