### PR TITLE
refactor(round-service): replace any with Prisma.TransactionClient and RoundMetadata

### DIFF
--- a/backend/src/repositories/roundRepository.ts
+++ b/backend/src/repositories/roundRepository.ts
@@ -117,7 +117,7 @@ export class RoundRepository {
     resolution: RoundResolution,
     metadata: RoundMetadata,
   ): Promise<void> {
-    await this.prisma.$transaction(async (tx) => {
+    await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       if (resolution.eliminatedPlayers.length > 0) {
         await tx.eliminationLog.createMany({
           data: resolution.eliminatedPlayers.map((userId) => ({


### PR DESCRIPTION
Summary\nFixes #678\nReplaces the untyped Prisma transaction callback with Prisma.TransactionClient.\n\nChanges\n\n- Typed the Prisma  callback with Prisma.TransactionClient\n- Kept the change type-only with no runtime logic changes\n\nVerification\n\n- npm run typecheck passes with zero errors\n- No changes to backend/src/services/roundService.ts were needed because the issue target code path lives in roundRepository.ts

closes #678 